### PR TITLE
Add calendar conversion with ToGregorian and cross-calendar Compare

### DIFF
--- a/gedcom/calendar.go
+++ b/gedcom/calendar.go
@@ -1,0 +1,647 @@
+package gedcom
+
+// Calendar conversion functions using Julian Day Number (JDN) as the universal
+// intermediate format. Implements standard algorithms from "Calendrical Calculations"
+// by Dershowitz & Reingold.
+//
+// JDN is a continuous count of days since the beginning of the Julian Period
+// (January 1, 4713 BC in the proleptic Julian calendar). It provides a
+// calendar-independent way to perform date arithmetic and conversions.
+
+// GregorianToJDN converts a Gregorian date to Julian Day Number.
+// Uses astronomical year numbering (year 0 exists, negative years for BC).
+//
+// Reference: Dershowitz & Reingold "Calendrical Calculations"
+//
+// Parameters:
+//   - year: astronomical year (0 = 1 BC, -1 = 2 BC, etc.)
+//   - month: 1-12 (January = 1, December = 12)
+//   - day: 1-31 depending on month
+//
+// Returns:
+//   - jdn: Julian Day Number
+//
+// Example:
+//
+//	GregorianToJDN(2000, 1, 1) = 2451545  // January 1, 2000
+//	GregorianToJDN(1970, 1, 1) = 2440588  // Unix epoch
+func GregorianToJDN(year, month, day int) int {
+	// Standard formula from Dershowitz & Reingold
+	a := (14 - month) / 12
+	y := year + 4800 - a
+	m := month + 12*a - 3
+
+	jdn := day + (153*m+2)/5 + 365*y + y/4 - y/100 + y/400 - 32045
+	return jdn
+}
+
+// JDNToGregorian converts a Julian Day Number to Gregorian date.
+// Returns year in astronomical numbering (0 = 1 BC, -1 = 2 BC, etc.)
+//
+// Reference: Dershowitz & Reingold "Calendrical Calculations"
+//
+// Parameters:
+//   - jdn: Julian Day Number
+//
+// Returns:
+//   - year: astronomical year (0 = 1 BC, -1 = 2 BC, etc.)
+//   - month: 1-12 (January = 1, December = 12)
+//   - day: 1-31 depending on month
+//
+// Example:
+//
+//	JDNToGregorian(2451545) = (2000, 1, 1)  // January 1, 2000
+func JDNToGregorian(jdn int) (year, month, day int) {
+	// Standard formula from Dershowitz & Reingold
+	a := jdn + 32044
+	b := (4*a + 3) / 146097
+	c := a - (146097*b)/4
+	d := (4*c + 3) / 1461
+	e := c - (1461*d)/4
+	m := (5*e + 2) / 153
+
+	day = e - (153*m+2)/5 + 1
+	month = m + 3 - 12*(m/10)
+	year = 100*b + d - 4800 + m/10
+
+	return year, month, day
+}
+
+// AstronomicalYear converts a GEDCOM year (with IsBC flag) to astronomical year.
+// GEDCOM uses historical year numbering (1 BC, 2 BC, etc. with no year 0),
+// while astronomical year numbering includes year 0 (0 = 1 BC, -1 = 2 BC, etc.).
+//
+// Conversion rules:
+//   - AD years: unchanged (e.g., 2000 AD = 2000)
+//   - BC years: year 0 = 1 BC, so n BC = -(n-1)
+//     Examples:
+//     1 BC = 0
+//     2 BC = -1
+//     44 BC = -43
+//
+// Parameters:
+//   - year: GEDCOM year (always positive, e.g., 44 for "44 BC")
+//   - isBC: true if the year is BC/BCE
+//
+// Returns:
+//   - astronomical year (may be negative or zero)
+//
+// Example:
+//
+//	AstronomicalYear(44, true) = -43   // 44 BC
+//	AstronomicalYear(2000, false) = 2000  // 2000 AD
+func AstronomicalYear(year int, isBC bool) int {
+	if !isBC {
+		return year
+	}
+	// BC years: 1 BC = 0, 2 BC = -1, etc.
+	return -(year - 1)
+}
+
+// FromAstronomicalYear converts astronomical year back to GEDCOM representation.
+// Inverse of AstronomicalYear.
+//
+// Conversion rules:
+//   - Positive years and zero: BC years
+//     0 = 1 BC
+//     -1 = 2 BC
+//     -43 = 44 BC
+//   - Positive years: AD years (unchanged)
+//
+// Parameters:
+//   - astroYear: astronomical year (may be negative or zero)
+//
+// Returns:
+//   - year: GEDCOM year (always positive)
+//   - isBC: true if the year is BC/BCE
+//
+// Example:
+//
+//	FromAstronomicalYear(-43) = (44, true)   // 44 BC
+//	FromAstronomicalYear(2000) = (2000, false)  // 2000 AD
+func FromAstronomicalYear(astroYear int) (year int, isBC bool) {
+	if astroYear > 0 {
+		return astroYear, false
+	}
+	// Astronomical year 0 or negative = BC
+	// 0 = 1 BC, -1 = 2 BC, etc.
+	return -(astroYear - 1), true
+}
+
+// JulianToJDN converts a Julian calendar date to Julian Day Number.
+// Uses astronomical year numbering (year 0 exists, negative years for BC).
+//
+// The Julian calendar was introduced by Julius Caesar in 45 BC and differs from
+// the Gregorian calendar only in leap year rules:
+//   - Julian: leap year every 4 years (no century exception)
+//   - Gregorian: leap year every 4 years, except centuries unless divisible by 400
+//
+// Most countries switched from Julian to Gregorian in October 1582, though some
+// regions continued using the Julian calendar until the 20th century. Historical
+// dates before October 15, 1582 are typically expressed in Julian calendar.
+//
+// Reference: Dershowitz & Reingold "Calendrical Calculations"
+//
+// Parameters:
+//   - year: astronomical year (0 = 1 BC, -1 = 2 BC, etc.)
+//   - month: 1-12 (January = 1, December = 12)
+//   - day: 1-31 depending on month
+//
+// Returns:
+//   - jdn: Julian Day Number
+//
+// Example:
+//
+//	JulianToJDN(1582, 10, 4) = 2299160   // Oct 4, 1582 (last Julian day in most countries)
+//	JulianToJDN(-43, 3, 15) = 1705426    // Ides of March, 44 BC
+//	JulianToJDN(1, 1, 1) = 1721424       // January 1, 1 AD
+func JulianToJDN(year, month, day int) int {
+	// Standard formula from Dershowitz & Reingold
+	// Same as Gregorian but without century leap year corrections
+	a := (14 - month) / 12
+	y := year + 4800 - a
+	m := month + 12*a - 3
+
+	jdn := day + (153*m+2)/5 + 365*y + y/4 - 32083
+	return jdn
+}
+
+// JDNToJulian converts a Julian Day Number to Julian calendar date.
+// Returns year in astronomical numbering (0 = 1 BC, -1 = 2 BC, etc.)
+//
+// Reference: Dershowitz & Reingold "Calendrical Calculations"
+//
+// Parameters:
+//   - jdn: Julian Day Number
+//
+// Returns:
+//   - year: astronomical year (0 = 1 BC, -1 = 2 BC, etc.)
+//   - month: 1-12 (January = 1, December = 12)
+//   - day: 1-31 depending on month
+//
+// Example:
+//
+//	JDNToJulian(2299160) = (1582, 10, 4)   // Oct 4, 1582 (last Julian day)
+//	JDNToJulian(1705426) = (-43, 3, 15)    // Ides of March, 44 BC
+func JDNToJulian(jdn int) (year, month, day int) {
+	// Standard formula from Dershowitz & Reingold
+	b := 0
+	c := jdn + 32082
+	d := (4*c + 3) / 1461
+	e := c - (1461*d)/4
+	m := (5*e + 2) / 153
+
+	day = e - (153*m+2)/5 + 1
+	month = m + 3 - 12*(m/10)
+	year = 100*b + d - 4800 + m/10
+
+	return year, month, day
+}
+
+// IsFrenchLeapYear returns true if the French Republican year is a leap year.
+// Uses the "continuous" method: leap if following Gregorian year is divisible by 4,
+// except centuries unless also divisible by 400.
+//
+// The French Republican calendar was historically based on astronomical observations,
+// but for computational purposes we use the Gregorian-aligned rule based on the epoch.
+// A French Republican year N spans from September 22 of Gregorian year (1791+N) to
+// September 21 of Gregorian year (1792+N). The year is a leap year (366 days) when
+// the following Gregorian year (1792+N) is a leap year.
+//
+// Parameters:
+//   - year: French Republican year (1 = Sep 22, 1792 - Sep 21, 1793)
+//
+// Returns:
+//   - true if the year has 6 complementary days (366 days total)
+//
+// Example:
+//
+//	IsFrenchLeapYear(4) = true   // Year 4 (Sep 22, 1795 - Sep 21, 1796), Gregorian 1796 is leap
+//	IsFrenchLeapYear(12) = true  // Year 12 (Sep 22, 1803 - Sep 21, 1804), Gregorian 1804 is leap
+//	IsFrenchLeapYear(16) = true  // Year 16 (Sep 22, 1807 - Sep 21, 1808), Gregorian 1808 is leap
+func IsFrenchLeapYear(year int) bool {
+	// The French Republican epoch is September 22, 1792 (Gregorian).
+	// Year N of the calendar starts on Sep 22 of Gregorian year (1791 + N).
+	// It is a leap year if the following Gregorian year (1792 + N) is a leap year.
+	// This is because the leap day falls late in the year (in the complementary days).
+	gregorianYear := 1791 + year + 1 // The year that follows the start year
+
+	// Apply Gregorian leap year rules
+	if gregorianYear%400 == 0 {
+		return true
+	}
+	if gregorianYear%100 == 0 {
+		return false
+	}
+	return gregorianYear%4 == 0
+}
+
+// FrenchToJDN converts a French Republican calendar date to Julian Day Number.
+// Month 13 (COMP) represents the complementary days (1-5 or 1-6 in leap years).
+//
+// The French Republican calendar was used in France from 1792-1805. It has:
+//   - 12 months of exactly 30 days each
+//   - 5 complementary days (6 in leap years) at the end of the year
+//   - Epoch: 1 Vendémiaire 1 = September 22, 1792 (Gregorian) = JDN 2375840
+//
+// Parameters:
+//   - year: French Republican year (1 = 1792-1793)
+//   - month: 1-13 (1-12 are regular months, 13 = complementary days)
+//   - day: 1-30 for months 1-12, 1-5 (or 1-6 in leap years) for month 13
+//
+// Returns:
+//   - jdn: Julian Day Number
+//
+// Example:
+//
+//	FrenchToJDN(1, 1, 1) = 2375840    // 1 Vendémiaire 1 (Sep 22, 1792)
+//	FrenchToJDN(8, 1, 1) = 2378396    // 1 Vendémiaire 8 (Sep 22, 1799)
+//	FrenchToJDN(14, 1, 1) = 2380587   // 1 Vendémiaire 14 (Sep 22, 1805)
+func FrenchToJDN(year, month, day int) int {
+	// French Republican epoch: 1 Vendémiaire 1 = September 22, 1792 (Gregorian) = JDN 2375840
+	const epoch = 2375840
+
+	// Calculate days before the start of this year
+	// Count leap years before this year
+	leapDays := 0
+	for y := 1; y < year; y++ {
+		if IsFrenchLeapYear(y) {
+			leapDays++
+		}
+	}
+	daysBeforeYear := (year-1)*365 + leapDays
+
+	// Calculate days within this year
+	daysInYear := 0
+	if month <= 12 {
+		// Regular months (1-12): each has exactly 30 days
+		daysInYear = (month-1)*30 + day
+	} else {
+		// Month 13 (complementary days): after all 12 regular months
+		daysInYear = 12*30 + day
+	}
+
+	// JDN = epoch + days before year + days in year - 1
+	// (subtract 1 because day 1 of year 1 should equal the epoch)
+	return epoch + daysBeforeYear + daysInYear - 1
+}
+
+// JDNToFrench converts a Julian Day Number to French Republican calendar date.
+// Returns month=13 for complementary days.
+//
+// The French Republican calendar was used in France from 1792-1805. It has:
+//   - 12 months of exactly 30 days each
+//   - 5 complementary days (6 in leap years) at the end of the year
+//   - Epoch: 1 Vendémiaire 1 = September 22, 1792 (Gregorian) = JDN 2375840
+//
+// Parameters:
+//   - jdn: Julian Day Number
+//
+// Returns:
+//   - year: French Republican year (1 = 1792-1793)
+//   - month: 1-13 (1-12 are regular months, 13 = complementary days)
+//   - day: 1-30 for months 1-12, 1-5 (or 1-6 in leap years) for month 13
+//
+// Example:
+//
+//	JDNToFrench(2375840) = (1, 1, 1)      // 1 Vendémiaire 1
+//	JDNToFrench(2378396) = (8, 1, 1)      // 1 Vendémiaire 8
+//	JDNToFrench(2380587) = (14, 1, 1)     // 1 Vendémiaire 14
+func JDNToFrench(jdn int) (year, month, day int) {
+	// French Republican epoch: 1 Vendémiaire 1 = September 22, 1792 (Gregorian) = JDN 2375840
+	const epoch = 2375840
+
+	// Days since epoch (0 = first day of year 1)
+	daysSinceEpoch := jdn - epoch
+
+	// Find the exact year by counting forward from epoch
+	year = 1
+	daysAccumulated := 0
+	for {
+		yearLength := 365
+		if IsFrenchLeapYear(year) {
+			yearLength = 366
+		}
+
+		if daysAccumulated+yearLength > daysSinceEpoch {
+			// Found the year
+			break
+		}
+
+		daysAccumulated += yearLength
+		year++
+	}
+
+	// Days remaining in this year (0-based)
+	dayInYear := daysSinceEpoch - daysAccumulated
+
+	// Determine month and day
+	if dayInYear < 360 {
+		// Regular months (1-12): each has 30 days
+		month = dayInYear/30 + 1
+		day = dayInYear%30 + 1
+	} else {
+		// Complementary days (month 13)
+		month = 13
+		day = dayInYear - 360 + 1
+	}
+
+	return year, month, day
+}
+
+// IsHebrewLeapYear returns true if the Hebrew year has 13 months.
+// Leap years occur in years 3, 6, 8, 11, 14, 17, 19 of each 19-year cycle.
+//
+// The Hebrew calendar uses a 19-year Metonic cycle where 7 out of every 19 years
+// are leap years with an additional month (Adar II). The pattern ensures that
+// the lunar calendar stays synchronized with the solar year.
+//
+// Parameters:
+//   - year: Hebrew year
+//
+// Returns:
+//   - true if the year has 13 months (leap year)
+//
+// Example:
+//
+//	IsHebrewLeapYear(5784) = true   // Year 5784 is a leap year
+//	IsHebrewLeapYear(5785) = false  // Year 5785 is not a leap year
+func IsHebrewLeapYear(year int) bool {
+	return (7*year+1)%19 < 7
+}
+
+// HebrewMonthsInYear returns the number of months in a Hebrew year (12 or 13).
+//
+// Regular years have 12 months, leap years have 13 months (with Adar I and Adar II).
+//
+// Parameters:
+//   - year: Hebrew year
+//
+// Returns:
+//   - 12 for regular years, 13 for leap years
+//
+// Example:
+//
+//	HebrewMonthsInYear(5784) = 13  // Leap year
+//	HebrewMonthsInYear(5785) = 12  // Regular year
+func HebrewMonthsInYear(year int) int {
+	if IsHebrewLeapYear(year) {
+		return 13
+	}
+	return 12
+}
+
+// hebrewDelay calculates the number of days from Hebrew epoch to the start of a Hebrew year.
+// This implements the complex Hebrew calendar arithmetic including the four dehiyot (postponement rules).
+//
+// The dehiyot ensure that:
+//  1. Rosh Hashanah (1 Tishrei) doesn't fall on Sunday, Wednesday, or Friday
+//  2. Yom Kippur (10 Tishrei) doesn't fall adjacent to Shabbat
+//  3. Hoshana Rabbah (21 Tishrei) doesn't fall on Shabbat
+//
+// Reference: Dershowitz & Reingold "Calendrical Calculations"
+func hebrewDelay(year int) int {
+	// Calculate months elapsed since epoch (including leap years)
+	monthsElapsed := 235*((year-1)/19) + // Complete 19-year cycles
+		12*((year-1)%19) + // Regular months in incomplete cycle
+		(7*((year-1)%19)+1)/19 // Leap months in incomplete cycle
+
+	// Calculate parts (chelek) elapsed
+	// 1 hour = 1080 parts, 1 day = 25920 parts
+	// New moon calculation: 29 days 12 hours 793 parts per lunar month
+	partsElapsed := 204 + 793*(monthsElapsed%1080)
+	hoursElapsed := 5 + 12*monthsElapsed + 793*(monthsElapsed/1080) + partsElapsed/1080
+
+	// Calculate day number since epoch
+	// The molad of Tishrei 1 in year 1 was on Monday (day of week 1)
+	// We count from the Sunday before as day 0, so the molad is on day 1
+	// But since we later use day % 7 to get day of week, we need to account
+	// for the fact that the epoch molad was on Monday (day 1 in 0-indexed week)
+	//
+	// Actually, we start counting from a base of day 1 (Monday), then add elapsed days
+	day := 1 + 29*monthsElapsed + hoursElapsed/24
+	parts := (hoursElapsed%24)*1080 + partsElapsed%1080
+
+	// Apply dehiyot (postponement rules)
+	// Rule 1 (Molad Zaken): If new moon is at or after noon (18 hours = 19440 parts), postpone
+	if parts >= 19440 {
+		day++
+		parts = 0 // Reset to midnight
+	}
+
+	// Day of week (0 = Sunday, 1 = Monday, ..., 6 = Saturday)
+	dayOfWeek := day % 7
+
+	// Rule 2 (GaTaRaD): If Monday and parts >= 9 hours 204 parts, postpone to Tuesday
+	// This only applies to regular (non-leap) years
+	if dayOfWeek == 1 && parts >= 9*1080+204 && !IsHebrewLeapYear(year) {
+		day += 1 // Tuesday
+	} else if dayOfWeek == 0 && parts >= 15*1080+589 && IsHebrewLeapYear(year-1) {
+		// Rule 3 (BeTuTaKFoT): If Tuesday and parts >= 15 hours 589 parts, postpone
+		// This only applies when previous year was a leap year
+		day += 1 // Wednesday, which will be postponed to Thursday by Rule 4
+	}
+
+	// Rule 4 (Lo ADU Rosh): Rosh Hashanah cannot fall on Sunday (0), Wednesday (3), or Friday (5)
+	dayOfWeek = day % 7
+	if dayOfWeek == 0 || dayOfWeek == 3 || dayOfWeek == 5 {
+		day += 1
+	}
+
+	// Return the number of days SINCE the epoch
+	// We started counting from day 1 (the molad of year 1), so subtract 1
+	return day - 1
+}
+
+// HebrewDaysInYear returns the number of days in a Hebrew year (353-385).
+//
+// Hebrew year lengths:
+//   - Regular years: 353 (deficient), 354 (regular), 355 (complete)
+//   - Leap years: 383 (deficient), 384 (regular), 385 (complete)
+//
+// The variation comes from the dehiyot (postponement rules) which adjust
+// the lengths of Cheshvan and Kislev to ensure proper calendar alignment.
+//
+// Parameters:
+//   - year: Hebrew year
+//
+// Returns:
+//   - Number of days in the year (353-385)
+//
+// Example:
+//
+//	HebrewDaysInYear(5785) = 355  // Regular complete year
+//	HebrewDaysInYear(5784) = 385  // Leap complete year
+func HebrewDaysInYear(year int) int {
+	return hebrewDelay(year+1) - hebrewDelay(year)
+}
+
+// HebrewDaysInMonth returns the number of days in a Hebrew month (29 or 30).
+//
+// Month lengths vary based on the year type (deficient, regular, complete):
+//   - Tishrei (1), Shevat (5), Nisan (8), Sivan (10), Av (12): always 30 days
+//   - Tevet (4), Iyar (9), Tammuz (11), Elul (13): always 29 days
+//   - Cheshvan (2): 29 (deficient/regular) or 30 (complete)
+//   - Kislev (3): 29 (deficient) or 30 (regular/complete)
+//   - Adar (6): 29 days in regular years, 30 days in leap years (as Adar I)
+//   - Adar II (7): only exists in leap years, 29 days
+//
+// Parameters:
+//   - year: Hebrew year
+//   - month: Month number (1-13, using GEDCOM numbering where Tishrei=1)
+//
+// Returns:
+//   - Number of days in the month (29 or 30)
+//
+// Example:
+//
+//	HebrewDaysInMonth(5785, 1) = 30   // Tishrei always has 30 days
+//	HebrewDaysInMonth(5785, 2) = 29   // Cheshvan varies by year type
+func HebrewDaysInMonth(year, month int) int {
+	// Determine year type by calculating year length
+	yearLength := HebrewDaysInYear(year)
+	isLeap := IsHebrewLeapYear(year)
+
+	// Base length for leap vs regular years
+	var baseLength int
+	if isLeap {
+		baseLength = 383
+	} else {
+		baseLength = 353
+	}
+
+	// Determine year type: deficient (base), regular (base+1), complete (base+2)
+	yearType := yearLength - baseLength // 0=deficient, 1=regular, 2=complete
+
+	switch month {
+	case 1, 5, 8, 10, 12: // Tishrei, Shevat, Nisan, Sivan, Av
+		return 30
+	case 4, 9, 11, 13: // Tevet, Iyar, Tammuz, Elul
+		return 29
+	case 2: // Cheshvan (Marcheshvan)
+		// 29 days normally, 30 in complete years
+		if yearType == 2 {
+			return 30
+		}
+		return 29
+	case 3: // Kislev
+		// 30 days normally, 29 in deficient years
+		if yearType == 0 {
+			return 29
+		}
+		return 30
+	case 6: // Adar (Adar I in leap years)
+		if isLeap {
+			return 30 // Adar I in leap years has 30 days
+		}
+		return 29 // Adar in non-leap years has 29 days
+	case 7: // Adar II (only in leap years)
+		if isLeap {
+			return 29
+		}
+		// Month 7 doesn't exist in non-leap years, but return 0 for safety
+		return 0
+	default:
+		return 0 // Invalid month
+	}
+}
+
+// HebrewToJDN converts a Hebrew calendar date to Julian Day Number.
+// Month numbering follows GEDCOM convention: Tishrei=1, ..., Elul=13.
+// In leap years, Adar I=6 and Adar II=7.
+//
+// The Hebrew calendar is a lunisolar calendar with years of 12 or 13 months.
+// The epoch is Tishrei 1, 1 = Monday, September 7, 3761 BC (Julian) = JDN 347998.
+//
+// Parameters:
+//   - year: Hebrew year
+//   - month: Month number (1-13, Tishrei=1 per GEDCOM convention)
+//   - day: Day of month (1-30)
+//
+// Returns:
+//   - jdn: Julian Day Number
+//
+// Example:
+//
+//	HebrewToJDN(5785, 1, 1) = 2460587   // 1 Tishrei 5785 (Rosh Hashanah)
+//	HebrewToJDN(5785, 8, 15) = 2460779  // 15 Nisan 5785 (Passover)
+func HebrewToJDN(year, month, day int) int {
+	// Hebrew epoch: 1 Tishrei 1 = JDN 347998 (Monday, September 7, 3761 BC Julian)
+	const epoch = 347998
+
+	// Calculate days from epoch to the start of this year
+	daysToYear := hebrewDelay(year)
+
+	// Calculate days from start of year to start of this month
+	daysToMonth := 0
+	for m := 1; m < month; m++ {
+		daysToMonth += HebrewDaysInMonth(year, m)
+	}
+
+	// JDN = epoch + days to year + days to month + day - 1
+	// (subtract 1 because day 1 of year 1 should equal the epoch)
+	return epoch + daysToYear + daysToMonth + day - 1
+}
+
+// JDNToHebrew converts a Julian Day Number to Hebrew calendar date.
+// Returns month in GEDCOM numbering (Tishrei=1).
+//
+// The Hebrew calendar is a lunisolar calendar with years of 12 or 13 months.
+// The epoch is Tishrei 1, 1 = Monday, September 7, 3761 BC (Julian) = JDN 347998.
+//
+// Parameters:
+//   - jdn: Julian Day Number
+//
+// Returns:
+//   - year: Hebrew year
+//   - month: Month number (1-13, Tishrei=1 per GEDCOM convention)
+//   - day: Day of month (1-30)
+//
+// Example:
+//
+//	JDNToHebrew(2460587) = (5785, 1, 1)   // 1 Tishrei 5785 (Rosh Hashanah)
+//	JDNToHebrew(2460779) = (5785, 8, 15)  // 15 Nisan 5785 (Passover)
+func JDNToHebrew(jdn int) (year, month, day int) {
+	// Hebrew epoch: 1 Tishrei 1 = JDN 347998
+	const epoch = 347998
+
+	// Days since epoch
+	daysSinceEpoch := jdn - epoch
+
+	// Estimate the year (approximate)
+	// Average Hebrew year is about 365.25 days
+	estimatedYear := daysSinceEpoch/366 + 1
+	if estimatedYear < 1 {
+		estimatedYear = 1
+	}
+
+	// Find the exact year by checking when the next year starts
+	year = estimatedYear
+	for hebrewDelay(year+1) <= daysSinceEpoch {
+		year++
+	}
+	for hebrewDelay(year) > daysSinceEpoch {
+		year--
+	}
+
+	// Days from start of year
+	daysIntoYear := daysSinceEpoch - hebrewDelay(year)
+
+	// Find the month
+	month = 1
+	daysAccumulated := 0
+	for month <= HebrewMonthsInYear(year) {
+		monthLength := HebrewDaysInMonth(year, month)
+		if daysAccumulated+monthLength > daysIntoYear {
+			// Found the month
+			break
+		}
+		daysAccumulated += monthLength
+		month++
+	}
+
+	// Calculate day within month (1-based)
+	day = daysIntoYear - daysAccumulated + 1
+
+	return year, month, day
+}

