### PR TITLE
feat(date): add validation and edge cases (Phase 2)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -226,12 +226,35 @@ Structured date parsing for GEDCOM date strings with full support for:
 | Range | `BET 1850 AND 1860` | Between two dates |
 | Period | `FROM 1880 TO 1920` | Duration/interval |
 
+### Edge Cases
+
+| Format | Example | Notes |
+|--------|---------|-------|
+| B.C. dates | `44 BC`, `753 B.C.E.` | IsBC flag set |
+| Dual dating | `21 FEB 1750/51` | Both years accessible |
+| Date phrases | `(unknown)` | GEDCOM 5.5 format |
+
+### Validation
+
+```go
+// Validate complete dates using stdlib
+err := date.Validate()
+// Returns nil for valid dates
+// Returns clear error for invalid: "invalid date: February has 28 days in 2023"
+```
+
+- Uses `time.Date()` normalization (no reimplemented calendar math)
+- Skips validation for partial dates (lossless representation)
+- Detects invalid day/month combinations (Feb 30, Jun 31)
+- Handles leap years correctly (Feb 29 2000 valid, 1900 invalid)
+
 ### Features
 
 - Case-insensitive month parsing (`Jan`, `JAN`, `jan`)
 - Whitespace tolerance (leading, trailing, multiple spaces)
 - Original string preserved for round-trip fidelity
 - Calendar escape recognition (`@#DJULIAN@`, `@#DHEBREW@`, `@#DFRENCH R@`)
+- B.C. date comparison (100 BC > 200 BC chronologically)
 
 ### API
 
@@ -244,6 +267,15 @@ date.Day      // 25
 date.Month    // 12
 date.Year     // 2020
 date.Modifier // ModifierNone
+
+// Edge case fields
+date.IsBC     // true for B.C. dates
+date.DualYear // second year from "1750/51" format
+date.Phrase   // text from "(unknown)" format
+date.IsPhrase // true for date phrases
+
+// Validate complete dates
+err := date.Validate()  // nil if valid
 
 // Compare dates for sorting
 result := date1.Compare(date2)  // -1, 0, or 1

--- a/gedcom/date.go
+++ b/gedcom/date.go
@@ -114,6 +114,18 @@ type Date struct {
 
 	// Calendar indicates the calendar system (Gregorian, Julian, Hebrew, French Republican)
 	Calendar Calendar
+
+	// IsBC is true for B.C./BCE dates
+	IsBC bool
+
+	// DualYear is the second year for dual dating (e.g., 1751 from "1750/51")
+	DualYear int
+
+	// Phrase contains the text for date phrases (e.g., "unknown" from "(unknown)")
+	Phrase string
+
+	// IsPhrase is true when the date is a phrase, not a parseable date
+	IsPhrase bool
 }
 
 // monthNames maps three-letter month abbreviations to month numbers.
@@ -125,8 +137,8 @@ var monthNames = map[string]int{
 }
 
 // ParseDate parses a GEDCOM date string into a Date struct.
-// Supports exact dates, partial dates, modifiers, ranges, and periods.
-// Currently only supports Gregorian calendar dates (Phase 1).
+// Supports exact dates, partial dates, modifiers, ranges, periods, dual dating,
+// B.C. dates, and date phrases.
 //
 // Examples:
 //   - "25 DEC 2020" -> exact date
