### PR TITLE
Add calendar dates and structural edge case test files

### DIFF
--- a/testdata/README.md
+++ b/testdata/README.md
@@ -20,7 +20,7 @@ testdata/
 
 ## Test File Summary
 
-**Total Test Files**: 53 GEDCOM files (as of 2025-01-12)
+**Total Test Files**: 55 GEDCOM files (as of 2026-01-12)
 
 ### GEDCOM 5.5 Files
 
@@ -131,6 +131,27 @@ Testing parser robustness with edge cases:
   - Unicode characters with CONT/CONC
   - Special characters and quotes in continued text
   - Tests that parser correctly reconstructs original text
+
+- **calendar-dates.ged** (~5K) - Non-Gregorian calendar date tests
+  - Hebrew calendar dates (`@#DHEBREW@`) with all 13 month codes
+  - Julian calendar dates (`@#DJULIAN@`) including BC dates and dual dating
+  - French Republican calendar dates (`@#DFRENCH R@`) with all 13 month codes
+  - Date modifiers (ABT, BEF, AFT, EST, BET...AND) with non-Gregorian calendars
+  - Partial dates (year-only, month-year) in each calendar system
+  - Historical figures: Julius Caesar, Augustus, Washington, Rashi, Maimonides, Napoleon
+  - Tests: 10 individuals with various calendar date formats
+
+- **structural-edge-cases.ged** (~3K) - Parser structural stress tests
+  - Very long XRef identifiers (>22 characters)
+  - Lowercase XRef identifiers
+  - Purely numeric XRef identifiers
+  - Deeply nested structures (6+ levels)
+  - Tags with empty or whitespace-only values
+  - Multiple consecutive spaces in values
+  - Tab characters in values
+  - Root-level NOTE records
+  - Tests: 9 individuals, 3 families, 1 source, 1 note record
+  - Note: Empty lines are invalid per GEDCOM spec (tested in malformed/)
 
 #### Vendor-Specific Test Files
 Source: https://github.com/frizbog/gedcom4j (sample/ directory)
@@ -340,6 +361,8 @@ When adding new test files:
   - `gedcom-5.5.1/comprehensive.ged` - GEDCOM 5.5.1 features
   - `encoding/utf8-unicode.ged` - International character testing
   - `edge-cases/cont-conc.ged` - Line continuation testing
+  - `edge-cases/calendar-dates.ged` - Non-Gregorian calendar dates (Hebrew, Julian, French Republican)
+  - `edge-cases/structural-edge-cases.ged` - Parser structural stress tests
   - `malformed/circular-reference.ged` - Circular relationship loops
   - `malformed/duplicate-xref.ged` - Duplicate identifier testing
 

