### PR TITLE
Enhance security CI with govulncheck SARIF and dependency review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,21 @@ jobs:
     - name: Run go vet
       run: go vet ./...
 
+  # Dependency review - blocks PRs introducing vulnerable dependencies
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Dependency Review
+      uses: actions/dependency-review-action@v4
+      with:
+        fail-on-severity: high
+        allow-licenses: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MPL-2.0, 0BSD, CC0-1.0, Unlicense
+
   security:
     name: Security Scan
     runs-on: ubuntu-latest
@@ -151,7 +166,15 @@ jobs:
     - name: Run govulncheck
       run: |
         go install golang.org/x/vuln/cmd/govulncheck@latest
+        govulncheck -format sarif ./... > govulncheck-results.sarif || true
         govulncheck ./...
+
+    - name: Upload govulncheck results to GitHub Security
+      uses: github/codeql-action/upload-sarif@v4
+      if: success() || failure()
+      with:
+        sarif_file: govulncheck-results.sarif
+        category: govulncheck
 
     - name: Run gosec
       run: |
@@ -163,6 +186,7 @@ jobs:
       if: success() || failure()
       with:
         sarif_file: gosec-results.sarif
+        category: gosec
 
   build-examples:
     name: Build Examples
@@ -223,7 +247,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [test, coverage, lint, format, security, build-examples, pr-title]
+    needs: [test, coverage, lint, format, dependency-review, security, build-examples, pr-title]
     if: always()
     steps:
       - name: Check all jobs passed


### PR DESCRIPTION
## Summary
- Add govulncheck SARIF output uploaded to GitHub Security tab
- Add dependency-review-action to block PRs introducing vulnerable dependencies
- Add category labels to SARIF uploads for better organization in Security tab

## Test plan
- [ ] CI passes with new security jobs
- [ ] govulncheck results appear in Security tab after merge
- [ ] dependency-review job runs on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)