@@ -135,6 +147,9 @@ var monthNames = map[string]int{
 //   - "ABT 1850" -> approximate date
 //   - "BET 1850 AND 1860" -> date range
 //   - "FROM 1880 TO 1920" -> date period
+//   - "21 FEB 1750/51" -> dual dating
+//   - "44 BC" -> B.C. date
+//   - "(unknown)" -> date phrase
 func ParseDate(s string) (*Date, error) {
 	if s == "" {
 		return nil, fmt.Errorf("empty date string")
@@ -151,6 +166,13 @@ func ParseDate(s string) (*Date, error) {
 	date := &Date{
 		Original: original,
 		Calendar: CalendarGregorian, // Default calendar
+	}
+
+	// Check for date phrase first (starts with '(')
+	if strings.HasPrefix(s, "(") && strings.HasSuffix(s, ")") {
+		date.IsPhrase = true
+		date.Phrase = s[1 : len(s)-1] // Remove parentheses
+		return date, nil
 	}
 
 	// Check for calendar escape sequence
@@ -182,7 +204,7 @@ func ParseDate(s string) (*Date, error) {
 		}
 	}
 
-	// Parse the date components (day, month, year)
+	// Parse the date components (day, month, year, BC, dual year)
 	if err := parseDateComponents(s, date); err != nil {
 		return nil, err
 	}
@@ -326,58 +348,90 @@ func parseDatePeriod(s, original string, modifier DateModifier) (*Date, error) {
 	return date, nil
 }
 
-// parseDateComponents parses the date components (day, month, year) from a string.
+// isBCSuffix checks if a string is a B.C./BCE suffix.
+func isBCSuffix(s string) bool {
+	upper := strings.ToUpper(s)
+	return upper == "BC" || upper == "B.C." || upper == "BCE" || upper == "B.C.E."
+}
+
+// parseDateComponents parses the date components (day, month, year, BC, dual year) from a string.
 func parseDateComponents(s string, date *Date) error {
 	fields := strings.Fields(s)
 	if len(fields) == 0 {
 		return fmt.Errorf("empty date")
 	}
 
-	// Try to parse based on number of fields
-	switch len(fields) {
-	case 1:
-		// Year only
-		year, err := strconv.Atoi(fields[0])
-		if err != nil {
-			return fmt.Errorf("invalid year: %s", fields[0])
+	// Check for B.C./BCE suffix on last field
+	if isBCSuffix(fields[len(fields)-1]) {
+		date.IsBC = true
+		fields = fields[:len(fields)-1] // Remove BC suffix
+		if len(fields) == 0 {
+			return fmt.Errorf("empty date after BC suffix")
 		}
-		date.Year = year
-
-	case 2:
-		// Month and year (no day)
-		month, err := parseMonth(fields[0])
-		if err != nil {
-			return err
-		}
-		year, err := strconv.Atoi(fields[1])
-		if err != nil {
-			return fmt.Errorf("invalid year: %s", fields[1])
-		}
-		date.Month = month
-		date.Year = year
-
-	case 3:
-		// Day, month, and year
-		day, err := strconv.Atoi(fields[0])
-		if err != nil {
-			return fmt.Errorf("invalid day: %s", fields[0])
-		}
-		month, err := parseMonth(fields[1])
-		if err != nil {
-			return err
-		}
-		year, err := strconv.Atoi(fields[2])
-		if err != nil {
-			return fmt.Errorf("invalid year: %s", fields[2])
-		}
-		date.Day = day
-		date.Month = month
-		date.Year = year
-
-	default:
-		return fmt.Errorf("invalid date format: too many components in '%s'", s)
 	}
 
+	return parseDateFields(fields, date)
+}
+
+// parseDateFields parses date fields after BC suffix has been handled.
+func parseDateFields(fields []string, date *Date) error {
+	switch len(fields) {
+	case 1:
+		return parseYearOnly(fields[0], date)
+	case 2:
+		return parseMonthYear(fields, date)
+	case 3:
+		return parseDayMonthYear(fields, date)
+	default:
+		return fmt.Errorf("invalid date format: too many components in '%s'", strings.Join(fields, " "))
+	}
+}
+
+// parseYearOnly parses a year-only date (possibly with dual year).
+func parseYearOnly(yearStr string, date *Date) error {
+	year, dualYear, err := parseYearWithDual(yearStr)
+	if err != nil {
+		return err
+	}
+	date.Year = year
+	date.DualYear = dualYear
+	return nil
+}
+
+// parseMonthYear parses a month-year date (no day).
+func parseMonthYear(fields []string, date *Date) error {
+	month, err := parseMonth(fields[0])
+	if err != nil {
+		return err
+	}
+	year, dualYear, err := parseYearWithDual(fields[1])
+	if err != nil {
+		return err
+	}
+	date.Month = month
+	date.Year = year
+	date.DualYear = dualYear
+	return nil
+}
+
+// parseDayMonthYear parses a full day-month-year date.
+func parseDayMonthYear(fields []string, date *Date) error {
+	day, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return fmt.Errorf("invalid day: %s", fields[0])
+	}
+	month, err := parseMonth(fields[1])
+	if err != nil {
+		return err
+	}
+	year, dualYear, err := parseYearWithDual(fields[2])
+	if err != nil {
+		return err
+	}
+	date.Day = day
+	date.Month = month
+	date.Year = year
+	date.DualYear = dualYear
 	return nil
 }
 
@@ -390,15 +444,125 @@ func parseMonth(s string) (int, error) {
 	return month, nil
 }
 
+// parseYearWithDual parses a year field that may contain dual dating (e.g., "1750/51" or "1750/1751").
+// Returns the primary year and dual year (0 if no dual year).
+func parseYearWithDual(s string) (primaryYear, dualYear int, err error) {
+	// Check for dual year format (year/year)
+	if strings.Contains(s, "/") {
+		parts := strings.Split(s, "/")
+		if len(parts) != 2 {
+			return 0, 0, fmt.Errorf("invalid dual year format: %s", s)
+		}
+
+		primaryYear, err := strconv.Atoi(parts[0])
+		if err != nil {
+			return 0, 0, fmt.Errorf("invalid primary year in dual date: %s", parts[0])
+		}
+
+		// Parse secondary year - may be 2-digit or 4-digit
+		secondaryStr := parts[1]
+		secondaryYear, err := strconv.Atoi(secondaryStr)
+		if err != nil {
+			return 0, 0, fmt.Errorf("invalid secondary year in dual date: %s", secondaryStr)
+		}
+
+		// If secondary year is 2 digits, infer century from primary year
+		if len(secondaryStr) <= 2 {
+			century := (primaryYear / 100) * 100
+			secondaryYear = century + secondaryYear
+		}
+
+		return primaryYear, secondaryYear, nil
+	}
+
+	// No dual year
+	year, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid year: %s", s)
+	}
+	return year, 0, nil
+}
+
 // normalizeWhitespace normalizes multiple spaces/tabs to single spaces.
 func normalizeWhitespace(s string) string {
 	fields := strings.Fields(s)
 	return strings.Join(fields, " ")
 }
 
+// Validate checks if the date is semantically valid (e.g., no day overflow like Feb 30).
+// Returns nil for partial dates (day, month, or year is 0) or non-Gregorian calendars.
+// Uses stdlib time.Date() to detect invalid dates via normalization.
+func (d *Date) Validate() error {
+	// Skip validation for partial dates
+	if d.Day == 0 || d.Month == 0 || d.Year == 0 {
+		return nil
+	}
+
+	// Only validate Gregorian calendar for now
+	if d.Calendar != CalendarGregorian {
+		return nil
+	}
+
+	// Use time.Date to check if the date normalizes (indicating overflow)
+	t := time.Date(d.Year, time.Month(d.Month), d.Day, 0, 0, 0, 0, time.UTC)
+
+	// If the date normalized to a different day or month, it's invalid
+	if t.Day() != d.Day || int(t.Month()) != d.Month {
+		// Build informative error message
+		monthName := getMonthName(d.Month)
+		daysInMonth := getDaysInMonth(d.Month, d.Year)
+
+		if d.Day > daysInMonth {
+			return fmt.Errorf("invalid date: %s has %d days in %d, got day %d", monthName, daysInMonth, d.Year, d.Day)
+		}
+		return fmt.Errorf("invalid date: %d %s %d", d.Day, monthName, d.Year)
+	}
+
+	return nil
+}
+
+// getMonthName returns the full month name for a month number (1-12).
+func getMonthName(month int) string {
+	monthNames := []string{
+		"", "January", "February", "March", "April", "May", "June",
+		"July", "August", "September", "October", "November", "December",
+	}
+	if month < 1 || month > 12 {
+		return "Unknown"
+	}
+	return monthNames[month]
+}
+
+// getDaysInMonth returns the number of days in a month for a given year.
+func getDaysInMonth(month, year int) int {
+	// Use time.Date with day 0 of next month to get last day of current month
+	t := time.Date(year, time.Month(month)+1, 0, 0, 0, 0, 0, time.UTC)
+	return t.Day()
+}
+
+// compareInts returns -1 if a < b, 0 if a == b, 1 if a > b.
+func compareInts(a, b int) int {
+	if a < b {
+		return -1
+	}
+	if a > b {
+		return 1
+	}
+	return 0
+}
+
+// defaultToOne returns 1 if val is 0, otherwise returns val.
+func defaultToOne(val int) int {
+	if val == 0 {
+		return 1
+	}
+	return val
+}
+
 // Compare compares two dates and returns -1 if d < other, 0 if d == other, 1 if d > other.
 // For partial dates, missing components are treated as the earliest possible value
-// (day=1, month=1). For ranges, the start dates are compared.
+// (day=1, month=1). B.C. dates sort before all A.D. dates, and among B.C. dates,
+// higher year numbers are earlier (100 BC < 200 BC).
 func (d *Date) Compare(other *Date) int {
 	if d == nil && other == nil {
 		return 0
@@ -410,46 +574,34 @@ func (d *Date) Compare(other *Date) int {
 		return 1
 	}
 
-	// Compare years
-	y1, y2 := d.Year, other.Year
-	if y1 < y2 {
-		return -1
+	// Handle BC vs AD comparison
+	if d.IsBC != other.IsBC {
+		if d.IsBC {
+			return -1 // BC dates come before AD dates
+		}
+		return 1 // AD dates come after BC dates
 	}
-	if y1 > y2 {
-		return 1
+
+	// Compare years (reversed for BC dates: 100 BC > 200 BC)
+	y1, y2 := d.Year, other.Year
+	if cmp := compareInts(y1, y2); cmp != 0 {
+		if d.IsBC {
+			return -cmp // Reverse for BC
+		}
+		return cmp
 	}
 
 	// Years are equal, compare months (treat 0 as 1)
-	m1, m2 := d.Month, other.Month
-	if m1 == 0 {
-		m1 = 1
-	}
-	if m2 == 0 {
-		m2 = 1
-	}
-	if m1 < m2 {
-		return -1
-	}
-	if m1 > m2 {
-		return 1
+	m1 := defaultToOne(d.Month)
+	m2 := defaultToOne(other.Month)
+	if cmp := compareInts(m1, m2); cmp != 0 {
+		return cmp
 	}
 
 	// Months are equal, compare days (treat 0 as 1)
-	d1, d2 := d.Day, other.Day
-	if d1 == 0 {
-		d1 = 1
-	}
-	if d2 == 0 {
-		d2 = 1
-	}
-	if d1 < d2 {
-		return -1
-	}
-	if d1 > d2 {
-		return 1
-	}
-
-	return 0
+	d1 := defaultToOne(d.Day)
+	d2 := defaultToOne(other.Day)
+	return compareInts(d1, d2)
 }
 
 // ToTime converts the date to a time.Time value.


### PR DESCRIPTION
## Summary

Implements issue #32 - Date validation and edge cases (Phase 2):

- **Validate() method**: Uses `time.Date()` normalization to detect invalid dates without reimplementing calendar math
- **Dual dating**: Parses `21 FEB 1750/51` format with both years accessible
- **B.C. dates**: Parses `44 BC`, `753 B.C.E.` with correct chronological comparison
- **Date phrases**: Captures `(unknown)`, `(about 1850)` as-is for lossless representation

## Changes

- `gedcom/date.go`: Added 4 new fields (`IsBC`, `DualYear`, `Phrase`, `IsPhrase`), `Validate()` method, and updated `Compare()` for BC dates
- `gedcom/date_test.go`: Added 9 new test functions with 50+ test cases
- `FEATURES.md`: Documented new capabilities

## Test plan

- [x] All existing tests pass
- [x] New tests cover validation, dual dating, BC dates, and phrases
- [x] Test coverage: 83.7% for gedcom package
- [x] golangci-lint: 0 issues
- [x] go vet: no issues

## Verification

| Test Case | Status |
|-----------|--------|
| `Validate()` returns nil for valid date | ✅ |
| `Validate()` returns error for Feb 30 | ✅ |
| Leap year validation (Feb 29 2000/1900) | ✅ |
| Dual dating "1750/51" parsed correctly | ✅ |
| BC dates parse and compare correctly | ✅ |
| Date phrases preserved without parsing | ✅ |

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)