### PR TITLE
Fix release-please PR not triggering CI

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,6 +20,7 @@ jobs:
         id: release
         with:
           release-type: go
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
   # Trigger pkg.go.dev indexing after release
   publish-docs:


### PR DESCRIPTION
## Summary
- Configure release-please to use a PAT instead of GITHUB_TOKEN
- This allows release-please PRs to trigger CI workflows

## Background
GitHub Actions created with `GITHUB_TOKEN` don't trigger other workflows (to prevent infinite loops). The release-please PR #51 wasn't running CI checks because of this limitation.

Using a PAT with workflow permissions allows the PR events to trigger CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)