### PR TITLE
Bump golang.org/x/text from 0.14.0 to 0.22.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/cacack/gedcom-go
 
 go 1.21
 
-require golang.org/x/text v0.14.0
+require golang.org/x/text v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
-golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+golang.org/x/text v0.22.0 h1:bofq7m3/HAFvbF51jz3Q9wLg3jkvSPuiZu/pD1XwgtM=
+golang.org/x/text v0.22.0/go.mod h1:YRoo4H8PVmsu+E3Ou7cqLVH8oXWIHVoX0jqUWALQhfY=


### PR DESCRIPTION
## Summary

- Updates `golang.org/x/text` from v0.14.0 to v0.22.0
- v0.22.0 is the **newest version compatible with Go 1.21**
- v0.23.0+ requires Go 1.23+, v0.30.0+ requires Go 1.24+

This replaces #73 (dependabot attempted v0.32.0 which requires Go 1.24).

## Test plan

- [x] All tests pass locally
- [x] Pre-commit hooks pass (lint, vet, coverage)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)