### PR TITLE
Add GEDCOM 7.0 ASSO/PHRASE and NAME TRAN support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ Thumbs.db
 
 # Claude Code prompts
 prompts/
+.prompts/

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -253,6 +253,33 @@ All vendor extensions are preserved during encode/decode cycles. Custom tags not
 - NICK - Nickname
 - TYPE - Name type (birth, married, aka)
 
+### Transliterations (TRAN)
+
+Support for alternative name representations in different scripts/languages (GEDCOM 7.0):
+
+```go
+// Access name transliterations
+for _, name := range individual.Names {
+    for _, tran := range name.Transliterations {
+        fmt.Println(tran.Value)     // "Johann /Müller/"
+        fmt.Println(tran.Language)  // "de"
+        fmt.Println(tran.Given)     // "Johann"
+        fmt.Println(tran.Surname)   // "Müller"
+    }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| Value | Full transliterated name |
+| Language | BCP 47 language tag (e.g., "en-GB", "ja-Latn") |
+| Given | Transliterated given name |
+| Surname | Transliterated surname |
+| Prefix | Transliterated name prefix |
+| Suffix | Transliterated name suffix |
+| Nickname | Transliterated nickname |
+| SurnamePrefix | Transliterated surname prefix |
+
 ## Pedigree (PEDI) Support
 
 - FAMC with pedigree linkage type
@@ -274,7 +301,20 @@ Each includes: DATE, PLAC, TEMP (temple), STAT (status)
 
 - Link individuals with roles
 - Supported roles: GODP (godparent), WITN (witness), custom roles
+- PHRASE - Human-readable description (GEDCOM 7.0)
+- Source citations on associations (GEDCOM 7.0)
 - Notes on associations
+
+```go
+// Access GEDCOM 7.0 association features
+for _, assoc := range individual.Associations {
+    fmt.Println(assoc.Role)    // "GODP"
+    fmt.Println(assoc.Phrase)  // "Godparent at baptism"
+    for _, cite := range assoc.SourceCitations {
+        fmt.Println(cite.SourceXRef)  // "@S1@"
+    }
+}
+```
 
 ## Date Parsing
 
@@ -302,6 +342,7 @@ Structured date parsing for GEDCOM date strings with full support for:
 | B.C. dates | `44 BC`, `753 B.C.E.` | IsBC flag set |
 | Dual dating | `21 FEB 1750/51` | Both years accessible |
 | Date phrases | `(unknown)` | GEDCOM 5.5 format |
+| PHRASE subordinate | `3 PHRASE Afternoon` | GEDCOM 7.0 human-readable description |
 
 ### Validation
 

--- a/encoder/entity_writer.go
+++ b/encoder/entity_writer.go
@@ -533,6 +533,44 @@ func nameToTags(name *gedcom.PersonalName, level int) []*gedcom.Tag {
 		tags = append(tags, &gedcom.Tag{Level: level + 1, Tag: "TYPE", Value: name.Type})
 	}
 
+	// Transliterations (GEDCOM 7.0 TRAN tag)
+	for _, tran := range name.Transliterations {
+		tags = append(tags, transliterationToTags(tran, level+1)...)
+	}
+
+	return tags
+}
+
+// transliterationToTags converts a Transliteration to GEDCOM tags at the specified level.
+func transliterationToTags(tran *gedcom.Transliteration, level int) []*gedcom.Tag {
+	var tags []*gedcom.Tag
+
+	// TRAN tag with transliterated name value
+	tags = append(tags, &gedcom.Tag{Level: level, Tag: "TRAN", Value: tran.Value})
+
+	// Subordinate tags at level+1
+	if tran.Language != "" {
+		tags = append(tags, &gedcom.Tag{Level: level + 1, Tag: "LANG", Value: tran.Language})
+	}
+	if tran.Given != "" {
+		tags = append(tags, &gedcom.Tag{Level: level + 1, Tag: "GIVN", Value: tran.Given})
+	}
+	if tran.Surname != "" {
+		tags = append(tags, &gedcom.Tag{Level: level + 1, Tag: "SURN", Value: tran.Surname})
+	}
+	if tran.Prefix != "" {
+		tags = append(tags, &gedcom.Tag{Level: level + 1, Tag: "NPFX", Value: tran.Prefix})
+	}
+	if tran.Suffix != "" {
+		tags = append(tags, &gedcom.Tag{Level: level + 1, Tag: "NSFX", Value: tran.Suffix})
+	}
+	if tran.Nickname != "" {
+		tags = append(tags, &gedcom.Tag{Level: level + 1, Tag: "NICK", Value: tran.Nickname})
+	}
+	if tran.SurnamePrefix != "" {
+		tags = append(tags, &gedcom.Tag{Level: level + 1, Tag: "SPFX", Value: tran.SurnamePrefix})
+	}
+
 	return tags
 }
 
@@ -821,9 +859,19 @@ func associationToTags(assoc *gedcom.Association, level int, opts *EncodeOptions
 	tags = append(tags, &gedcom.Tag{Level: level, Tag: "ASSO", Value: assoc.IndividualXRef})
 
 	// Subordinate tags at level+1
+	// PHRASE (GEDCOM 7.0) - human-readable description of the association
+	if assoc.Phrase != "" {
+		tags = append(tags, &gedcom.Tag{Level: level + 1, Tag: "PHRASE", Value: assoc.Phrase})
+	}
+
 	// Use ROLE for GEDCOM 7.0 compatibility (also compatible with 5.5.1 RELA)
 	if assoc.Role != "" {
 		tags = append(tags, &gedcom.Tag{Level: level + 1, Tag: "ROLE", Value: assoc.Role})
+	}
+
+	// Source citations (GEDCOM 7.0)
+	for _, cite := range assoc.SourceCitations {
+		tags = append(tags, sourceCitationToTags(cite, level+1, opts)...)
 	}
 
 	// Notes (with CONT/CONC for multiline/long)

--- a/gedcom/individual.go
+++ b/gedcom/individual.go
@@ -84,6 +84,43 @@ type PersonalName struct {
 
 	// Type is the name type (e.g., "birth", "married", "aka")
 	Type string
+
+	// Transliterations are alternative representations of the name in different
+	// writing systems or scripts (GEDCOM 7.0 TRAN tag). Used to store the same
+	// name in different languages, scripts, or romanization systems.
+	Transliterations []*Transliteration
+}
+
+// Transliteration represents an alternative representation of a name in a different
+// writing system, script, or language (GEDCOM 7.0 TRAN tag under NAME).
+// Each transliteration can include the full transliterated name value plus
+// individual name components in that writing system.
+type Transliteration struct {
+	// Value is the full transliterated name in GEDCOM format (e.g., "John /Doe/").
+	// This is the value from the TRAN tag itself.
+	Value string
+
+	// Language is the BCP 47 language tag indicating the language/script of this
+	// transliteration (GEDCOM 7.0 LANG tag). Examples: "en-GB", "ja-Latn", "zh-Hans".
+	Language string
+
+	// Given is the transliterated given (first) name (GIVN tag).
+	Given string
+
+	// Surname is the transliterated family name (SURN tag).
+	Surname string
+
+	// Prefix is the transliterated name prefix, e.g., "Dr.", "Sir" (NPFX tag).
+	Prefix string
+
+	// Suffix is the transliterated name suffix, e.g., "Jr.", "III" (NSFX tag).
+	Suffix string
+
+	// Nickname is the transliterated nickname (NICK tag).
+	Nickname string
+
+	// SurnamePrefix is the transliterated surname prefix, e.g., "von", "de" (SPFX tag).
+	SurnamePrefix string
 }
 
 // FamilyLink represents a link to a family with optional pedigree type.
@@ -105,6 +142,15 @@ type Association struct {
 	// Role is the relationship role (e.g., "GODP" for godparent, "WITN" for witness)
 	// In GEDCOM 5.5.1 this comes from RELA tag, in GEDCOM 7.0 from ROLE tag
 	Role string
+
+	// Phrase is a human-readable description of the association (GEDCOM 7.0 PHRASE tag).
+	// Used when the structured data cannot fully express the relationship.
+	// Example: "Mr Stockdale" as the associated person's name when @XREF@ is unavailable.
+	Phrase string
+
+	// SourceCitations are source citations documenting this association (GEDCOM 7.0).
+	// Allows citing sources for the association relationship itself.
+	SourceCitations []*SourceCitation
 
 	// Notes are note references for this association
 	Notes []string


### PR DESCRIPTION
## Summary

Implements GEDCOM 7.0 specific features for associations and name transliterations.

### Association enhancements (Issue #40)
- **PHRASE** subordinate for human-readable association descriptions
- **Source citations (SOUR)** under ASSO tags
- Full decode/encode round-trip support

### Name transliterations (Issue #39)
- **TRAN** tags for alternative name representations in different scripts/languages
- Language (LANG) and name component subordinates (GIVN, SURN, NPFX, NSFX, NICK, SPFX)
- Support for multiple transliterations per name

### DATE PHRASE support
- Parse PHRASE subordinate under DATE tags in events
- Store in `ParsedDate.Phrase` field

## Changes

| File | Changes |
|------|---------|
| `gedcom/individual.go` | Extended Association struct, added Transliteration struct |
| `decoder/entity.go` | Updated parsing for ASSO, NAME, and DATE |
| `encoder/entity_writer.go` | Updated encoding for ASSO and NAME |
| `decoder/entity_test.go` | Added 9 decoder tests |
| `encoder/entity_writer_test.go` | Added 8 encoder tests including round-trip |
| `FEATURES.md` | Documented new capabilities |

## Test Coverage

- decoder: 97.6%
- encoder: 99.5%
- All pre-commit checks passed

## Issues

Closes #40
Closes #39

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)