### PR TITLE
Add LATIN1 (ISO-8859-1) encoding support

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -22,7 +22,7 @@ For planned features, see [GitHub Issues](https://github.com/cacack/gedcom-go/is
 |----------|--------|-------|
 | UTF-8 | Full | With BOM detection |
 | ASCII | Full | Subset of UTF-8 |
-| LATIN1 (ISO-8859-1) | Recognized | Declared but not converted |
+| LATIN1 (ISO-8859-1) | Full | Converted to UTF-8 |
 | UTF-16 LE/BE | Full | With BOM detection |
 | ANSEL | Full | With combining diacritical reordering |
 


### PR DESCRIPTION
## Summary

Add full LATIN1 (ISO-8859-1) encoding support to the charset package. Files declaring `1 CHAR LATIN1` (or `ISO-8859-1` or `ANSI`) are now properly detected and converted to UTF-8.

## Changes

- Add `EncodingLATIN1` constant to `charset.Encoding` type
- Update `DetectEncodingFromHeader()` to recognize LATIN1/ISO-8859-1/ANSI (case-insensitive)
- Update `NewReaderWithEncoding()` to convert LATIN1 bytes (128-255) to UTF-8 using `charmap.ISO8859_1`
- Add comprehensive tests for detection and conversion (92% coverage)
- Update FEATURES.md to show LATIN1 as "Full" status

## Test Plan

- [x] All existing tests pass
- [x] New tests cover LATIN1/ISO-8859-1/ANSI detection variants
- [x] New tests verify byte conversion for high bytes (é, ü, ñ, etc.)
- [x] End-to-end tests with GEDCOM-formatted content
- [x] Coverage ≥85% (actual: 92%)

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)