--- a/gedcom/calendar_test.go
+++ b/gedcom/calendar_test.go
@@ -1,0 +1,1651 @@
+package gedcom
+
+import (
+	"testing"
+)
+
+// TestGregorianToJDN tests the Gregorian to JDN conversion with known reference dates.
+func TestGregorianToJDN(t *testing.T) {
+	tests := []struct {
+		name  string
+		year  int
+		month int
+		day   int
+		want  int
+	}{
+		// Modern reference dates
+		{
+			name:  "January 1, 2000",
+			year:  2000,
+			month: 1,
+			day:   1,
+			want:  2451545,
+		},
+		{
+			name:  "Unix epoch (January 1, 1970)",
+			year:  1970,
+			month: 1,
+			day:   1,
+			want:  2440588,
+		},
+		{
+			name:  "Gregorian calendar adoption (October 15, 1582)",
+			year:  1582,
+			month: 10,
+			day:   15,
+			want:  2299161,
+		},
+
+		// Historical BC dates (using astronomical year numbering)
+		// Note: These are proleptic Gregorian dates, not Julian calendar dates
+		{
+			name:  "Ides of March, 44 BC (astronomical year -43)",
+			year:  -43,
+			month: 3,
+			day:   15,
+			want:  1705428,
+		},
+		{
+			name:  "January 1, 1 BC (astronomical year 0)",
+			year:  0,
+			month: 1,
+			day:   1,
+			want:  1721060,
+		},
+		{
+			name:  "January 1, 1 AD",
+			year:  1,
+			month: 1,
+			day:   1,
+			want:  1721426,
+		},
+
+		// Year boundaries
+		{
+			name:  "December 31, 1999",
+			year:  1999,
+			month: 12,
+			day:   31,
+			want:  2451544,
+		},
+		{
+			name:  "January 1, 2001",
+			year:  2001,
+			month: 1,
+			day:   1,
+			want:  2451911,
+		},
+
+		// Leap year dates
+		{
+			name:  "February 29, 2000 (leap year)",
+			year:  2000,
+			month: 2,
+			day:   29,
+			want:  2451604,
+		},
+		{
+			name:  "February 29, 1600 (leap year)",
+			year:  1600,
+			month: 2,
+			day:   29,
+			want:  2305507,
+		},
+
+		// Other notable dates
+		{
+			name:  "July 4, 1776 (US Independence)",
+			year:  1776,
+			month: 7,
+			day:   4,
+			want:  2369916,
+		},
+		{
+			name:  "November 24, 4714 BC (JDN epoch, astronomical year -4713)",
+			year:  -4713,
+			month: 11,
+			day:   24,
+			want:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GregorianToJDN(tt.year, tt.month, tt.day)
+			if got != tt.want {
+				t.Errorf("GregorianToJDN(%d, %d, %d) = %d, want %d",
+					tt.year, tt.month, tt.day, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestJDNToGregorian tests the JDN to Gregorian conversion with known reference dates.
+func TestJDNToGregorian(t *testing.T) {
+	tests := []struct {
+		name      string
+		jdn       int
+		wantYear  int
+		wantMonth int
+		wantDay   int
+	}{
+		// Modern reference dates
+		{
+			name:      "JDN 2451545 (January 1, 2000)",
+			jdn:       2451545,
+			wantYear:  2000,
+			wantMonth: 1,
+			wantDay:   1,
+		},
+		{
+			name:      "JDN 2440588 (Unix epoch, January 1, 1970)",
+			jdn:       2440588,
+			wantYear:  1970,
+			wantMonth: 1,
+			wantDay:   1,
+		},
+		{
+			name:      "JDN 2299161 (Gregorian adoption, October 15, 1582)",
+			jdn:       2299161,
+			wantYear:  1582,
+			wantMonth: 10,
+			wantDay:   15,
+		},
+
+		// Historical BC dates (astronomical year numbering)
+		// Note: These are proleptic Gregorian dates, not Julian calendar dates
+		{
+			name:      "JDN 1705428 (Ides of March, 44 BC)",
+			jdn:       1705428,
+			wantYear:  -43,
+			wantMonth: 3,
+			wantDay:   15,
+		},
+		{
+			name:      "JDN 1721060 (January 1, 1 BC / astronomical year 0)",
+			jdn:       1721060,
+			wantYear:  0,
+			wantMonth: 1,
+			wantDay:   1,
+		},
+
+		// Year boundaries
+		{
+			name:      "JDN 2451544 (December 31, 1999)",
+			jdn:       2451544,
+			wantYear:  1999,
+			wantMonth: 12,
+			wantDay:   31,
+		},
+		{
+			name:      "JDN 2451911 (January 1, 2001)",
+			jdn:       2451911,
+			wantYear:  2001,
+			wantMonth: 1,
+			wantDay:   1,
+		},
+
+		// Leap year dates
+		{
+			name:      "JDN 2451604 (February 29, 2000)",
+			jdn:       2451604,
+			wantYear:  2000,
+			wantMonth: 2,
+			wantDay:   29,
+		},
+
+		// JDN epoch
+		{
+			name:      "JDN 0 (November 24, 4714 BC)",
+			jdn:       0,
+			wantYear:  -4713,
+			wantMonth: 11,
+			wantDay:   24,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotYear, gotMonth, gotDay := JDNToGregorian(tt.jdn)
+			if gotYear != tt.wantYear || gotMonth != tt.wantMonth || gotDay != tt.wantDay {
+				t.Errorf("JDNToGregorian(%d) = (%d, %d, %d), want (%d, %d, %d)",
+					tt.jdn, gotYear, gotMonth, gotDay, tt.wantYear, tt.wantMonth, tt.wantDay)
+			}
+		})
+	}
+}
+
+// TestGregorianJDNRoundTrip tests that converting Gregorian -> JDN -> Gregorian
+// returns the same date (verifying the functions are inverse operations).
+func TestGregorianJDNRoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		year  int
+		month int
+		day   int
+	}{
+		{"Modern date", 2000, 6, 15},
+		{"Leap year", 2000, 2, 29},
+		{"Non-leap year", 1900, 2, 28},
+		{"BC date (astronomical)", -43, 3, 15},
+		{"Year 0 (1 BC)", 0, 1, 1},
+		{"Year 1 AD", 1, 1, 1},
+		{"Recent date", 2024, 12, 23},
+		{"19th century", 1850, 7, 4},
+		{"16th century", 1582, 10, 15},
+		{"Deep BC (astronomical)", -4713, 11, 24},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Convert to JDN and back
+			jdn := GregorianToJDN(tt.year, tt.month, tt.day)
+			gotYear, gotMonth, gotDay := JDNToGregorian(jdn)
+
+			if gotYear != tt.year || gotMonth != tt.month || gotDay != tt.day {
+				t.Errorf("Round trip failed for (%d, %d, %d): got (%d, %d, %d) via JDN %d",
+					tt.year, tt.month, tt.day, gotYear, gotMonth, gotDay, jdn)
+			}
+		})
+	}
+}
+
+// TestAstronomicalYear tests the conversion from GEDCOM year/BC format to astronomical year.
+func TestAstronomicalYear(t *testing.T) {
+	tests := []struct {
+		name string
+		year int
+		isBC bool
+		want int
+	}{
+		// AD years (unchanged)
+		{
+			name: "2000 AD",
+			year: 2000,
+			isBC: false,
+			want: 2000,
+		},
+		{
+			name: "1 AD",
+			year: 1,
+			isBC: false,
+			want: 1,
+		},
+
+		// BC years (subtract 1 and negate)
+		{
+			name: "1 BC",
+			year: 1,
+			isBC: true,
+			want: 0,
+		},
+		{
+			name: "2 BC",
+			year: 2,
+			isBC: true,
+			want: -1,
+		},
+		{
+			name: "44 BC",
+			year: 44,
+			isBC: true,
+			want: -43,
+		},
+		{
+			name: "100 BC",
+			year: 100,
+			isBC: true,
+			want: -99,
+		},
+		{
+			name: "4714 BC (JDN epoch)",
+			year: 4714,
+			isBC: true,
+			want: -4713,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AstronomicalYear(tt.year, tt.isBC)
+			if got != tt.want {
+				t.Errorf("AstronomicalYear(%d, %v) = %d, want %d",
+					tt.year, tt.isBC, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFromAstronomicalYear tests the conversion from astronomical year back to GEDCOM format.
+func TestFromAstronomicalYear(t *testing.T) {
+	tests := []struct {
+		name      string
+		astroYear int
+		wantYear  int
+		wantIsBC  bool
+	}{
+		// AD years (positive)
+		{
+			name:      "2000 AD",
+			astroYear: 2000,
+			wantYear:  2000,
+			wantIsBC:  false,
+		},
+		{
+			name:      "1 AD",
+			astroYear: 1,
+			wantYear:  1,
+			wantIsBC:  false,
+		},
+
+		// BC years (zero and negative)
+		{
+			name:      "1 BC (astronomical 0)",
+			astroYear: 0,
+			wantYear:  1,
+			wantIsBC:  true,
+		},
+		{
+			name:      "2 BC (astronomical -1)",
+			astroYear: -1,
+			wantYear:  2,
+			wantIsBC:  true,
+		},
+		{
+			name:      "44 BC (astronomical -43)",
+			astroYear: -43,
+			wantYear:  44,
+			wantIsBC:  true,
+		},
+		{
+			name:      "100 BC (astronomical -99)",
+			astroYear: -99,
+			wantYear:  100,
+			wantIsBC:  true,
+		},
+		{
+			name:      "4714 BC (JDN epoch, astronomical -4713)",
+			astroYear: -4713,
+			wantYear:  4714,
+			wantIsBC:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotYear, gotIsBC := FromAstronomicalYear(tt.astroYear)
+			if gotYear != tt.wantYear || gotIsBC != tt.wantIsBC {
+				t.Errorf("FromAstronomicalYear(%d) = (%d, %v), want (%d, %v)",
+					tt.astroYear, gotYear, gotIsBC, tt.wantYear, tt.wantIsBC)
+			}
+		})
+	}
+}
+
+// TestAstronomicalYearRoundTrip tests that converting GEDCOM year -> astronomical -> GEDCOM
+// returns the same values.
+func TestAstronomicalYearRoundTrip(t *testing.T) {
+	tests := []struct {
+		year int
+		isBC bool
+	}{
+		{2000, false},
+		{1, false},
+		{1, true},
+		{2, true},
+		{44, true},
+		{100, true},
+		{4714, true},
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			// Convert to astronomical and back
+			astro := AstronomicalYear(tt.year, tt.isBC)
+			gotYear, gotIsBC := FromAstronomicalYear(astro)
+
+			if gotYear != tt.year || gotIsBC != tt.isBC {
+				t.Errorf("Round trip failed for (%d, %v): got (%d, %v) via astro %d",
+					tt.year, tt.isBC, gotYear, gotIsBC, astro)
+			}
+		})
+	}
+}
+
+// TestGEDCOMDateToJDN tests converting a GEDCOM Date to JDN using the helper functions.
+func TestGEDCOMDateToJDN(t *testing.T) {
+	tests := []struct {
+		name     string
+		year     int
+		month    int
+		day      int
+		isBC     bool
+		wantJDN  int
+		wantDesc string
+	}{
+		{
+			name:     "Modern date",
+			year:     2000,
+			month:    1,
+			day:      1,
+			isBC:     false,
+			wantJDN:  2451545,
+			wantDesc: "January 1, 2000 AD",
+		},
+		{
+			name:     "Ides of March 44 BC",
+			year:     44,
+			month:    3,
+			day:      15,
+			isBC:     true,
+			wantJDN:  1705428,
+			wantDesc: "March 15, 44 BC",
+		},
+		{
+			name:     "Year 1 BC",
+			year:     1,
+			month:    1,
+			day:      1,
+			isBC:     true,
+			wantJDN:  1721060,
+			wantDesc: "January 1, 1 BC",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Convert GEDCOM year to astronomical year
+			astroYear := AstronomicalYear(tt.year, tt.isBC)
+
+			// Convert to JDN
+			jdn := GregorianToJDN(astroYear, tt.month, tt.day)
+
+			if jdn != tt.wantJDN {
+				t.Errorf("%s: got JDN %d, want %d", tt.wantDesc, jdn, tt.wantJDN)
+			}
+		})
+	}
+}
+
+// TestJDNToGEDCOMDate tests converting a JDN back to GEDCOM Date format.
+func TestJDNToGEDCOMDate(t *testing.T) {
+	tests := []struct {
+		name      string
+		jdn       int
+		wantYear  int
+		wantMonth int
+		wantDay   int
+		wantIsBC  bool
+	}{
+		{
+			name:      "Modern date",
+			jdn:       2451545,
+			wantYear:  2000,
+			wantMonth: 1,
+			wantDay:   1,
+			wantIsBC:  false,
+		},
+		{
+			name:      "Ides of March 44 BC",
+			jdn:       1705428,
+			wantYear:  44,
+			wantMonth: 3,
+			wantDay:   15,
+			wantIsBC:  true,
+		},
+		{
+			name:      "Year 1 BC",
+			jdn:       1721060,
+			wantYear:  1,
+			wantMonth: 1,
+			wantDay:   1,
+			wantIsBC:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Convert JDN to astronomical year
+			astroYear, month, day := JDNToGregorian(tt.jdn)
+
+			// Convert astronomical year back to GEDCOM format
+			year, isBC := FromAstronomicalYear(astroYear)
+
+			if year != tt.wantYear || month != tt.wantMonth || day != tt.wantDay || isBC != tt.wantIsBC {
+				t.Errorf("JDN %d: got (%d %s, %d, %d), want (%d %s, %d, %d)",
+					tt.jdn,
+					year, bcString(isBC), month, day,
+					tt.wantYear, bcString(tt.wantIsBC), tt.wantMonth, tt.wantDay)
+			}
+		})
+	}
+}
+
+// Helper function to format BC/AD string for error messages.
+func bcString(isBC bool) string {
+	if isBC {
+		return "BC"
+	}
+	return "AD"
+}
+
+// TestJulianToJDN tests the Julian to JDN conversion with known reference dates.
+func TestJulianToJDN(t *testing.T) {
+	tests := []struct {
+		name  string
+		year  int
+		month int
+		day   int
+		want  int
+	}{
+		// Historical reference dates
+		{
+			name:  "October 4, 1582 (last Julian day in most countries)",
+			year:  1582,
+			month: 10,
+			day:   4,
+			want:  2299160,
+		},
+		{
+			name:  "Ides of March, 44 BC (astronomical year -43)",
+			year:  -43,
+			month: 3,
+			day:   15,
+			want:  1705426,
+		},
+		{
+			name:  "January 1, 1 AD",
+			year:  1,
+			month: 1,
+			day:   1,
+			want:  1721424,
+		},
+		{
+			name:  "January 1, 1 BC (astronomical year 0)",
+			year:  0,
+			month: 1,
+			day:   1,
+			want:  1721058,
+		},
+
+		// Test leap year behavior (every 4 years, no century exception)
+		{
+			name:  "February 29, 100 AD (Julian leap year)",
+			year:  100,
+			month: 2,
+			day:   29,
+			want:  1757642,
+		},
+		{
+			name:  "February 29, 200 AD (Julian leap year)",
+			year:  200,
+			month: 2,
+			day:   29,
+			want:  1794167,
+		},
+		{
+			name:  "February 29, 1900 (Julian leap year)",
+			year:  1900,
+			month: 2,
+			day:   29,
+			want:  2415092,
+		},
+
+		// Modern dates (for comparison with Gregorian)
+		{
+			name:  "January 1, 2000 (Julian calendar)",
+			year:  2000,
+			month: 1,
+			day:   1,
+			want:  2451558, // 13 days ahead of Gregorian
+		},
+
+		// Year boundaries
+		{
+			name:  "December 31, 1581",
+			year:  1581,
+			month: 12,
+			day:   31,
+			want:  2298883,
+		},
+		{
+			name:  "January 1, 1583",
+			year:  1583,
+			month: 1,
+			day:   1,
+			want:  2299249,
+		},
+
+		// Deep BC dates
+		{
+			name:  "January 1, 4713 BC (JDN epoch, astronomical year -4712)",
+			year:  -4712,
+			month: 1,
+			day:   1,
+			want:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := JulianToJDN(tt.year, tt.month, tt.day)
+			if got != tt.want {
+				t.Errorf("JulianToJDN(%d, %d, %d) = %d, want %d",
+					tt.year, tt.month, tt.day, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestJDNToJulian tests the JDN to Julian conversion with known reference dates.
+func TestJDNToJulian(t *testing.T) {
+	tests := []struct {
+		name      string
+		jdn       int
+		wantYear  int
+		wantMonth int
+		wantDay   int
+	}{
+		// Historical reference dates
+		{
+			name:      "JDN 2299160 (October 4, 1582)",
+			jdn:       2299160,
+			wantYear:  1582,
+			wantMonth: 10,
+			wantDay:   4,
+		},
+		{
+			name:      "JDN 1705426 (Ides of March, 44 BC)",
+			jdn:       1705426,
+			wantYear:  -43,
+			wantMonth: 3,
+			wantDay:   15,
+		},
+		{
+			name:      "JDN 1721424 (January 1, 1 AD)",
+			jdn:       1721424,
+			wantYear:  1,
+			wantMonth: 1,
+			wantDay:   1,
+		},
+		{
+			name:      "JDN 1721058 (January 1, 1 BC / astronomical year 0)",
+			jdn:       1721058,
+			wantYear:  0,
+			wantMonth: 1,
+			wantDay:   1,
+		},
+
+		// Test leap year dates
+		{
+			name:      "JDN 1757642 (February 29, 100 AD)",
+			jdn:       1757642,
+			wantYear:  100,
+			wantMonth: 2,
+			wantDay:   29,
+		},
+
+		// Modern date
+		{
+			name:      "JDN 2451558 (January 1, 2000 Julian)",
+			jdn:       2451558,
+			wantYear:  2000,
+			wantMonth: 1,
+			wantDay:   1,
+		},
+
+		// Year boundaries
+		{
+			name:      "JDN 2298883 (December 31, 1581)",
+			jdn:       2298883,
+			wantYear:  1581,
+			wantMonth: 12,
+			wantDay:   31,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotYear, gotMonth, gotDay := JDNToJulian(tt.jdn)
+			if gotYear != tt.wantYear || gotMonth != tt.wantMonth || gotDay != tt.wantDay {
+				t.Errorf("JDNToJulian(%d) = (%d, %d, %d), want (%d, %d, %d)",
+					tt.jdn, gotYear, gotMonth, gotDay, tt.wantYear, tt.wantMonth, tt.wantDay)
+			}
+		})
+	}
+}
+
+// TestJulianJDNRoundTrip tests that converting Julian -> JDN -> Julian
+// returns the same date (verifying the functions are inverse operations).
+func TestJulianJDNRoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		year  int
+		month int
+		day   int
+	}{
+		{"October 4, 1582", 1582, 10, 4},
+		{"Ides of March 44 BC", -43, 3, 15},
+		{"January 1, 1 AD", 1, 1, 1},
+		{"Year 0 (1 BC)", 0, 1, 1},
+		{"February 29, 100 AD", 100, 2, 29},
+		{"February 29, 1900", 1900, 2, 29},
+		{"January 1, 2000", 2000, 1, 1},
+		{"December 31, 1999", 1999, 12, 31},
+		{"July 4, 1776", 1776, 7, 4},
+		{"Deep BC", -4712, 1, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Convert to JDN and back
+			jdn := JulianToJDN(tt.year, tt.month, tt.day)
+			gotYear, gotMonth, gotDay := JDNToJulian(jdn)
+
+			if gotYear != tt.year || gotMonth != tt.month || gotDay != tt.day {
+				t.Errorf("Round trip failed for (%d, %d, %d): got (%d, %d, %d) via JDN %d",
+					tt.year, tt.month, tt.day, gotYear, gotMonth, gotDay, jdn)
+			}
+		})
+	}
+}
+
+// TestJulianVsGregorian tests the difference between Julian and Gregorian calendars.
+// This verifies that the two calendar systems produce different JDN values for the same date,
+// and demonstrates the historical calendar transition.
+func TestJulianVsGregorian(t *testing.T) {
+	tests := []struct {
+		name            string
+		year            int
+		month           int
+		day             int
+		wantDaysDiff    int // Expected difference in days (Julian JDN - Gregorian JDN)
+		descriptionDiff string
+	}{
+		{
+			name:            "October 1582 transition",
+			year:            1582,
+			month:           10,
+			day:             4,
+			wantDaysDiff:    10, // Oct 4 Julian = JDN 2299160, Oct 4 Gregorian = JDN 2299150
+			descriptionDiff: "Oct 4, 1582 Julian is 10 days ahead of same date in Gregorian",
+		},
+		{
+			name:            "Ides of March 44 BC",
+			year:            -43,
+			month:           3,
+			day:             15,
+			wantDaysDiff:    -2, // Julian = 1705426, Gregorian = 1705428 (2 days earlier)
+			descriptionDiff: "In 44 BC, Julian calendar is 2 days behind proleptic Gregorian",
+		},
+		{
+			name:            "January 1, 1 AD",
+			year:            1,
+			month:           1,
+			day:             1,
+			wantDaysDiff:    -2, // Julian = 1721424, Gregorian = 1721426
+			descriptionDiff: "At year 1 AD, Julian is 2 days behind Gregorian",
+		},
+		{
+			name:            "Modern era (2000)",
+			year:            2000,
+			month:           1,
+			day:             1,
+			wantDaysDiff:    13, // Julian = 2451558, Gregorian = 2451545
+			descriptionDiff: "By year 2000, Julian calendar is 13 days ahead of Gregorian",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			julianJDN := JulianToJDN(tt.year, tt.month, tt.day)
+			gregorianJDN := GregorianToJDN(tt.year, tt.month, tt.day)
+			diff := julianJDN - gregorianJDN
+
+			if diff != tt.wantDaysDiff {
+				t.Errorf("%s: Julian-Gregorian difference = %d days, want %d days\n"+
+					"Julian JDN: %d, Gregorian JDN: %d\n"+
+					"Context: %s",
+					tt.name, diff, tt.wantDaysDiff,
+					julianJDN, gregorianJDN, tt.descriptionDiff)
+			}
+		})
+	}
+}
+
+// TestCalendarTransition tests the specific dates of the Gregorian calendar transition.
+// October 4, 1582 (Julian) was followed by October 15, 1582 (Gregorian),
+// skipping 10 days. Both dates should have JDN values that differ by exactly 1.
+func TestCalendarTransition(t *testing.T) {
+	// Last day of Julian calendar in most countries
+	lastJulianJDN := JulianToJDN(1582, 10, 4)
+
+	// First day of Gregorian calendar
+	firstGregorianJDN := GregorianToJDN(1582, 10, 15)
+
+	// These should be consecutive JDN values
+	if firstGregorianJDN-lastJulianJDN != 1 {
+		t.Errorf("Calendar transition error: Oct 4, 1582 (Julian) JDN=%d should be followed by Oct 15, 1582 (Gregorian) JDN=%d, diff=%d",
+			lastJulianJDN, firstGregorianJDN, firstGregorianJDN-lastJulianJDN)
+	}
+
+	// Verify the actual JDN values
+	if lastJulianJDN != 2299160 {
+		t.Errorf("Oct 4, 1582 (Julian) JDN = %d, want 2299160", lastJulianJDN)
+	}
+	if firstGregorianJDN != 2299161 {
+		t.Errorf("Oct 15, 1582 (Gregorian) JDN = %d, want 2299161", firstGregorianJDN)
+	}
+}
+
+// TestGEDCOMJulianDateToJDN tests converting a GEDCOM Julian Date to JDN.
+func TestGEDCOMJulianDateToJDN(t *testing.T) {
+	tests := []struct {
+		name     string
+		year     int
+		month    int
+		day      int
+		isBC     bool
+		wantJDN  int
+		wantDesc string
+	}{
+		{
+			name:     "October 4, 1582",
+			year:     1582,
+			month:    10,
+			day:      4,
+			isBC:     false,
+			wantJDN:  2299160,
+			wantDesc: "Last day of Julian calendar",
+		},
+		{
+			name:     "Ides of March 44 BC",
+			year:     44,
+			month:    3,
+			day:      15,
+			isBC:     true,
+			wantJDN:  1705426,
+			wantDesc: "Julius Caesar assassination",
+		},
+		{
+			name:     "January 1, 1 AD",
+			year:     1,
+			month:    1,
+			day:      1,
+			isBC:     false,
+			wantJDN:  1721424,
+			wantDesc: "Start of AD era",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Convert GEDCOM year to astronomical year
+			astroYear := AstronomicalYear(tt.year, tt.isBC)
+
+			// Convert to JDN using Julian calendar
+			jdn := JulianToJDN(astroYear, tt.month, tt.day)
+
+			if jdn != tt.wantJDN {
+				t.Errorf("%s: got JDN %d, want %d", tt.wantDesc, jdn, tt.wantJDN)
+			}
+		})
+	}
+}
+
+// TestIsFrenchLeapYear tests the French Republican leap year calculation.
+func TestIsFrenchLeapYear(t *testing.T) {
+	tests := []struct {
+		year int
+		want bool
+	}{
+		// Based on actual calendar: FR year N is leap if Gregorian year (1792+N) is leap
+		{1, false},  // Year 1 (Sep 22, 1792 - Sep 21, 1793), Gregorian 1793 not leap
+		{2, false},  // Year 2 (Sep 22, 1793 - Sep 21, 1794), Gregorian 1794 not leap
+		{3, false},  // Year 3 (Sep 22, 1794 - Sep 21, 1795), Gregorian 1795 not leap
+		{4, true},   // Year 4 (Sep 22, 1795 - Sep 21, 1796), Gregorian 1796 IS leap
+		{5, false},  // Year 5 (Sep 22, 1796 - Sep 21, 1797), Gregorian 1797 not leap
+		{6, false},  // Year 6 (Sep 22, 1797 - Sep 21, 1798), Gregorian 1798 not leap
+		{7, false},  // Year 7 (Sep 22, 1798 - Sep 21, 1799), Gregorian 1799 not leap
+		{8, false},  // Year 8 (Sep 22, 1799 - Sep 21, 1800), Gregorian 1800 not leap (century)
+		{9, false},  // Year 9 (Sep 22, 1800 - Sep 21, 1801), Gregorian 1801 not leap
+		{10, false}, // Year 10 (Sep 22, 1801 - Sep 21, 1802), Gregorian 1802 not leap
+		{11, false}, // Year 11 (Sep 22, 1802 - Sep 21, 1803), Gregorian 1803 not leap
+		{12, true},  // Year 12 (Sep 22, 1803 - Sep 21, 1804), Gregorian 1804 IS leap
+		{13, false}, // Year 13 (Sep 22, 1804 - Sep 21, 1805), Gregorian 1805 not leap
+		{14, false}, // Year 14 (Sep 22, 1805 - Sep 21, 1806), Gregorian 1806 not leap
+
+		// Test pattern continues beyond historical range
+		{15, false}, // Year 15 (Sep 22, 1806 - Sep 21, 1807), Gregorian 1807 not leap
+		{16, true},  // Year 16 (Sep 22, 1807 - Sep 21, 1808), Gregorian 1808 IS leap
+		{20, true},  // Year 20 (Sep 22, 1811 - Sep 21, 1812), Gregorian 1812 IS leap
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			got := IsFrenchLeapYear(tt.year)
+			if got != tt.want {
+				t.Errorf("IsFrenchLeapYear(%d) = %v, want %v", tt.year, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFrenchToJDN tests the French Republican to JDN conversion with known reference dates.
+func TestFrenchToJDN(t *testing.T) {
+	tests := []struct {
+		name  string
+		year  int
+		month int
+		day   int
+		want  int
+	}{
+		// Epoch and critical dates
+		{
+			name:  "1 Vendémiaire 1 (epoch)",
+			year:  1,
+			month: 1,
+			day:   1,
+			want:  2375840, // September 22, 1792
+		},
+		{
+			name:  "1 Vendémiaire 8",
+			year:  8,
+			month: 1,
+			day:   1,
+			want:  2378396, // September 22, 1799
+		},
+		{
+			name:  "1 Vendémiaire 14",
+			year:  14,
+			month: 1,
+			day:   1,
+			want:  2380587, // September 22, 1805
+		},
+
+		// Test each month type
+		{
+			name:  "1 Brumaire 1",
+			year:  1,
+			month: 2,
+			day:   1,
+			want:  2375870, // 30 days after epoch
+		},
+		{
+			name:  "1 Frimaire 1",
+			year:  1,
+			month: 3,
+			day:   1,
+			want:  2375900, // 60 days after epoch
+		},
+
+		// Test last day of regular month
+		{
+			name:  "30 Vendémiaire 1",
+			year:  1,
+			month: 1,
+			day:   30,
+			want:  2375869,
+		},
+
+		// Test complementary days (month 13)
+		{
+			name:  "1 Complementary 1 (first complementary day)",
+			year:  1,
+			month: 13,
+			day:   1,
+			want:  2376200, // After 12 months of 30 days each
+		},
+		{
+			name:  "5 Complementary 1 (last complementary day, non-leap)",
+			year:  1,
+			month: 13,
+			day:   5,
+			want:  2376204,
+		},
+
+		// Test leap year complementary days
+		{
+			name:  "6 Complementary 4 (leap year, 6th day)",
+			year:  4,
+			month: 13,
+			day:   6,
+			want:  2377300, // Year 4 is a leap year
+		},
+
+		// Test year boundaries
+		{
+			name:  "1 Vendémiaire 2",
+			year:  2,
+			month: 1,
+			day:   1,
+			want:  2376205, // Should be day after last complementary day of year 1
+		},
+		{
+			name:  "1 Vendémiaire 3",
+			year:  3,
+			month: 1,
+			day:   1,
+			want:  2376570,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FrenchToJDN(tt.year, tt.month, tt.day)
+			if got != tt.want {
+				t.Errorf("FrenchToJDN(%d, %d, %d) = %d, want %d",
+					tt.year, tt.month, tt.day, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestJDNToFrench tests the JDN to French Republican conversion with known reference dates.
+func TestJDNToFrench(t *testing.T) {
+	tests := []struct {
+		name      string
+		jdn       int
+		wantYear  int
+		wantMonth int
+		wantDay   int
+	}{
+		// Epoch and critical dates
+		{
+			name:      "JDN 2375840 (1 Vendémiaire 1)",
+			jdn:       2375840,
+			wantYear:  1,
+			wantMonth: 1,
+			wantDay:   1,
+		},
+		{
+			name:      "JDN 2378396 (1 Vendémiaire 8)",
+			jdn:       2378396,
+			wantYear:  8,
+			wantMonth: 1,
+			wantDay:   1,
+		},
+		{
+			name:      "JDN 2380587 (1 Vendémiaire 14)",
+			jdn:       2380587,
+			wantYear:  14,
+			wantMonth: 1,
+			wantDay:   1,
+		},
+
+		// Test each month
+		{
+			name:      "JDN 2375870 (1 Brumaire 1)",
+			jdn:       2375870,
+			wantYear:  1,
+			wantMonth: 2,
+			wantDay:   1,
+		},
+		{
+			name:      "JDN 2375900 (1 Frimaire 1)",
+			jdn:       2375900,
+			wantYear:  1,
+			wantMonth: 3,
+			wantDay:   1,
+		},
+
+		// Test last day of month
+		{
+			name:      "JDN 2375869 (30 Vendémiaire 1)",
+			jdn:       2375869,
+			wantYear:  1,
+			wantMonth: 1,
+			wantDay:   30,
+		},
+
+		// Test complementary days
+		{
+			name:      "JDN 2376200 (1 Complementary 1)",
+			jdn:       2376200,
+			wantYear:  1,
+			wantMonth: 13,
+			wantDay:   1,
+		},
+		{
+			name:      "JDN 2376204 (5 Complementary 1)",
+			jdn:       2376204,
+			wantYear:  1,
+			wantMonth: 13,
+			wantDay:   5,
+		},
+
+		// Test leap year complementary days
+		{
+			name:      "JDN 2377300 (6 Complementary 4, leap year)",
+			jdn:       2377300,
+			wantYear:  4,
+			wantMonth: 13,
+			wantDay:   6,
+		},
+
+		// Test year boundaries
+		{
+			name:      "JDN 2376205 (1 Vendémiaire 2)",
+			jdn:       2376205,
+			wantYear:  2,
+			wantMonth: 1,
+			wantDay:   1,
+		},
+		{
+			name:      "JDN 2376570 (1 Vendémiaire 3)",
+			jdn:       2376570,
+			wantYear:  3,
+			wantMonth: 1,
+			wantDay:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotYear, gotMonth, gotDay := JDNToFrench(tt.jdn)
+			if gotYear != tt.wantYear || gotMonth != tt.wantMonth || gotDay != tt.wantDay {
+				t.Errorf("JDNToFrench(%d) = (%d, %d, %d), want (%d, %d, %d)",
+					tt.jdn, gotYear, gotMonth, gotDay, tt.wantYear, tt.wantMonth, tt.wantDay)
+			}
+		})
+	}
+}
+
+// TestFrenchJDNRoundTrip tests that converting French -> JDN -> French
+// returns the same date (verifying the functions are inverse operations).
+func TestFrenchJDNRoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		year  int
+		month int
+		day   int
+	}{
+		{"Epoch", 1, 1, 1},
+		{"End of first month", 1, 1, 30},
+		{"Start of second month", 1, 2, 1},
+		{"Mid year", 1, 6, 15},
+		{"Last regular month", 1, 12, 30},
+		{"First complementary day", 1, 13, 1},
+		{"Last complementary day (non-leap)", 1, 13, 5},
+		{"Last complementary day (leap year 4)", 4, 13, 6},
+		{"Year 2 start", 2, 1, 1},
+		{"Year 3 start", 3, 1, 1},
+		{"Year 8 start", 8, 1, 1},
+		{"Year 14 start", 14, 1, 1},
+		{"Year 10 mid", 10, 7, 15},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Convert to JDN and back
+			jdn := FrenchToJDN(tt.year, tt.month, tt.day)
+			gotYear, gotMonth, gotDay := JDNToFrench(jdn)
+
+			if gotYear != tt.year || gotMonth != tt.month || gotDay != tt.day {
+				t.Errorf("Round trip failed for (%d, %d, %d): got (%d, %d, %d) via JDN %d",
+					tt.year, tt.month, tt.day, gotYear, gotMonth, gotDay, jdn)
+			}
+		})
+	}
+}
+
+// TestFrenchToGregorian tests conversion from French Republican to Gregorian calendar.
+func TestFrenchToGregorian(t *testing.T) {
+	tests := []struct {
+		name          string
+		frenchYear    int
+		frenchMonth   int
+		frenchDay     int
+		gregorianYear int
+		gregorianMon  int
+		gregorianDay  int
+	}{
+		{
+			name:          "1 Vendémiaire 1 = Sep 22, 1792",
+			frenchYear:    1,
+			frenchMonth:   1,
+			frenchDay:     1,
+			gregorianYear: 1792,
+			gregorianMon:  9,
+			gregorianDay:  22,
+		},
+		{
+			name:          "1 Vendémiaire 8 = Sep 22, 1799",
+			frenchYear:    8,
+			frenchMonth:   1,
+			frenchDay:     1,
+			gregorianYear: 1799,
+			gregorianMon:  9,
+			gregorianDay:  22,
+		},
+		{
+			name:          "1 Vendémiaire 14 = Sep 22, 1805",
+			frenchYear:    14,
+			frenchMonth:   1,
+			frenchDay:     1,
+			gregorianYear: 1805,
+			gregorianMon:  9,
+			gregorianDay:  22,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Convert French to JDN
+			jdn := FrenchToJDN(tt.frenchYear, tt.frenchMonth, tt.frenchDay)
+
+			// Convert JDN to Gregorian
+			year, month, day := JDNToGregorian(jdn)
+
+			if year != tt.gregorianYear || month != tt.gregorianMon || day != tt.gregorianDay {
+				t.Errorf("French %d/%d/%d = JDN %d = Gregorian %d/%d/%d, want %d/%d/%d",
+					tt.frenchYear, tt.frenchMonth, tt.frenchDay,
+					jdn,
+					year, month, day,
+					tt.gregorianYear, tt.gregorianMon, tt.gregorianDay)
+			}
+		})
+	}
+}
+
+// TestIsHebrewLeapYear tests the Hebrew leap year calculation using the 19-year Metonic cycle.
+func TestIsHebrewLeapYear(t *testing.T) {
+	tests := []struct {
+		year int
+		want bool
+	}{
+		// Known leap years in recent cycle (years where (7*year+1)%19 < 7)
+		{5784, true}, // 2023-2024 (leap year) - (7*5784+1)%19 = 0
+		{5787, true}, // 2026-2027 (leap year) - (7*5787+1)%19 = 2
+		{5790, true}, // 2029-2030 (leap year) - (7*5790+1)%19 = 4
+		{5793, true}, // 2032-2033 (leap year) - (7*5793+1)%19 = 6
+		{5795, true}, // 2034-2035 (leap year) - (7*5795+1)%19 = 1
+		{5798, true}, // 2037-2038 (leap year) - (7*5798+1)%19 = 3
+		{5776, true}, // 2015-2016 (leap year) - (7*5776+1)%19 = 1
+
+		// Known regular years in recent cycle
+		{5785, false}, // 2024-2025 (not leap) - (7*5785+1)%19 = 7
+		{5786, false}, // 2025-2026 (not leap) - (7*5786+1)%19 = 14
+		{5788, false}, // 2027-2028 (not leap) - (7*5788+1)%19 = 9
+		{5789, false}, // 2028-2029 (not leap) - (7*5789+1)%19 = 16
+		{5791, false}, // 2030-2031 (not leap) - (7*5791+1)%19 = 11
+		{5792, false}, // 2031-2032 (not leap) - (7*5792+1)%19 = 18
+		{5794, false}, // 2033-2034 (not leap) - (7*5794+1)%19 = 12
+		{5796, false}, // 2035-2036 (not leap) - (7*5796+1)%19 = 8
+		{5797, false}, // 2036-2037 (not leap) - (7*5797+1)%19 = 15
+		{5799, false}, // 2038-2039 (not leap) - (7*5799+1)%19 = 10
+		{5800, false}, // 2039-2040 (not leap) - (7*5800+1)%19 = 17
+		{5780, false}, // 2019-2020 (not leap) - (7*5780+1)%19 = 10
+
+		// Very early years
+		{1, false},
+		{3, true},  // First leap year in the cycle
+		{6, true},  // Second leap year
+		{8, true},  // Third leap year
+		{11, true}, // Fourth leap year
+		{14, true}, // Fifth leap year
+		{17, true}, // Sixth leap year
+		{19, true}, // Seventh leap year
+		{20, false},
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			got := IsHebrewLeapYear(tt.year)
+			if got != tt.want {
+				t.Errorf("IsHebrewLeapYear(%d) = %v, want %v", tt.year, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHebrewMonthsInYear tests the number of months in Hebrew years.
+func TestHebrewMonthsInYear(t *testing.T) {
+	tests := []struct {
+		year int
+		want int
+	}{
+		{5784, 13}, // Leap year
+		{5785, 12}, // Regular year
+		{5787, 13}, // Leap year
+		{5789, 12}, // Regular year
+		{1, 12},    // First year, regular
+		{3, 13},    // First leap year
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			got := HebrewMonthsInYear(tt.year)
+			if got != tt.want {
+				t.Errorf("HebrewMonthsInYear(%d) = %d, want %d", tt.year, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHebrewDaysInYear tests the calculation of year length including the dehiyot.
+func TestHebrewDaysInYear(t *testing.T) {
+	tests := []struct {
+		year int
+		want int
+	}{
+		// Known year lengths (can be verified with hebcal.com or similar)
+		{5785, 355}, // Regular complete year (not leap)
+		{5784, 383}, // Leap deficient year
+		{5780, 355}, // Regular complete year (not leap, not 385!)
+
+		// Test that all year lengths are in valid range
+		{1, 0},    // Will calculate
+		{100, 0},  // Will calculate
+		{5000, 0}, // Will calculate
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			got := HebrewDaysInYear(tt.year)
+
+			// If expected value is 0, just verify it's in valid range
+			if tt.want == 0 {
+				isLeap := IsHebrewLeapYear(tt.year)
+				minDays, maxDays := 353, 355
+				if isLeap {
+					minDays, maxDays = 383, 385
+				}
+				if got < minDays || got > maxDays {
+					t.Errorf("HebrewDaysInYear(%d) = %d, want between %d and %d (leap=%v)",
+						tt.year, got, minDays, maxDays, isLeap)
+				}
+			} else if got != tt.want {
+				t.Errorf("HebrewDaysInYear(%d) = %d, want %d", tt.year, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHebrewDaysInMonth tests the calculation of month lengths.
+func TestHebrewDaysInMonth(t *testing.T) {
+	tests := []struct {
+		name  string
+		year  int
+		month int
+		want  int
+	}{
+		// Fixed-length months
+		{"Tishrei always 30", 5785, 1, 30},
+		{"Tevet always 29", 5785, 4, 29},
+		{"Shevat always 30", 5785, 5, 30},
+		{"Adar 29 in regular year", 5785, 6, 29},
+		{"Nisan always 30", 5785, 8, 30},
+		{"Iyar always 29", 5785, 9, 29},
+		{"Sivan always 30", 5785, 10, 30},
+		{"Tammuz always 29", 5785, 11, 29},
+		{"Av always 30", 5785, 12, 30},
+		{"Elul always 29", 5785, 13, 29},
+
+		// Variable months (Cheshvan and Kislev)
+		{"Cheshvan in complete year", 5785, 2, 30},
+		{"Kislev in complete year", 5785, 3, 30},
+
+		// Leap year Adar I and Adar II
+		{"Adar I in leap year", 5784, 6, 30},
+		{"Adar II in leap year", 5784, 7, 29},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := HebrewDaysInMonth(tt.year, tt.month)
+			if got != tt.want {
+				t.Errorf("HebrewDaysInMonth(%d, %d) = %d, want %d",
+					tt.year, tt.month, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHebrewToJDN tests the Hebrew to JDN conversion with known reference dates.
+func TestHebrewToJDN(t *testing.T) {
+	tests := []struct {
+		name   string
+		year   int
+		month  int
+		day    int
+		want   int
+		verify string // Description for manual verification
+	}{
+		// Reference dates from the prompt
+		{
+			name:   "Rosh Hashanah 5785",
+			year:   5785,
+			month:  1,
+			day:    1,
+			want:   2460587,
+			verify: "Oct 3, 2024",
+		},
+		{
+			name:   "Passover 5785",
+			year:   5785,
+			month:  8,
+			day:    15,
+			want:   2460779,
+			verify: "Apr 13, 2025",
+		},
+		{
+			name:   "Yom Kippur 5780",
+			year:   5780,
+			month:  1,
+			day:    10,
+			want:   2458766,
+			verify: "Oct 9, 2019",
+		},
+
+		// Additional test points
+		{
+			name:   "Hebrew epoch",
+			year:   1,
+			month:  1,
+			day:    1,
+			want:   347998,
+			verify: "Sep 7, 3761 BC (Julian)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := HebrewToJDN(tt.year, tt.month, tt.day)
+			if got != tt.want {
+				t.Errorf("HebrewToJDN(%d, %d, %d) = %d, want %d (%s)",
+					tt.year, tt.month, tt.day, got, tt.want, tt.verify)
+			}
+		})
+	}
+}
+
+// TestJDNToHebrew tests the JDN to Hebrew conversion with known reference dates.
+func TestJDNToHebrew(t *testing.T) {
+	tests := []struct {
+		name      string
+		jdn       int
+		wantYear  int
+		wantMonth int
+		wantDay   int
+		verify    string
+	}{
+		{
+			name:      "JDN 2460587 (Rosh Hashanah 5785)",
+			jdn:       2460587,
+			wantYear:  5785,
+			wantMonth: 1,
+			wantDay:   1,
+			verify:    "Oct 3, 2024",
+		},
+		{
+			name:      "JDN 2460779 (Passover 5785)",
+			jdn:       2460779,
+			wantYear:  5785,
+			wantMonth: 8,
+			wantDay:   15,
+			verify:    "Apr 13, 2025",
+		},
+		{
+			name:      "JDN 2458766 (Yom Kippur 5780)",
+			jdn:       2458766,
+			wantYear:  5780,
+			wantMonth: 1,
+			wantDay:   10,
+			verify:    "Oct 9, 2019",
+		},
+		{
+			name:      "JDN 347998 (Hebrew epoch)",
+			jdn:       347998,
+			wantYear:  1,
+			wantMonth: 1,
+			wantDay:   1,
+			verify:    "Sep 7, 3761 BC",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotYear, gotMonth, gotDay := JDNToHebrew(tt.jdn)
+			if gotYear != tt.wantYear || gotMonth != tt.wantMonth || gotDay != tt.wantDay {
+				t.Errorf("JDNToHebrew(%d) = (%d, %d, %d), want (%d, %d, %d) (%s)",
+					tt.jdn, gotYear, gotMonth, gotDay,
+					tt.wantYear, tt.wantMonth, tt.wantDay, tt.verify)
+			}
+		})
+	}
+}
+
+// TestHebrewJDNRoundTrip tests that converting Hebrew -> JDN -> Hebrew returns the same date.
+func TestHebrewJDNRoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		year  int
+		month int
+		day   int
+	}{
+		{"Rosh Hashanah 5785", 5785, 1, 1},
+		{"Passover 5785", 5785, 8, 15},
+		{"Yom Kippur 5780", 5780, 1, 10},
+		{"Hebrew epoch", 1, 1, 1},
+		{"Mid year regular", 5785, 6, 15},
+		{"End of Tishrei", 5785, 1, 30},
+		{"Leap year Adar I", 5784, 6, 15},
+		{"Leap year Adar II", 5784, 7, 15},
+		{"Last month Elul", 5785, 13, 29},
+		{"Cheshvan", 5785, 2, 15},
+		{"Kislev", 5785, 3, 15},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Convert to JDN and back
+			jdn := HebrewToJDN(tt.year, tt.month, tt.day)
+			gotYear, gotMonth, gotDay := JDNToHebrew(jdn)
+
+			if gotYear != tt.year || gotMonth != tt.month || gotDay != tt.day {
+				t.Errorf("Round trip failed for (%d, %d, %d): got (%d, %d, %d) via JDN %d",
+					tt.year, tt.month, tt.day, gotYear, gotMonth, gotDay, jdn)
+			}
+		})
+	}
+}
+
+// TestHebrewToGregorian tests conversion from Hebrew to Gregorian calendar.
+func TestHebrewToGregorian(t *testing.T) {
+	tests := []struct {
+		name          string
+		hebrewYear    int
+		hebrewMonth   int
+		hebrewDay     int
+		gregorianYear int
+		gregorianMon  int
+		gregorianDay  int
+	}{
+		{
+			name:          "Rosh Hashanah 5785 = Oct 3, 2024",
+			hebrewYear:    5785,
+			hebrewMonth:   1,
+			hebrewDay:     1,
+			gregorianYear: 2024,
+			gregorianMon:  10,
+			gregorianDay:  3,
+		},
+		{
+			name:          "Passover 5785 = Apr 13, 2025",
+			hebrewYear:    5785,
+			hebrewMonth:   8,
+			hebrewDay:     15,
+			gregorianYear: 2025,
+			gregorianMon:  4,
+			gregorianDay:  13,
+		},
+		{
+			name:          "Yom Kippur 5780 = Oct 9, 2019",
+			hebrewYear:    5780,
+			hebrewMonth:   1,
+			hebrewDay:     10,
+			gregorianYear: 2019,
+			gregorianMon:  10,
+			gregorianDay:  9,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Convert Hebrew to JDN
+			jdn := HebrewToJDN(tt.hebrewYear, tt.hebrewMonth, tt.hebrewDay)
+
+			// Convert JDN to Gregorian
+			year, month, day := JDNToGregorian(jdn)
+
+			if year != tt.gregorianYear || month != tt.gregorianMon || day != tt.gregorianDay {
+				t.Errorf("Hebrew %d/%d/%d = JDN %d = Gregorian %d/%d/%d, want %d/%d/%d",
+					tt.hebrewYear, tt.hebrewMonth, tt.hebrewDay,
+					jdn,
+					year, month, day,
+					tt.gregorianYear, tt.gregorianMon, tt.gregorianDay)
+			}
+		})
+	}
+}
+
+// TestHebrewLeapYearAdarHandling tests that Adar I and Adar II are handled correctly in leap years.
+func TestHebrewLeapYearAdarHandling(t *testing.T) {
+	// Year 5784 is a leap year
+	leapYear := 5784
+
+	// Verify it's a leap year
+	if !IsHebrewLeapYear(leapYear) {
+		t.Fatalf("Year %d should be a leap year", leapYear)
+	}
+
+	// Verify 13 months
+	if HebrewMonthsInYear(leapYear) != 13 {
+		t.Fatalf("Leap year %d should have 13 months", leapYear)
+	}
+
+	// Verify Adar I (month 6) has 30 days
+	adarIDays := HebrewDaysInMonth(leapYear, 6)
+	if adarIDays != 30 {
+		t.Errorf("Adar I in leap year should have 30 days, got %d", adarIDays)
+	}
+
+	// Verify Adar II (month 7) has 29 days
+	adarIIDays := HebrewDaysInMonth(leapYear, 7)
+	if adarIIDays != 29 {
+		t.Errorf("Adar II in leap year should have 29 days, got %d", adarIIDays)
+	}
+
+	// Test round trip for both Adar months
+	for month := 6; month <= 7; month++ {
+		for day := 1; day <= HebrewDaysInMonth(leapYear, month); day++ {
+			jdn := HebrewToJDN(leapYear, month, day)
+			gotYear, gotMonth, gotDay := JDNToHebrew(jdn)
+			if gotYear != leapYear || gotMonth != month || gotDay != day {
+				t.Errorf("Adar round trip failed for (%d, %d, %d): got (%d, %d, %d)",
+					leapYear, month, day, gotYear, gotMonth, gotDay)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements Issue #33 Phase 3b - calendar conversion functionality with zero external dependencies.

- **Julian Day Number (JDN) foundation** - Universal intermediate format for all calendar conversions
- **ToGregorian() method** - Convert any supported calendar to Gregorian
- **Cross-calendar Compare()** - Accurately compare dates across different calendar systems
- **Full calendar support** - Julian, Hebrew (with 19-year Metonic cycle), French Republican

## Changes

### New Files
- `gedcom/calendar.go` (654 lines) - JDN conversion algorithms
- `gedcom/calendar_test.go` (1651 lines) - Comprehensive calendar tests

### Modified Files
- `gedcom/date.go` - Added `ToGregorian()`, `toJDN()`, updated `Compare()`
- `gedcom/date_test.go` - Added conversion and cross-calendar comparison tests

## API Examples

```go
// Convert Hebrew date to Gregorian
date, _ := ParseDate("@#DHEBREW@ 15 NSN 5785")
greg, _ := date.ToGregorian()
// greg.Year=2025, greg.Month=4, greg.Day=13 (Passover)

// Cross-calendar comparison works automatically
julian, _ := ParseDate("@#DJULIAN@ 4 OCT 1582")
gregorian, _ := ParseDate("14 OCT 1582")
result := julian.Compare(gregorian)  // 0 (same day)
```

## Test Coverage

| Package | Coverage |
|---------|----------|
| gedcom | 97.6% |

Closes #33

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)