### PR TITLE
Document O(1) record lookup by cross-reference ID

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -359,6 +359,35 @@ s := date.String()  // "25 DEC 2020"
 - Example code for common use cases
 - Zero external dependencies (standard library only)
 
+### Record Lookup
+
+O(1) lookup by cross-reference ID for all record types:
+
+| Method | Return Type | Description |
+|--------|-------------|-------------|
+| `GetRecord(xref)` | `*Record` | Generic record lookup |
+| `GetIndividual(xref)` | `*Individual` | Individual lookup |
+| `GetFamily(xref)` | `*Family` | Family lookup |
+| `GetSource(xref)` | `*Source` | Source lookup |
+| `GetRepository(xref)` | `*Repository` | Repository lookup |
+| `GetSubmitter(xref)` | `*Submitter` | Submitter lookup |
+| `GetNote(xref)` | `*Note` | Note lookup |
+| `GetMediaObject(xref)` | `*MediaObject` | Media object lookup |
+
+All methods return `nil` if the record is not found (consistent with Go map behavior).
+
+### Collection Accessors
+
+| Method | Return Type | Description |
+|--------|-------------|-------------|
+| `Individuals()` | `[]*Individual` | All individuals |
+| `Families()` | `[]*Family` | All families |
+| `Sources()` | `[]*Source` | All sources |
+| `Repositories()` | `[]*Repository` | All repositories |
+| `Submitters()` | `[]*Submitter` | All submitters |
+| `Notes()` | `[]*Note` | All notes |
+| `MediaObjects()` | `[]*MediaObject` | All media objects |
+
 ## Testing
 
 - 93% test coverage across core packages

--- a/README.md
+++ b/README.md
@@ -82,6 +82,27 @@ for _, individual := range doc.Individuals() {
 }
 ```
 
+### Lookup by Cross-Reference ID
+
+```go
+// O(1) lookup by cross-reference ID
+person := doc.GetIndividual("@I1@")
+if person != nil {
+    fmt.Printf("Found: %s\n", person.Names[0].Full)
+}
+
+// Lookup works for all record types
+family := doc.GetFamily("@F1@")
+source := doc.GetSource("@S1@")
+repo := doc.GetRepository("@R1@")
+
+// Navigate family relationships
+if family != nil {
+    husband := doc.GetIndividual(family.Husband)
+    wife := doc.GetIndividual(family.Wife)
+}
+```
+
 ### Validating GEDCOM Files
 
 ```go


### PR DESCRIPTION
## Summary

Documents the existing O(1) record lookup feature that was already implemented but not well-documented.

## Changes

- **README.md**: Add "Lookup by Cross-Reference ID" section with practical code examples
- **FEATURES.md**: Add "Record Lookup" and "Collection Accessors" tables documenting all available methods

## Documentation Added

### Record Lookup Methods
| Method | Return Type | Description |
|--------|-------------|-------------|
| `GetRecord(xref)` | `*Record` | Generic record lookup |
| `GetIndividual(xref)` | `*Individual` | Individual lookup |
| `GetFamily(xref)` | `*Family` | Family lookup |
| `GetSource(xref)` | `*Source` | Source lookup |
| `GetRepository(xref)` | `*Repository` | Repository lookup |

All methods return `nil` if not found (consistent with Go map behavior).

## Issues

Closes #35

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)