### PR TITLE
chore: improve CI and pre-commit hook reliability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,3 +193,22 @@ jobs:
         if [ -f testdata/gedcom-5.5/minimal.ged ]; then
           /tmp/example-parse testdata/gedcom-5.5/minimal.ged
         fi
+
+  # Gate job for branch protection - only require this one check
+  ci-success:
+    name: CI Success
+    runs-on: ubuntu-latest
+    needs: [test, coverage, lint, format, security, build-examples]
+    if: always()
+    steps:
+      - name: Check all jobs passed
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "❌ Some jobs failed"
+            exit 1
+          fi
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "❌ Some jobs were cancelled"
+            exit 1
+          fi
+          echo "✅ All CI jobs passed"

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -24,11 +24,18 @@ go vet ./...
 
 # Run linter (assumes golangci-lint is installed via make install-tools)
 echo "→ Running golangci-lint..."
-if ! command -v golangci-lint &> /dev/null; then
+# Check common locations for golangci-lint
+if command -v golangci-lint &> /dev/null; then
+  GOLANGCI_LINT="golangci-lint"
+elif [ -x "$HOME/go/bin/golangci-lint" ]; then
+  GOLANGCI_LINT="$HOME/go/bin/golangci-lint"
+elif [ -x "$(go env GOPATH)/bin/golangci-lint" ]; then
+  GOLANGCI_LINT="$(go env GOPATH)/bin/golangci-lint"
+else
   echo "Error: golangci-lint not found. Run 'make install-tools' first."
   exit 1
 fi
-golangci-lint run --timeout=5m
+$GOLANGCI_LINT run --timeout=5m
 
 # Run tests (same packages as CI)
 echo "→ Running tests..."


### PR DESCRIPTION
## Summary
- Add CI Success gate job for simplified branch protection (only need to require this single check instead of enumerating every individual job)
- Fix pre-commit hook to find golangci-lint in common locations (PATH, ~/go/bin, GOPATH/bin)

## Test plan
- [ ] CI Success job runs after all other jobs complete
- [ ] CI Success fails if any upstream job fails
- [ ] Pre-commit hook finds golangci-lint when not in PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)