### PR TITLE
Add Codecov integration with token authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,8 @@ jobs:
       if: matrix.os == 'ubuntu-latest' && matrix.go == '1.25'
       uses: codecov/codecov-action@v5
       with:
-        file: ./coverage.out
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./coverage.out
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gedcom-go
 
 [![CI](https://github.com/cacack/gedcom-go/actions/workflows/ci.yml/badge.svg)](https://github.com/cacack/gedcom-go/actions/workflows/ci.yml)
-[![Coverage](https://img.shields.io/badge/coverage-93%25-brightgreen)](https://github.com/cacack/gedcom-go)
+[![codecov](https://codecov.io/gh/cacack/gedcom-go/graph/badge.svg)](https://codecov.io/gh/cacack/gedcom-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/cacack/gedcom-go)](https://goreportcard.com/report/github.com/cacack/gedcom-go)
 [![GoDoc](https://pkg.go.dev/badge/github.com/cacack/gedcom-go.svg)](https://pkg.go.dev/github.com/cacack/gedcom-go)
 [![Release](https://img.shields.io/github/v/release/cacack/gedcom-go)](https://github.com/cacack/gedcom-go/releases)


### PR DESCRIPTION
## Summary

- Update README badge to use dynamic Codecov badge
- Add CODECOV_TOKEN secret reference to CI workflow for v5 compatibility
- Fix parameter name from `file:` to `files:` for codecov-action v5

## Prerequisites

Before merging, add the `CODECOV_TOKEN` secret to the repository:
1. Go to codecov.io and get the repository upload token
2. Add it as a GitHub secret named `CODECOV_TOKEN`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)