### PR TITLE
Enforce non-conventional PR titles to fix duplicate changelog entries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,15 +194,33 @@ jobs:
           /tmp/example-parse testdata/gedcom-5.5/minimal.ged
         fi
 
+  pr-title:
+    name: PR Title Check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Check PR title is not conventional commit format
+        run: |
+          TITLE="${{ github.event.pull_request.title }}"
+          PATTERN="^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?!?:"
+          if echo "$TITLE" | grep -qE "$PATTERN"; then
+            echo "::error::PR title should NOT use conventional commit format."
+            echo "Use descriptive titles (e.g., 'Add date parsing') not 'feat(date): ...'"
+            echo "Conventional commits are for commit messages only."
+            exit 1
+          fi
+          echo "✅ PR title valid: $TITLE"
+
   # Gate job for branch protection - only require this one check
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [test, coverage, lint, format, security, build-examples]
+    needs: [test, coverage, lint, format, security, build-examples, pr-title]
     if: always()
     steps:
       - name: Check all jobs passed
         run: |
+          # pr-title is skipped on push events, which is expected
           if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
             echo "❌ Some jobs failed"
             exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,26 @@ Key principles: Library-First Design, API Clarity, Test Coverage (≥85%), Versi
 Priority: `priority:high`, `priority:medium`, `priority:low`, `priority:future`
 Area: `area:encoding`, `area:parsing`, `area:validation`, `area:api`, `area:tooling`, `area:dx`
 
+## Git Conventions
+
+### Commit Messages
+Use [conventional commits](https://www.conventionalcommits.org/): `type(scope): description`
+- `feat(parser): add GEDCOM 7.0 header parsing`
+- `fix(decoder): handle empty CONC values`
+- `docs: update API examples`
+
+### PR Titles (IMPORTANT)
+PR titles must **NOT** use conventional commit format. Use plain descriptive titles:
+- **Good**: `Add GEDCOM 7.0 header parsing`
+- **Bad**: `feat(parser): add GEDCOM 7.0 header parsing`
+
+**Why?** We use merge commits (not squash) for semi-linear history. Release-please picks up both PR titles and commit messages. If both use conventional format, changelog entries are duplicated.
+
+### Branch Strategy
+- Rebase feature branches on `main` before merging
+- Use merge commits (not squash) to preserve commit history
+- CI enforces PR title format via `.github/workflows/pr-title.yml`
+
 ## Downstream Consumer
 
 This library is used by `github.com/cacack/my-family` (at `/Users/chris/devel/home/my-family`) via a `replace` directive during development. When adding features:


### PR DESCRIPTION
## Summary

- Add CI check that rejects PR titles using conventional commit format
- Document convention in CLAUDE.md for developer guidance

## Problem

When using merge commits (for semi-linear history), release-please picks up both:
1. PR titles (associated with merge commit)
2. Actual commit messages (from the branch)

If both use conventional commit format (`feat:`, `fix:`, etc.), features appear twice in the changelog with different SHAs.

## Solution

Enforce a simple rule:
| Where | Format | Example |
|-------|--------|---------|
| Commit message | `feat(scope): ...` | `feat(date): add parsing` |
| PR title | Descriptive | `Add date parsing support` |

This ensures release-please only picks up commit messages (the real changes).

## Test plan

- [ ] Create a test PR with title `feat: test` - should fail CI
- [ ] Create a test PR with title `Add test feature` - should pass CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)