### PR TITLE
Require Go 1.24+ (drop EOL versions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: ['1.21', '1.22', '1.23', '1.24', '1.25']
+        go: ['1.24', '1.25']
 
     steps:
     - name: Checkout code
@@ -142,7 +142,7 @@ jobs:
       uses: actions/dependency-review-action@v4
       with:
         fail-on-severity: high
-        allow-licenses: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MPL-2.0, 0BSD, CC0-1.0, Unlicense
+        allow-licenses: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MPL-2.0, 0BSD, CC0-1.0, Unlicense, BSD-3-Clause AND LicenseRef-scancode-google-patent-license-golang
 
   security:
     name: Security Scan

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.23'
+        go-version: '1.24'
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Quick Start
 
-**Required**: Go 1.21+
+**Required**: Go 1.24+
 
 ```bash
 make setup-dev-env    # Downloads deps, installs tools, sets up hooks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ This project adheres to a simple code of conduct:
 
 ### Prerequisites
 
-- Go 1.21 or later
+- Go 1.24 or later
 - Git
 - Familiarity with the GEDCOM specification (helpful but not required)
 
@@ -408,7 +408,7 @@ Include the following information:
    What actually happened
 
    **Environment**
-   - Go version: 1.21.0
+   - Go version: 1.24.0
    - OS: macOS 14.0
    - go-gedcom version: v0.1.0
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -715,6 +715,6 @@ children := family.ChildrenIndividuals(doc)
 
 - 93% test coverage across core packages
 - Multi-platform CI (Linux, macOS, Windows)
-- Multi-version Go testing (1.21, 1.22, 1.23)
+- Multi-version Go testing (1.24, 1.25)
 - Benchmark regression testing
 - Real-world GEDCOM file testing

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ go get github.com/cacack/gedcom-go
 
 ## Requirements
 
-- Go 1.21 or later
+- Go 1.24 or later
 
 ## Quick Start
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -84,7 +84,7 @@ go get github.com/cacack/gedcom-go
 ```
 
 Requirements:
-- Go 1.21 or later
+- Go 1.24 or later
 - No external dependencies (uses only the Go standard library)
 
 ## Quick Start

--- a/examples/README.md
+++ b/examples/README.md
@@ -325,10 +325,10 @@ go run main.go ../../testdata/gedcom-5.5/minimal.ged
 
 ### Import errors
 
-Ensure you're using Go 1.21 or later:
+Ensure you're using Go 1.24 or later:
 
 ```bash
-go version  # Should show 1.21 or higher
+go version  # Should show 1.24 or higher
 ```
 
 ### Module issues

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/cacack/gedcom-go
 
-go 1.21
+go 1.24
 
 require golang.org/x/text v0.22.0


### PR DESCRIPTION
## Summary
- Update minimum Go version to 1.24 (aligns with Go's official support policy)
- Go 1.21, 1.22, and 1.23 are end-of-life and no longer receive security patches
- Update CI test matrix from [1.21-1.25] to [1.24, 1.25]
- Update CodeQL workflow to use Go 1.24
- Add compound license for golang.org/x/text to dependency-review allow-list
- Update all documentation to reflect new requirements

## Motivation
This unblocks Dependabot PR #94 which upgrades golang.org/x/text from 0.22.0 to 0.33.0. The new version requires Go 1.24+.

## Test plan
- [x] All tests pass locally
- [x] Pre-commit hooks pass (gofmt, vet, lint, coverage)
- [ ] CI passes on this PR
- [ ] After merge, rebase Dependabot PR #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)