--- a/testdata/edge-cases/calendar-dates.ged
+++ b/testdata/edge-cases/calendar-dates.ged
@@ -1,0 +1,244 @@
+0 HEAD
+1 SOUR gedcom-go
+2 VERS 1.0.0
+2 NAME gedcom-go test suite
+1 GEDC
+2 VERS 5.5.1
+2 FORM LINEAGE-LINKED
+1 CHAR UTF-8
+1 NOTE Calendar date test file for non-Gregorian calendar systems.
+2 CONT Tests Hebrew, Julian, and French Republican calendar date parsing.
+2 CONT Created for gedcom-go test suite - issue #88.
+0 @I1@ INDI
+1 NAME Julius /Caesar/
+1 SEX M
+1 NOTE Julian calendar dates (used before Gregorian adoption in 1582)
+1 BIRT
+2 DATE @#DJULIAN@ 12 JUL 100 BC
+2 PLAC Rome, Roman Republic
+1 DEAT
+2 DATE @#DJULIAN@ 15 MAR 44 BC
+2 PLAC Rome, Roman Republic
+2 NOTE The Ides of March - famously assassinated
+0 @I2@ INDI
+1 NAME Augustus /Caesar/
+1 SEX M
+1 NOTE Julian calendar - Roman emperor
+1 BIRT
+2 DATE @#DJULIAN@ 23 SEP 63 BC
+2 PLAC Rome, Roman Republic
+1 DEAT
+2 DATE @#DJULIAN@ 19 AUG 14
+2 PLAC Nola, Roman Empire
+0 @I3@ INDI
+1 NAME George /Washington/
+1 SEX M
+1 NOTE Birth in Julian calendar (Virginia used Julian until 1752)
+1 BIRT
+2 DATE @#DJULIAN@ 11 FEB 1731/32
+2 PLAC Westmoreland County, Virginia
+2 NOTE Dual dating: Old Style 11 Feb 1731, New Style 22 Feb 1732
+0 @I4@ INDI
+1 NAME Rashi /ben Isaac/
+2 GIVN Shlomo Yitzchaki
+1 SEX M
+1 NOTE Hebrew calendar dates - famous medieval rabbi
+1 BIRT
+2 DATE @#DHEBREW@ TSH 4800
+2 PLAC Troyes, France
+2 NOTE Tishrei 4800 (approximately 1040 CE)
+1 DEAT
+2 DATE @#DHEBREW@ 29 TMZ 4865
+2 PLAC Troyes, France
+2 NOTE 29 Tammuz 4865 (approximately July 1105 CE)
+0 @I5@ INDI
+1 NAME Moses /Maimonides/
+2 GIVN Moshe ben Maimon
+1 SEX M
+1 NOTE Hebrew calendar dates - philosopher and scholar
+1 BIRT
+2 DATE @#DHEBREW@ 14 NSN 4895
+2 PLAC Cordoba, Spain
+2 NOTE 14 Nisan 4895 - eve of Passover
+1 DEAT
+2 DATE @#DHEBREW@ 20 TVT 4965
+2 PLAC Fostat, Egypt
+2 NOTE 20 Tevet 4965
+0 @I6@ INDI
+1 NAME Test /HebrewMonths/
+1 SEX U
+1 NOTE Tests all Hebrew month codes
+1 EVEN
+2 TYPE Hebrew Month Test
+2 DATE @#DHEBREW@ 1 TSH 5784
+2 NOTE Tishrei - first month of civil year
+1 EVEN
+2 TYPE Hebrew Month Test
+2 DATE @#DHEBREW@ 15 CSH 5784
+2 NOTE Cheshvan - second month
+1 EVEN
+2 TYPE Hebrew Month Test
+2 DATE @#DHEBREW@ 25 KSL 5784
+2 NOTE Kislev - Hanukkah begins
+1 EVEN
+2 TYPE Hebrew Month Test
+2 DATE @#DHEBREW@ 10 TVT 5784
+2 NOTE Tevet - fourth month
+1 EVEN
+2 TYPE Hebrew Month Test
+2 DATE @#DHEBREW@ 15 SHV 5784
+2 NOTE Shevat - Tu B'Shevat
+1 EVEN
+2 TYPE Hebrew Month Test
+2 DATE @#DHEBREW@ 14 ADR 5784
+2 NOTE Adar - Purim (in non-leap year)
+1 EVEN
+2 TYPE Hebrew Month Test
+2 DATE @#DHEBREW@ 14 ADS 5784
+2 NOTE Adar II - Purim (in leap year only)
+1 EVEN
+2 TYPE Hebrew Month Test
+2 DATE @#DHEBREW@ 15 NSN 5784
+2 NOTE Nisan - Passover begins
+1 EVEN
+2 TYPE Hebrew Month Test
+2 DATE @#DHEBREW@ 5 IYR 5784
+2 NOTE Iyar - Yom HaAtzmaut
+1 EVEN
+2 TYPE Hebrew Month Test
+2 DATE @#DHEBREW@ 6 SVN 5784
+2 NOTE Sivan - Shavuot
+1 EVEN
+2 TYPE Hebrew Month Test
+2 DATE @#DHEBREW@ 17 TMZ 5784
+2 NOTE Tammuz - Fast of 17th Tammuz
+1 EVEN
+2 TYPE Hebrew Month Test
+2 DATE @#DHEBREW@ 9 AAV 5784
+2 NOTE Av - Tisha B'Av
+1 EVEN
+2 TYPE Hebrew Month Test
+2 DATE @#DHEBREW@ 29 ELL 5784
+2 NOTE Elul - last month before Rosh Hashanah
+0 @I7@ INDI
+1 NAME Napoleon /Bonaparte/
+1 SEX M
+1 NOTE French Republican calendar dates
+1 BIRT
+2 DATE 15 AUG 1769
+2 PLAC Ajaccio, Corsica
+2 NOTE Before French Republican calendar (1792-1805)
+1 EVEN
+2 TYPE Coronation as Emperor
+2 DATE @#DFRENCH R@ 11 FRIM 13
+2 PLAC Notre-Dame, Paris
+2 NOTE 11 Frimaire Year 13 = 2 December 1804
+0 @I8@ INDI
+1 NAME Test /FrenchMonths/
+1 SEX U
+1 NOTE Tests all French Republican month codes
+1 EVEN
+2 TYPE French Month Test
+2 DATE @#DFRENCH R@ 1 VEND 1
+2 NOTE Vendemiaire - first month (grape harvest)
+1 EVEN
+2 TYPE French Month Test
+2 DATE @#DFRENCH R@ 15 BRUM 1
+2 NOTE Brumaire - fog month
+1 EVEN
+2 TYPE French Month Test
+2 DATE @#DFRENCH R@ 30 FRIM 1
+2 NOTE Frimaire - frost month
+1 EVEN
+2 TYPE French Month Test
+2 DATE @#DFRENCH R@ 10 NIVO 1
+2 NOTE Nivose - snow month
+1 EVEN
+2 TYPE French Month Test
+2 DATE @#DFRENCH R@ 20 PLUV 1
+2 NOTE Pluviose - rain month
+1 EVEN
+2 TYPE French Month Test
+2 DATE @#DFRENCH R@ 5 VENT 1
+2 NOTE Ventose - wind month
+1 EVEN
+2 TYPE French Month Test
+2 DATE @#DFRENCH R@ 15 GERM 1
+2 NOTE Germinal - germination month
+1 EVEN
+2 TYPE French Month Test
+2 DATE @#DFRENCH R@ 25 FLOR 1
+2 NOTE Floreal - flower month
+1 EVEN
+2 TYPE French Month Test
+2 DATE @#DFRENCH R@ 1 PRAI 1
+2 NOTE Prairial - meadow month
+1 EVEN
+2 TYPE French Month Test
+2 DATE @#DFRENCH R@ 10 MESS 1
+2 NOTE Messidor - harvest month
+1 EVEN
+2 TYPE French Month Test
+2 DATE @#DFRENCH R@ 9 THER 1
+2 NOTE Thermidor - heat month (9th = fall of Robespierre)
+1 EVEN
+2 TYPE French Month Test
+2 DATE @#DFRENCH R@ 18 FRUC 1
+2 NOTE Fructidor - fruit month
+1 EVEN
+2 TYPE French Month Test
+2 DATE @#DFRENCH R@ 5 COMP 1
+2 NOTE Complementary days (Sans-culottides)
+0 @I9@ INDI
+1 NAME Test /DateModifiers/
+1 SEX U
+1 NOTE Tests calendar dates with modifiers
+1 EVEN
+2 TYPE Approximate Julian
+2 DATE ABT @#DJULIAN@ MAR 1066
+2 NOTE Battle of Hastings era
+1 EVEN
+2 TYPE Before Hebrew
+2 DATE BEF @#DHEBREW@ 1 TSH 5000
+2 NOTE Before a Hebrew date
+1 EVEN
+2 TYPE After French
+2 DATE AFT @#DFRENCH R@ 1 VEND 1
+2 NOTE After start of French Republican era
+1 EVEN
+2 TYPE Estimated Julian
+2 DATE EST @#DJULIAN@ 1200
+2 NOTE Estimated year only
+1 EVEN
+2 TYPE Between Hebrew
+2 DATE BET @#DHEBREW@ 1 NSN 5700 AND @#DHEBREW@ 30 ELL 5700
+2 NOTE Range within Hebrew calendar year
+0 @I10@ INDI
+1 NAME Test /PartialDates/
+1 SEX U
+1 NOTE Tests partial dates (year-only, month-year) in non-Gregorian calendars
+1 EVEN
+2 TYPE Julian Year Only
+2 DATE @#DJULIAN@ 1066
+2 NOTE Year only - Norman Conquest
+1 EVEN
+2 TYPE Hebrew Year Only
+2 DATE @#DHEBREW@ 5784
+2 NOTE Year only in Hebrew calendar
+1 EVEN
+2 TYPE French Year Only
+2 DATE @#DFRENCH R@ 7
+2 NOTE Year 7 of French Republic
+1 EVEN
+2 TYPE Julian Month-Year
+2 DATE @#DJULIAN@ OCT 1066
+2 NOTE Month and year only
+1 EVEN
+2 TYPE Hebrew Month-Year
+2 DATE @#DHEBREW@ NSN 5784
+2 NOTE Nisan month and year only
+1 EVEN
+2 TYPE French Month-Year
+2 DATE @#DFRENCH R@ THER 2
+2 NOTE Thermidor Year 2
+0 TRLR

