### PR TITLE
Integrate parsed dates with record types

### DIFF
--- a/decoder/entity.go
+++ b/decoder/entity.go
@@ -274,6 +274,9 @@ func parseEvent(tags []*gedcom.Tag, eventIdx int, eventTag string) *gedcom.Event
 			switch tag.Tag {
 			case "DATE":
 				event.Date = tag.Value
+				if parsed, err := gedcom.ParseDate(tag.Value); err == nil {
+					event.ParsedDate = parsed
+				}
 			case "PLAC":
 				event.Place = tag.Value
 				event.PlaceDetail = parsePlaceDetail(tags, i, tag.Level)
@@ -426,6 +429,9 @@ func parseAttribute(tags []*gedcom.Tag, attrIdx int, attrTag string) *gedcom.Att
 			switch tag.Tag {
 			case "DATE":
 				attr.Date = tag.Value
+				if parsed, err := gedcom.ParseDate(tag.Value); err == nil {
+					attr.ParsedDate = parsed
+				}
 			case "PLAC":
 				attr.Place = tag.Value
 			case "SOUR":
@@ -474,6 +480,9 @@ func parseLDSOrdinance(tags []*gedcom.Tag, ordIdx int, ordType gedcom.LDSOrdinan
 			switch tag.Tag {
 			case "DATE":
 				ord.Date = tag.Value
+				if parsed, err := gedcom.ParseDate(tag.Value); err == nil {
+					ord.ParsedDate = parsed
+				}
 			case "TEMP":
 				ord.Temple = tag.Value
 			case "PLAC":

--- a/gedcom/date_test.go
+++ b/gedcom/date_test.go
@@ -1936,6 +1936,446 @@ func TestDate_Compare_CrossCalendar(t *testing.T) {
 	}
 }
 
+// TestDate_IsAfter tests the IsAfter convenience method
+func TestDate_IsAfter(t *testing.T) {
+	tests := []struct {
+		name  string
+		date1 string
+		date2 string
+		want  bool
+	}{
+		// Complete dates
+		{"same date", "25 DEC 2020", "25 DEC 2020", false},
+		{"later date", "26 DEC 2020", "25 DEC 2020", true},
+		{"earlier date", "25 DEC 2020", "26 DEC 2020", false},
+		{"later year", "1 JAN 2021", "31 DEC 2020", true},
+		{"earlier year", "31 DEC 2019", "1 JAN 2020", false},
+
+		// Partial dates
+		{"partial year after", "1851", "1850", true},
+		{"partial year before", "1850", "1851", false},
+		{"partial year same", "1850", "1850", false},
+
+		// Mix of complete and partial
+		{"year vs complete (same)", "1920", "1 JAN 1920", false},
+		{"year vs complete (after)", "1920", "31 DEC 1919", true},
+
+		// BC dates
+		{"BC later than BC", "44 BC", "100 BC", true},
+		{"BC earlier than BC", "100 BC", "44 BC", false},
+		{"AD after BC", "100", "100 BC", true},
+		{"BC before AD", "100 BC", "100", false},
+
+		// Cross-calendar
+		{"Julian after Gregorian", "@#DJULIAN@ 15 JAN 1700", "1 JAN 1700", true},
+		{"Julian before Gregorian", "@#DJULIAN@ 1 JAN 1700", "12 JAN 1700", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d1, err := ParseDate(tt.date1)
+			if err != nil {
+				t.Fatalf("ParseDate(%q) error = %v", tt.date1, err)
+			}
+			d2, err := ParseDate(tt.date2)
+			if err != nil {
+				t.Fatalf("ParseDate(%q) error = %v", tt.date2, err)
+			}
+
+			got := d1.IsAfter(d2)
+			if got != tt.want {
+				t.Errorf("IsAfter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDate_IsAfter_Nil tests nil handling for IsAfter
+func TestDate_IsAfter_Nil(t *testing.T) {
+	d1, _ := ParseDate("25 DEC 2020")
+
+	tests := []struct {
+		name string
+		d1   *Date
+		d2   *Date
+		want bool
+	}{
+		{"both nil", nil, nil, false},
+		{"first nil", nil, d1, false},
+		{"second nil", d1, nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.d1.IsAfter(tt.d2)
+			if got != tt.want {
+				t.Errorf("IsAfter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDate_IsBefore tests the IsBefore convenience method
+func TestDate_IsBefore(t *testing.T) {
+	tests := []struct {
+		name  string
+		date1 string
+		date2 string
+		want  bool
+	}{
+		// Complete dates
+		{"same date", "25 DEC 2020", "25 DEC 2020", false},
+		{"later date", "26 DEC 2020", "25 DEC 2020", false},
+		{"earlier date", "25 DEC 2020", "26 DEC 2020", true},
+		{"later year", "1 JAN 2021", "31 DEC 2020", false},
+		{"earlier year", "31 DEC 2019", "1 JAN 2020", true},
+
+		// Partial dates
+		{"partial year after", "1851", "1850", false},
+		{"partial year before", "1850", "1851", true},
+		{"partial year same", "1850", "1850", false},
+
+		// Mix of complete and partial
+		{"year vs complete (same)", "1920", "1 JAN 1920", false},
+		{"year vs complete (before)", "1919", "1 JAN 1920", true},
+
+		// BC dates
+		{"BC later than BC", "44 BC", "100 BC", false},
+		{"BC earlier than BC", "100 BC", "44 BC", true},
+		{"AD after BC", "100", "100 BC", false},
+		{"BC before AD", "100 BC", "100", true},
+
+		// Cross-calendar
+		{"Julian after Gregorian", "@#DJULIAN@ 15 JAN 1700", "1 JAN 1700", false},
+		{"Julian before Gregorian", "@#DJULIAN@ 1 JAN 1700", "12 JAN 1700", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d1, err := ParseDate(tt.date1)
+			if err != nil {
+				t.Fatalf("ParseDate(%q) error = %v", tt.date1, err)
+			}
+			d2, err := ParseDate(tt.date2)
+			if err != nil {
+				t.Fatalf("ParseDate(%q) error = %v", tt.date2, err)
+			}
+
+			got := d1.IsBefore(d2)
+			if got != tt.want {
+				t.Errorf("IsBefore() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDate_IsBefore_Nil tests nil handling for IsBefore
+func TestDate_IsBefore_Nil(t *testing.T) {
+	d1, _ := ParseDate("25 DEC 2020")
+
+	tests := []struct {
+		name string
+		d1   *Date
+		d2   *Date
+		want bool
+	}{
+		{"both nil", nil, nil, false},
+		{"first nil", nil, d1, false},
+		{"second nil", d1, nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.d1.IsBefore(tt.d2)
+			if got != tt.want {
+				t.Errorf("IsBefore() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDate_IsEqual tests the IsEqual convenience method
+func TestDate_IsEqual(t *testing.T) {
+	tests := []struct {
+		name  string
+		date1 string
+		date2 string
+		want  bool
+	}{
+		// Complete dates
+		{"same date", "25 DEC 2020", "25 DEC 2020", true},
+		{"different day", "25 DEC 2020", "26 DEC 2020", false},
+		{"different month", "25 DEC 2020", "25 NOV 2020", false},
+		{"different year", "25 DEC 2020", "25 DEC 2019", false},
+
+		// Partial dates
+		{"partial year equal", "1850", "1850", true},
+		{"partial year different", "1850", "1851", false},
+		{"partial month-year equal", "JAN 1920", "JAN 1920", true},
+		{"partial month-year different month", "JAN 1920", "FEB 1920", false},
+
+		// Mix of complete and partial
+		{"year vs complete (same)", "1920", "1 JAN 1920", true},
+		{"year vs complete (different)", "1920", "2 JAN 1920", false},
+		{"month-year vs complete (same)", "JAN 1920", "1 JAN 1920", true},
+
+		// BC dates
+		{"BC equal", "44 BC", "44 BC", true},
+		{"BC different", "44 BC", "100 BC", false},
+		{"BC vs AD", "100 BC", "100", false},
+
+		// Cross-calendar - same JDN
+		{"Julian equals Gregorian (same JDN)", "@#DJULIAN@ 4 OCT 1582", "14 OCT 1582", true},
+		{"Hebrew equals Gregorian (same JDN)", "@#DHEBREW@ 1 TSH 5785", "3 OCT 2024", true},
+		{"French equals Gregorian (same JDN)", "@#DFRENCH R@ 1 VEND 1", "22 SEP 1792", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d1, err := ParseDate(tt.date1)
+			if err != nil {
+				t.Fatalf("ParseDate(%q) error = %v", tt.date1, err)
+			}
+			d2, err := ParseDate(tt.date2)
+			if err != nil {
+				t.Fatalf("ParseDate(%q) error = %v", tt.date2, err)
+			}
+
+			got := d1.IsEqual(d2)
+			if got != tt.want {
+				t.Errorf("IsEqual() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDate_IsEqual_Nil tests nil handling for IsEqual
+func TestDate_IsEqual_Nil(t *testing.T) {
+	d1, _ := ParseDate("25 DEC 2020")
+
+	tests := []struct {
+		name string
+		d1   *Date
+		d2   *Date
+		want bool
+	}{
+		{"both nil", nil, nil, true},
+		{"first nil", nil, d1, false},
+		{"second nil", d1, nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.d1.IsEqual(tt.d2)
+			if got != tt.want {
+				t.Errorf("IsEqual() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestYearsBetween tests the YearsBetween function
+func TestYearsBetween(t *testing.T) {
+	tests := []struct {
+		name      string
+		date1     string
+		date2     string
+		wantYears int
+		wantExact bool
+		wantErr   bool
+	}{
+		// Complete Gregorian dates - exact calculation
+		{
+			name:      "same date",
+			date1:     "25 DEC 2020",
+			date2:     "25 DEC 2020",
+			wantYears: 0,
+			wantExact: true,
+		},
+		{
+			name:      "exactly 10 years",
+			date1:     "1 JAN 2010",
+			date2:     "1 JAN 2020",
+			wantYears: 10,
+			wantExact: true,
+		},
+		{
+			name:      "birthday not yet occurred",
+			date1:     "25 DEC 2020",
+			date2:     "24 DEC 2030",
+			wantYears: 9,
+			wantExact: true,
+		},
+		{
+			name:      "birthday just occurred",
+			date1:     "25 DEC 2020",
+			date2:     "25 DEC 2030",
+			wantYears: 10,
+			wantExact: true,
+		},
+		{
+			name:      "birthday passed",
+			date1:     "25 DEC 2020",
+			date2:     "26 DEC 2030",
+			wantYears: 10,
+			wantExact: true,
+		},
+		{
+			name:      "leap year consideration",
+			date1:     "29 FEB 2000",
+			date2:     "28 FEB 2004",
+			wantYears: 3,
+			wantExact: true,
+		},
+		{
+			name:      "reverse order (absolute value)",
+			date1:     "1 JAN 2020",
+			date2:     "1 JAN 2010",
+			wantYears: 10,
+			wantExact: true,
+		},
+
+		// Partial dates - year subtraction
+		{
+			name:      "year only - same",
+			date1:     "1850",
+			date2:     "1850",
+			wantYears: 0,
+			wantExact: false,
+		},
+		{
+			name:      "year only - different",
+			date1:     "1850",
+			date2:     "1900",
+			wantYears: 50,
+			wantExact: false,
+		},
+		{
+			name:      "month-year only",
+			date1:     "JAN 1920",
+			date2:     "DEC 1930",
+			wantYears: 10,
+			wantExact: false,
+		},
+		{
+			name:      "mix complete and partial",
+			date1:     "25 DEC 2020",
+			date2:     "1900",
+			wantYears: 120,
+			wantExact: false,
+		},
+
+		// Non-Gregorian calendars - year subtraction
+		{
+			name:      "Julian calendar",
+			date1:     "@#DJULIAN@ 25 DEC 1700",
+			date2:     "@#DJULIAN@ 25 DEC 1750",
+			wantYears: 50,
+			wantExact: false,
+		},
+		{
+			name:      "Hebrew calendar",
+			date1:     "@#DHEBREW@ 1 TSH 5785",
+			date2:     "@#DHEBREW@ 1 TSH 5795",
+			wantYears: 10,
+			wantExact: false,
+		},
+		{
+			name:      "French Republican calendar",
+			date1:     "@#DFRENCH R@ 1 VEND 1",
+			date2:     "@#DFRENCH R@ 1 VEND 10",
+			wantYears: 9,
+			wantExact: false,
+		},
+
+		// Cross-calendar - year subtraction (can't use ToTime)
+		{
+			name:      "Julian vs Gregorian",
+			date1:     "@#DJULIAN@ 25 DEC 1700",
+			date2:     "25 DEC 1750",
+			wantYears: 50,
+			wantExact: false,
+		},
+
+		// BC dates
+		{
+			name:      "BC dates",
+			date1:     "100 BC",
+			date2:     "44 BC",
+			wantYears: 56,
+			wantExact: false,
+		},
+
+		// Error cases
+		{
+			name:    "missing year in first date",
+			date1:   "(unknown)",
+			date2:   "2020",
+			wantErr: true,
+		},
+		{
+			name:    "missing year in second date",
+			date1:   "2020",
+			date2:   "(unknown)",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d1, err := ParseDate(tt.date1)
+			if err != nil {
+				t.Fatalf("ParseDate(%q) error = %v", tt.date1, err)
+			}
+			d2, err := ParseDate(tt.date2)
+			if err != nil {
+				t.Fatalf("ParseDate(%q) error = %v", tt.date2, err)
+			}
+
+			years, exact, err := YearsBetween(d1, d2)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("YearsBetween() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("YearsBetween() error = %v", err)
+			}
+			if years != tt.wantYears {
+				t.Errorf("YearsBetween() years = %d, want %d", years, tt.wantYears)
+			}
+			if exact != tt.wantExact {
+				t.Errorf("YearsBetween() exact = %v, want %v", exact, tt.wantExact)
+			}
+		})
+	}
+}
+
+// TestYearsBetween_Nil tests nil handling for YearsBetween
+func TestYearsBetween_Nil(t *testing.T) {
+	d1, _ := ParseDate("25 DEC 2020")
+
+	tests := []struct {
+		name string
+		d1   *Date
+		d2   *Date
+	}{
+		{"both nil", nil, nil},
+		{"first nil", nil, d1},
+		{"second nil", d1, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := YearsBetween(tt.d1, tt.d2)
+			if err == nil {
+				t.Errorf("YearsBetween() expected error for nil dates, got nil")
+			}
+		})
+	}
+}
+
 // TestDate_toJDN tests the internal JDN conversion helper
 func TestDate_toJDN(t *testing.T) {
 	tests := []struct {

--- a/gedcom/event.go
+++ b/gedcom/event.go
@@ -77,6 +77,10 @@ type Event struct {
 	// Date is when the event occurred (in GEDCOM date format)
 	Date string
 
+	// ParsedDate is the parsed representation of Date.
+	// This is nil if the date string could not be parsed.
+	ParsedDate *Date
+
 	// Place is where the event occurred (kept for backward compatibility)
 	Place string
 

--- a/gedcom/individual.go
+++ b/gedcom/individual.go
@@ -116,9 +116,53 @@ type Attribute struct {
 	// Date when the attribute was applicable (optional)
 	Date string
 
+	// ParsedDate is the parsed representation of Date.
+	// This is nil if the date string could not be parsed.
+	ParsedDate *Date
+
 	// Place where the attribute was applicable (optional)
 	Place string
 
 	// SourceCitations are source citations with page/quality details
 	SourceCitations []*SourceCitation
+}
+
+// BirthEvent returns the first birth event for this individual, or nil if none found.
+func (i *Individual) BirthEvent() *Event {
+	for _, event := range i.Events {
+		if event.Type == EventBirth {
+			return event
+		}
+	}
+	return nil
+}
+
+// DeathEvent returns the first death event for this individual, or nil if none found.
+func (i *Individual) DeathEvent() *Event {
+	for _, event := range i.Events {
+		if event.Type == EventDeath {
+			return event
+		}
+	}
+	return nil
+}
+
+// BirthDate returns the parsed birth date for this individual, or nil if no birth event
+// or no parsed date is available.
+func (i *Individual) BirthDate() *Date {
+	event := i.BirthEvent()
+	if event == nil {
+		return nil
+	}
+	return event.ParsedDate
+}
+
+// DeathDate returns the parsed death date for this individual, or nil if no death event
+// or no parsed date is available.
+func (i *Individual) DeathDate() *Date {
+	event := i.DeathEvent()
+	if event == nil {
+		return nil
+	}
+	return event.ParsedDate
 }

--- a/gedcom/individual_test.go
+++ b/gedcom/individual_test.go
@@ -1,0 +1,275 @@
+package gedcom
+
+import "testing"
+
+func TestIndividual_BirthEvent(t *testing.T) {
+	tests := []struct {
+		name   string
+		events []*Event
+		want   *Event
+	}{
+		{
+			name: "has birth event",
+			events: []*Event{
+				{Type: EventBirth, Date: "1 JAN 1850"},
+				{Type: EventDeath, Date: "1 JAN 1920"},
+			},
+			want: &Event{Type: EventBirth, Date: "1 JAN 1850"},
+		},
+		{
+			name: "multiple birth events returns first",
+			events: []*Event{
+				{Type: EventBirth, Date: "1 JAN 1850"},
+				{Type: EventBirth, Date: "2 JAN 1850"},
+				{Type: EventDeath, Date: "1 JAN 1920"},
+			},
+			want: &Event{Type: EventBirth, Date: "1 JAN 1850"},
+		},
+		{
+			name: "no birth event",
+			events: []*Event{
+				{Type: EventDeath, Date: "1 JAN 1920"},
+				{Type: EventBaptism, Date: "15 JAN 1850"},
+			},
+			want: nil,
+		},
+		{
+			name:   "no events",
+			events: []*Event{},
+			want:   nil,
+		},
+		{
+			name:   "nil events slice",
+			events: nil,
+			want:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := &Individual{Events: tt.events}
+			got := i.BirthEvent()
+
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("BirthEvent() = %v, want nil", got)
+				}
+				return
+			}
+
+			if got == nil {
+				t.Errorf("BirthEvent() = nil, want %v", tt.want)
+				return
+			}
+
+			if got.Type != tt.want.Type || got.Date != tt.want.Date {
+				t.Errorf("BirthEvent() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIndividual_DeathEvent(t *testing.T) {
+	tests := []struct {
+		name   string
+		events []*Event
+		want   *Event
+	}{
+		{
+			name: "has death event",
+			events: []*Event{
+				{Type: EventBirth, Date: "1 JAN 1850"},
+				{Type: EventDeath, Date: "1 JAN 1920"},
+			},
+			want: &Event{Type: EventDeath, Date: "1 JAN 1920"},
+		},
+		{
+			name: "multiple death events returns first",
+			events: []*Event{
+				{Type: EventBirth, Date: "1 JAN 1850"},
+				{Type: EventDeath, Date: "1 JAN 1920"},
+				{Type: EventDeath, Date: "2 JAN 1920"},
+			},
+			want: &Event{Type: EventDeath, Date: "1 JAN 1920"},
+		},
+		{
+			name: "no death event",
+			events: []*Event{
+				{Type: EventBirth, Date: "1 JAN 1850"},
+				{Type: EventBaptism, Date: "15 JAN 1850"},
+			},
+			want: nil,
+		},
+		{
+			name:   "no events",
+			events: []*Event{},
+			want:   nil,
+		},
+		{
+			name:   "nil events slice",
+			events: nil,
+			want:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := &Individual{Events: tt.events}
+			got := i.DeathEvent()
+
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("DeathEvent() = %v, want nil", got)
+				}
+				return
+			}
+
+			if got == nil {
+				t.Errorf("DeathEvent() = nil, want %v", tt.want)
+				return
+			}
+
+			if got.Type != tt.want.Type || got.Date != tt.want.Date {
+				t.Errorf("DeathEvent() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIndividual_BirthDate(t *testing.T) {
+	birthDate := mustParseDate("1 JAN 1850")
+	deathDate := mustParseDate("1 JAN 1920")
+
+	tests := []struct {
+		name   string
+		events []*Event
+		want   *Date
+	}{
+		{
+			name: "has birth date",
+			events: []*Event{
+				{Type: EventBirth, Date: "1 JAN 1850", ParsedDate: birthDate},
+				{Type: EventDeath, Date: "1 JAN 1920", ParsedDate: deathDate},
+			},
+			want: birthDate,
+		},
+		{
+			name: "birth event without parsed date",
+			events: []*Event{
+				{Type: EventBirth, Date: "1 JAN 1850", ParsedDate: nil},
+				{Type: EventDeath, Date: "1 JAN 1920", ParsedDate: deathDate},
+			},
+			want: nil,
+		},
+		{
+			name: "no birth event",
+			events: []*Event{
+				{Type: EventDeath, Date: "1 JAN 1920", ParsedDate: deathDate},
+				{Type: EventBaptism, Date: "15 JAN 1850"},
+			},
+			want: nil,
+		},
+		{
+			name:   "no events",
+			events: []*Event{},
+			want:   nil,
+		},
+		{
+			name:   "nil events slice",
+			events: nil,
+			want:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := &Individual{Events: tt.events}
+			got := i.BirthDate()
+
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("BirthDate() = %v, want nil", got)
+				}
+				return
+			}
+
+			if got == nil {
+				t.Errorf("BirthDate() = nil, want %v", tt.want)
+				return
+			}
+
+			if got.Original != tt.want.Original {
+				t.Errorf("BirthDate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIndividual_DeathDate(t *testing.T) {
+	birthDate := mustParseDate("1 JAN 1850")
+	deathDate := mustParseDate("1 JAN 1920")
+
+	tests := []struct {
+		name   string
+		events []*Event
+		want   *Date
+	}{
+		{
+			name: "has death date",
+			events: []*Event{
+				{Type: EventBirth, Date: "1 JAN 1850", ParsedDate: birthDate},
+				{Type: EventDeath, Date: "1 JAN 1920", ParsedDate: deathDate},
+			},
+			want: deathDate,
+		},
+		{
+			name: "death event without parsed date",
+			events: []*Event{
+				{Type: EventBirth, Date: "1 JAN 1850", ParsedDate: birthDate},
+				{Type: EventDeath, Date: "1 JAN 1920", ParsedDate: nil},
+			},
+			want: nil,
+		},
+		{
+			name: "no death event",
+			events: []*Event{
+				{Type: EventBirth, Date: "1 JAN 1850", ParsedDate: birthDate},
+				{Type: EventBaptism, Date: "15 JAN 1850"},
+			},
+			want: nil,
+		},
+		{
+			name:   "no events",
+			events: []*Event{},
+			want:   nil,
+		},
+		{
+			name:   "nil events slice",
+			events: nil,
+			want:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := &Individual{Events: tt.events}
+			got := i.DeathDate()
+
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("DeathDate() = %v, want nil", got)
+				}
+				return
+			}
+
+			if got == nil {
+				t.Errorf("DeathDate() = nil, want %v", tt.want)
+				return
+			}
+
+			if got.Original != tt.want.Original {
+				t.Errorf("DeathDate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/gedcom/lds.go
+++ b/gedcom/lds.go
@@ -29,6 +29,10 @@ type LDSOrdinance struct {
 	// Date is when the ordinance was performed (DATE subordinate)
 	Date string
 
+	// ParsedDate is the parsed representation of Date.
+	// This is nil if the date string could not be parsed.
+	ParsedDate *Date
+
 	// Temple is the temple code where the ordinance was performed (TEMP subordinate)
 	Temple string
 

--- a/gedcom/validation.go
+++ b/gedcom/validation.go
@@ -1,0 +1,75 @@
+package gedcom
+
+import "fmt"
+
+// ValidateBirthBeforeDeath checks if a birth date is before or equal to a death date.
+// Returns nil if the birth date is before or equal to the death date, or if either date is nil.
+// Returns an error with descriptive message if the death date is before the birth date.
+func ValidateBirthBeforeDeath(birth, death *Date) error {
+	if birth == nil || death == nil {
+		return nil // Can't validate without both dates
+	}
+
+	if death.IsBefore(birth) {
+		return fmt.Errorf("death date (%s) is before birth date (%s)",
+			death.Original, birth.Original)
+	}
+
+	return nil
+}
+
+// ValidateParentChildDates validates that a parent was at least minParentAge years old
+// when a child was born. Returns nil if either date is nil, or if the parent meets
+// the minimum age requirement. Returns an error if the parent would have been too young.
+//
+// The minParentAge parameter specifies the minimum biological age for parenthood.
+// A typical value is 12 years (biological minimum).
+func ValidateParentChildDates(parentBirth, childBirth *Date, minParentAge int) error {
+	if parentBirth == nil || childBirth == nil {
+		return nil // Can't validate without both dates
+	}
+
+	years, _, err := YearsBetween(parentBirth, childBirth)
+	if err != nil {
+		return nil // Insufficient data to validate
+	}
+
+	if years < minParentAge {
+		return fmt.Errorf("parent would have been %d years old at child's birth (minimum: %d)",
+			years, minParentAge)
+	}
+
+	return nil
+}
+
+// ValidateMarriageDates validates that both spouses were at least minMarriageAge years old
+// at the time of marriage. Returns nil if there is insufficient date data to validate.
+// Returns an error if either spouse would have been too young at the marriage date.
+//
+// The minMarriageAge parameter specifies the minimum age for marriage.
+// A typical value is 12 years (historical minimum in some cultures).
+func ValidateMarriageDates(marriage, spouseBirth1, spouseBirth2 *Date, minMarriageAge int) error {
+	if marriage == nil {
+		return nil // Can't validate without marriage date
+	}
+
+	// Validate first spouse if birth date is available
+	if spouseBirth1 != nil {
+		years, _, err := YearsBetween(spouseBirth1, marriage)
+		if err == nil && years < minMarriageAge {
+			return fmt.Errorf("first spouse would have been %d years old at marriage (minimum: %d)",
+				years, minMarriageAge)
+		}
+	}
+
+	// Validate second spouse if birth date is available
+	if spouseBirth2 != nil {
+		years, _, err := YearsBetween(spouseBirth2, marriage)
+		if err == nil && years < minMarriageAge {
+			return fmt.Errorf("second spouse would have been %d years old at marriage (minimum: %d)",
+				years, minMarriageAge)
+		}
+	}
+
+	return nil
+}

--- a/gedcom/validation_test.go
+++ b/gedcom/validation_test.go
@@ -1,0 +1,369 @@
+package gedcom
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateBirthBeforeDeath(t *testing.T) {
+	tests := []struct {
+		name      string
+		birth     *Date
+		death     *Date
+		wantError bool
+		errMsg    string
+	}{
+		{
+			name:      "valid: birth before death",
+			birth:     mustParseDate("15 MAR 1850"),
+			death:     mustParseDate("20 DEC 1920"),
+			wantError: false,
+		},
+		{
+			name:      "valid: birth equals death (same day)",
+			birth:     mustParseDate("1 JAN 1850"),
+			death:     mustParseDate("1 JAN 1850"),
+			wantError: false,
+		},
+		{
+			name:      "valid: partial dates (years only)",
+			birth:     mustParseDate("1850"),
+			death:     mustParseDate("1920"),
+			wantError: false,
+		},
+		{
+			name:      "valid: partial dates (month and year)",
+			birth:     mustParseDate("MAR 1850"),
+			death:     mustParseDate("DEC 1920"),
+			wantError: false,
+		},
+		{
+			name:      "invalid: death before birth",
+			birth:     mustParseDate("15 MAR 1920"),
+			death:     mustParseDate("20 DEC 1850"),
+			wantError: true,
+			errMsg:    "death date",
+		},
+		{
+			name:      "valid: nil birth date",
+			birth:     nil,
+			death:     mustParseDate("20 DEC 1920"),
+			wantError: false,
+		},
+		{
+			name:      "valid: nil death date",
+			birth:     mustParseDate("15 MAR 1850"),
+			death:     nil,
+			wantError: false,
+		},
+		{
+			name:      "valid: both nil",
+			birth:     nil,
+			death:     nil,
+			wantError: false,
+		},
+		{
+			name:      "valid: partial dates edge case",
+			birth:     mustParseDate("1850"),
+			death:     mustParseDate("JAN 1851"),
+			wantError: false,
+		},
+		{
+			name:      "invalid: partial dates (same year, death month before birth month)",
+			birth:     mustParseDate("DEC 1850"),
+			death:     mustParseDate("JAN 1850"),
+			wantError: true,
+			errMsg:    "death date",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateBirthBeforeDeath(tt.birth, tt.death)
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("ValidateBirthBeforeDeath() expected error, got nil")
+				} else if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("ValidateBirthBeforeDeath() error = %v, want error containing %q", err, tt.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("ValidateBirthBeforeDeath() unexpected error = %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateParentChildDates(t *testing.T) {
+	tests := []struct {
+		name         string
+		parentBirth  *Date
+		childBirth   *Date
+		minParentAge int
+		wantError    bool
+		errMsg       string
+	}{
+		{
+			name:         "valid: parent 25 years old",
+			parentBirth:  mustParseDate("1850"),
+			childBirth:   mustParseDate("1875"),
+			minParentAge: 12,
+			wantError:    false,
+		},
+		{
+			name:         "valid: parent exactly minimum age",
+			parentBirth:  mustParseDate("1850"),
+			childBirth:   mustParseDate("1862"),
+			minParentAge: 12,
+			wantError:    false,
+		},
+		{
+			name:         "valid: parent 13 years old (above minimum)",
+			parentBirth:  mustParseDate("15 JAN 1850"),
+			childBirth:   mustParseDate("20 FEB 1863"),
+			minParentAge: 12,
+			wantError:    false,
+		},
+		{
+			name:         "invalid: parent too young (11 years)",
+			parentBirth:  mustParseDate("1850"),
+			childBirth:   mustParseDate("1861"),
+			minParentAge: 12,
+			wantError:    true,
+			errMsg:       "11 years old",
+		},
+		{
+			name:         "invalid: parent 5 years old",
+			parentBirth:  mustParseDate("1850"),
+			childBirth:   mustParseDate("1855"),
+			minParentAge: 12,
+			wantError:    true,
+			errMsg:       "5 years old",
+		},
+		{
+			name:         "valid: nil parent birth date",
+			parentBirth:  nil,
+			childBirth:   mustParseDate("1875"),
+			minParentAge: 12,
+			wantError:    false,
+		},
+		{
+			name:         "valid: nil child birth date",
+			parentBirth:  mustParseDate("1850"),
+			childBirth:   nil,
+			minParentAge: 12,
+			wantError:    false,
+		},
+		{
+			name:         "valid: both nil",
+			parentBirth:  nil,
+			childBirth:   nil,
+			minParentAge: 12,
+			wantError:    false,
+		},
+		{
+			name:         "valid: partial dates",
+			parentBirth:  mustParseDate("MAR 1850"),
+			childBirth:   mustParseDate("DEC 1875"),
+			minParentAge: 12,
+			wantError:    false,
+		},
+		{
+			name:         "valid: different minimum age (15 years)",
+			parentBirth:  mustParseDate("1850"),
+			childBirth:   mustParseDate("1865"),
+			minParentAge: 15,
+			wantError:    false,
+		},
+		{
+			name:         "invalid: different minimum age (15 years, parent 14)",
+			parentBirth:  mustParseDate("1850"),
+			childBirth:   mustParseDate("1864"),
+			minParentAge: 15,
+			wantError:    true,
+			errMsg:       "14 years old",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateParentChildDates(tt.parentBirth, tt.childBirth, tt.minParentAge)
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("ValidateParentChildDates() expected error, got nil")
+				} else if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("ValidateParentChildDates() error = %v, want error containing %q", err, tt.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("ValidateParentChildDates() unexpected error = %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateMarriageDates(t *testing.T) {
+	tests := []struct {
+		name           string
+		marriage       *Date
+		spouseBirth1   *Date
+		spouseBirth2   *Date
+		minMarriageAge int
+		wantError      bool
+		errMsg         string
+	}{
+		{
+			name:           "valid: both spouses old enough",
+			marriage:       mustParseDate("1875"),
+			spouseBirth1:   mustParseDate("1850"),
+			spouseBirth2:   mustParseDate("1852"),
+			minMarriageAge: 12,
+			wantError:      false,
+		},
+		{
+			name:           "valid: first spouse exactly minimum age",
+			marriage:       mustParseDate("1862"),
+			spouseBirth1:   mustParseDate("1850"),
+			spouseBirth2:   mustParseDate("1848"),
+			minMarriageAge: 12,
+			wantError:      false,
+		},
+		{
+			name:           "valid: second spouse exactly minimum age",
+			marriage:       mustParseDate("1864"),
+			spouseBirth1:   mustParseDate("1848"),
+			spouseBirth2:   mustParseDate("1852"),
+			minMarriageAge: 12,
+			wantError:      false,
+		},
+		{
+			name:           "invalid: first spouse too young",
+			marriage:       mustParseDate("1861"),
+			spouseBirth1:   mustParseDate("1850"),
+			spouseBirth2:   mustParseDate("1848"),
+			minMarriageAge: 12,
+			wantError:      true,
+			errMsg:         "first spouse",
+		},
+		{
+			name:           "invalid: second spouse too young",
+			marriage:       mustParseDate("1861"),
+			spouseBirth1:   mustParseDate("1848"),
+			spouseBirth2:   mustParseDate("1850"),
+			minMarriageAge: 12,
+			wantError:      true,
+			errMsg:         "second spouse",
+		},
+		{
+			name:           "invalid: both spouses too young",
+			marriage:       mustParseDate("1860"),
+			spouseBirth1:   mustParseDate("1850"),
+			spouseBirth2:   mustParseDate("1851"),
+			minMarriageAge: 12,
+			wantError:      true,
+			errMsg:         "spouse",
+		},
+		{
+			name:           "valid: nil marriage date",
+			marriage:       nil,
+			spouseBirth1:   mustParseDate("1850"),
+			spouseBirth2:   mustParseDate("1852"),
+			minMarriageAge: 12,
+			wantError:      false,
+		},
+		{
+			name:           "valid: nil first spouse birth",
+			marriage:       mustParseDate("1875"),
+			spouseBirth1:   nil,
+			spouseBirth2:   mustParseDate("1852"),
+			minMarriageAge: 12,
+			wantError:      false,
+		},
+		{
+			name:           "valid: nil second spouse birth",
+			marriage:       mustParseDate("1875"),
+			spouseBirth1:   mustParseDate("1850"),
+			spouseBirth2:   nil,
+			minMarriageAge: 12,
+			wantError:      false,
+		},
+		{
+			name:           "valid: all dates nil",
+			marriage:       nil,
+			spouseBirth1:   nil,
+			spouseBirth2:   nil,
+			minMarriageAge: 12,
+			wantError:      false,
+		},
+		{
+			name:           "valid: partial dates",
+			marriage:       mustParseDate("JUN 1875"),
+			spouseBirth1:   mustParseDate("MAR 1850"),
+			spouseBirth2:   mustParseDate("1852"),
+			minMarriageAge: 12,
+			wantError:      false,
+		},
+		{
+			name:           "valid: only first spouse birth known",
+			marriage:       mustParseDate("1875"),
+			spouseBirth1:   mustParseDate("1850"),
+			spouseBirth2:   nil,
+			minMarriageAge: 12,
+			wantError:      false,
+		},
+		{
+			name:           "invalid: only first spouse birth known, too young",
+			marriage:       mustParseDate("1860"),
+			spouseBirth1:   mustParseDate("1850"),
+			spouseBirth2:   nil,
+			minMarriageAge: 12,
+			wantError:      true,
+			errMsg:         "first spouse",
+		},
+		{
+			name:           "valid: different minimum age (16 years)",
+			marriage:       mustParseDate("1875"),
+			spouseBirth1:   mustParseDate("1850"),
+			spouseBirth2:   mustParseDate("1852"),
+			minMarriageAge: 16,
+			wantError:      false,
+		},
+		{
+			name:           "invalid: different minimum age (16 years, first spouse 15)",
+			marriage:       mustParseDate("1865"),
+			spouseBirth1:   mustParseDate("1850"),
+			spouseBirth2:   mustParseDate("1848"),
+			minMarriageAge: 16,
+			wantError:      true,
+			errMsg:         "first spouse",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateMarriageDates(tt.marriage, tt.spouseBirth1, tt.spouseBirth2, tt.minMarriageAge)
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("ValidateMarriageDates() expected error, got nil")
+				} else if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("ValidateMarriageDates() error = %v, want error containing %q", err, tt.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("ValidateMarriageDates() unexpected error = %v", err)
+				}
+			}
+		})
+	}
+}
+
+// mustParseDate is a helper that panics on parse error (for test data only)
+func mustParseDate(s string) *Date {
+	d, err := ParseDate(s)
+	if err != nil {
+		panic("mustParseDate: " + err.Error())
+	}
+	return d
+}


### PR DESCRIPTION
## Summary

Implements Phase 4 of the date parsing feature (#34), integrating the date parsing system with existing GEDCOM record types:

- **ParsedDate fields**: Added `ParsedDate *Date` to `Event`, `Attribute`, and `LDSOrdinance` structs
- **Decoder integration**: Dates are automatically parsed during entity decoding with graceful degradation for invalid dates
- **Helper methods**: `IsAfter()`, `IsBefore()`, `IsEqual()`, `YearsBetween()` for date comparison and arithmetic
- **Validation helpers**: `ValidateBirthBeforeDeath()`, `ValidateParentChildDates()`, `ValidateMarriageDates()` for genealogical validation
- **Individual methods**: `BirthEvent()`, `DeathEvent()`, `BirthDate()`, `DeathDate()` for convenient date access

## Changes

| File | Changes |
|------|---------|
| `gedcom/event.go` | Add `ParsedDate *Date` field |
| `gedcom/individual.go` | Add `ParsedDate` to Attribute, add helper methods |
| `gedcom/lds.go` | Add `ParsedDate *Date` field |
| `gedcom/date.go` | Add comparison and arithmetic helpers |
| `gedcom/validation.go` | New validation functions |
| `decoder/entity.go` | Parse dates during entity decoding |

## Test plan

- [x] All existing tests pass
- [x] New tests for date helper methods (91.5% coverage)
- [x] New tests for validation functions (97.7% coverage)
- [x] New tests for Individual helper methods
- [x] Pre-commit hooks pass (gofmt, vet, lint, coverage)

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)