--- a/testdata/edge-cases/structural-edge-cases.ged
+++ b/testdata/edge-cases/structural-edge-cases.ged
@@ -1,0 +1,111 @@
+0 HEAD
+1 SOUR gedcom-go
+2 VERS 1.0.0
+2 NAME gedcom-go test suite
+1 GEDC
+2 VERS 5.5.1
+2 FORM LINEAGE-LINKED
+1 CHAR UTF-8
+1 NOTE Structural edge case test file.
+2 CONT Tests long XRef identifiers, deep nesting, and unusual but valid structures.
+2 CONT Created for gedcom-go test suite - issue #88.
+2 CONT Note: Empty lines are NOT tested here because they are invalid per GEDCOM spec.
+0 @I1@ INDI
+1 NAME Simple /Test/
+1 SEX M
+0 @INDIVIDUAL_WITH_VERY_LONG_XREF_IDENTIFIER_12345678901234567890@ INDI
+1 NAME Long /XRefTest/
+1 SEX U
+1 NOTE Tests very long cross-reference identifiers
+2 CONT GEDCOM 5.5 allows up to 22 characters for XRef
+2 CONT Some software produces longer identifiers
+0 @F1@ FAM
+1 HUSB @I1@
+1 WIFE @I2@
+1 CHIL @INDIVIDUAL_WITH_VERY_LONG_XREF_IDENTIFIER_12345678901234567890@
+1 NOTE Family referencing record with long XRef
+0 @I2@ INDI
+1 NAME Deeply /Nested/
+1 SEX M
+1 NOTE Tests deeply nested structures (6+ levels)
+1 SOUR @S1@
+2 PAGE Vol 1, Page 23
+2 DATA
+3 DATE 15 JAN 1900
+3 TEXT Deeply nested source citation text
+4 CONT with continuation across multiple
+4 CONC lines testing deep nesting behavior
+4 CONT and proper level handling
+5 NOTE Even deeper nested note
+6 CONT with its own continuation
+0 @I3@ INDI
+1 NAME Tab	/Separated/
+1 SEX F
+1 NOTE Record with tabs in various places
+1 OCCU Farmer	(with tab)
+1 RESI
+2 ADDR 123	Main	Street
+3 CITY Test	City
+3 STAE Test	State
+0 @I4@ INDI
+1 NAME Multiple /Spaces/
+1 SEX M
+1 NOTE Tests handling of multiple consecutive spaces
+1 OCCU Test    Job    Title
+1 NOTE This    has    multiple    spaces
+0 @I5@ INDI
+1 NAME Empty /Values/
+1 SEX U
+1 NOTE Tests tags with empty or whitespace-only values
+1 OCCU
+1 RESI
+2 ADDR
+2 PLAC
+1 BIRT
+2 DATE
+2 PLAC
+1 NOTE Empty tags above should parse without error
+0 @I6@ INDI
+1 NAME Mixed /CaseXRef/
+1 SEX M
+1 FAMC @f2@
+1 NOTE Tests lowercase XRef (some software produces these)
+0 @f2@ FAM
+1 HUSB @I1@
+1 WIFE @I4@
+1 CHIL @I6@
+1 NOTE Lowercase XRef identifier
+0 @I7@ INDI
+1 NAME Numeric /XRef/
+1 SEX F
+1 FAMC @123@
+1 NOTE Tests purely numeric XRef
+0 @123@ FAM
+1 HUSB @I1@
+1 WIFE @I3@
+1 CHIL @I7@
+1 NOTE Purely numeric XRef identifier
+0 @I8@ INDI
+1 NAME Unicode /InValues/
+1 SEX M
+1 NOTE
+2 CONT Tests Unicode in various value positions
+1 BIRT
+2 DATE 1 JAN 2000
+2 PLAC Tokyo, Japan
+1 NAME Tanaka /Taro/
+2 ROMN Tanaka Taro
+2 FONE Tanaka Taro
+1 NOTE Names with various scripts should parse correctly
+0 @S1@ SOUR
+1 TITL Test Source for Deep Nesting
+1 AUTH Test Author
+0 @N1@ NOTE This is a root-level note record
+1 CONT with continuation lines
+1 CONC and concatenation as well.
+0 @I9@ INDI
+1 NAME Final /Record/
+1 SEX F
+1 NOTE @N1@
+1 NOTE Final record to ensure file closes properly after all edge cases
+0 TRLR


### PR DESCRIPTION
## Summary

Adds comprehensive test files for non-Gregorian calendar date parsing and parser structural edge cases.

### New Test Files

**calendar-dates.ged** (~5K)
- Hebrew calendar dates with all 13 month codes
- Julian calendar dates including BC dates and dual dating
- French Republican calendar dates with all 13 month codes
- Date modifiers (ABT, BEF, AFT, EST, BET...AND) with non-Gregorian calendars
- Partial dates (year-only, month-year) in each calendar system
- 10 individuals including historical figures (Caesar, Washington, Rashi, Maimonides, Napoleon)

**structural-edge-cases.ged** (~3K)
- Very long XRef identifiers (>22 characters)
- Lowercase and numeric XRef identifiers
- Deeply nested structures (6+ levels)
- Tags with empty or whitespace-only values
- Multiple consecutive spaces and tab characters
- Root-level NOTE records
- 9 individuals, 3 families

## Test plan

- [x] Both files parse successfully with decoder
- [x] All existing tests pass
- [x] testdata/README.md updated with documentation

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)