### PR TITLE
Add streaming APIs for memory-efficient large file processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A pure Go library for parsing and validating GEDCOM (GEnealogical Data COMmunica
 - **Multi-version Support**: Parse GEDCOM 5.5, 5.5.1, and 7.0 files
 - **Historical Calendar Support**: Parse dates in Julian, Hebrew, and French Republican calendars
 - **Read and Write**: Full decoder and encoder for round-trip processing
+- **Streaming Support**: Memory-efficient APIs for very large files (1M+ records)
 - **Comprehensive Validation**: Version-aware validation with clear error messages
 - **Zero Dependencies**: Uses only the Go standard library
 - **Well-tested**: 93% test coverage with multi-platform CI

--- a/encoder/streaming.go
+++ b/encoder/streaming.go
@@ -1,0 +1,265 @@
+package encoder
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/cacack/gedcom-go/gedcom"
+)
+
+// encodeState represents the current state of the streaming encoder.
+type encodeState int
+
+const (
+	stateInitial        encodeState = iota // Initial state, waiting for WriteHeader
+	stateHeaderWritten                     // Header has been written, can write records or trailer
+	stateRecordsWritten                    // At least one record has been written, can write more records or trailer
+	stateComplete                          // Trailer has been written, encoding is complete
+)
+
+// String returns a human-readable name for the encode state.
+func (s encodeState) String() string {
+	switch s {
+	case stateInitial:
+		return "Initial"
+	case stateHeaderWritten:
+		return "HeaderWritten"
+	case stateRecordsWritten:
+		return "RecordsWritten"
+	case stateComplete:
+		return "Complete"
+	default:
+		return "Unknown"
+	}
+}
+
+// StreamEncoder provides a streaming interface for writing GEDCOM documents.
+// It allows writing records one at a time with constant memory usage,
+// enabling generation of very large GEDCOM files without loading the entire
+// document into memory first.
+//
+// The encoder enforces valid GEDCOM structure through a state machine:
+//   - WriteHeader must be called first (and only once)
+//   - WriteRecord can be called zero or more times
+//   - WriteTrailer must be called to complete the document
+//   - Close should be called to flush any buffered data
+//
+// Example usage:
+//
+//	f, _ := os.Create("output.ged")
+//	defer f.Close()
+//
+//	enc := encoder.NewStreamEncoder(f)
+//	enc.WriteHeader(header)
+//	for _, record := range records {
+//	    enc.WriteRecord(record)
+//	}
+//	enc.WriteTrailer()
+//	enc.Close()
+type StreamEncoder struct {
+	writer  *bufio.Writer
+	options *EncodeOptions
+	state   encodeState
+	err     error // sticky error for early exit
+}
+
+// Errors returned by StreamEncoder for invalid state transitions.
+var (
+	ErrHeaderNotWritten      = errors.New("header must be written before writing records")
+	ErrHeaderAlreadyWritten  = errors.New("header has already been written")
+	ErrTrailerNotWritten     = errors.New("trailer has not been written")
+	ErrTrailerAlreadyWritten = errors.New("trailer has already been written")
+	ErrEncodingComplete      = errors.New("encoding is complete, no further writes allowed")
+)
+
+// NewStreamEncoder creates a new StreamEncoder that writes to w.
+// It uses default encoding options (LF line endings, default max line length).
+func NewStreamEncoder(w io.Writer) *StreamEncoder {
+	return NewStreamEncoderWithOptions(w, DefaultOptions())
+}
+
+// NewStreamEncoderWithOptions creates a new StreamEncoder with custom options.
+// If opts is nil, default options are used.
+func NewStreamEncoderWithOptions(w io.Writer, opts *EncodeOptions) *StreamEncoder {
+	if opts == nil {
+		opts = DefaultOptions()
+	}
+	return &StreamEncoder{
+		writer:  bufio.NewWriter(w),
+		options: opts,
+		state:   stateInitial,
+	}
+}
+
+// WriteHeader writes the GEDCOM header. This must be the first method called
+// on the encoder and can only be called once.
+//
+// Returns ErrHeaderAlreadyWritten if the header has already been written,
+// or ErrEncodingComplete if the encoding is already complete.
+func (e *StreamEncoder) WriteHeader(h *gedcom.Header) error {
+	if e.err != nil {
+		return e.err
+	}
+
+	switch e.state {
+	case stateInitial:
+		// Valid state, proceed
+	case stateHeaderWritten, stateRecordsWritten:
+		return ErrHeaderAlreadyWritten
+	case stateComplete:
+		return ErrEncodingComplete
+	}
+
+	if err := writeHeader(e.writer, h, e.options); err != nil {
+		e.err = err
+		return err
+	}
+
+	e.state = stateHeaderWritten
+	return nil
+}
+
+// WriteRecord writes a single GEDCOM record. WriteHeader must have been called
+// before calling this method. This method can be called multiple times to write
+// multiple records.
+//
+// Returns ErrHeaderNotWritten if the header has not been written,
+// or ErrEncodingComplete if the encoding is already complete.
+func (e *StreamEncoder) WriteRecord(r *gedcom.Record) error {
+	if e.err != nil {
+		return e.err
+	}
+
+	switch e.state {
+	case stateInitial:
+		return ErrHeaderNotWritten
+	case stateHeaderWritten, stateRecordsWritten:
+		// Valid states, proceed
+	case stateComplete:
+		return ErrEncodingComplete
+	}
+
+	if err := writeRecord(e.writer, r, e.options); err != nil {
+		e.err = err
+		return err
+	}
+
+	e.state = stateRecordsWritten
+	return nil
+}
+
+// WriteTrailer writes the GEDCOM trailer (0 TRLR) to complete the document.
+// This must be called after WriteHeader and optionally after WriteRecord calls.
+//
+// Returns ErrHeaderNotWritten if the header has not been written,
+// or ErrTrailerAlreadyWritten if the trailer has already been written.
+func (e *StreamEncoder) WriteTrailer() error {
+	if e.err != nil {
+		return e.err
+	}
+
+	switch e.state {
+	case stateInitial:
+		return ErrHeaderNotWritten
+	case stateHeaderWritten, stateRecordsWritten:
+		// Valid states, proceed
+	case stateComplete:
+		return ErrTrailerAlreadyWritten
+	}
+
+	if err := writeTrailer(e.writer, e.options); err != nil {
+		e.err = err
+		return err
+	}
+
+	e.state = stateComplete
+	return nil
+}
+
+// Flush flushes any buffered data to the underlying writer.
+// This can be called at any time to ensure data is written.
+func (e *StreamEncoder) Flush() error {
+	if e.err != nil {
+		return e.err
+	}
+	if err := e.writer.Flush(); err != nil {
+		e.err = err
+		return err
+	}
+	return nil
+}
+
+// Close flushes any buffered data and marks the encoder as complete.
+// If the trailer has not been written, it returns ErrTrailerNotWritten
+// but still flushes any buffered data.
+//
+// After Close is called, no further writes are allowed.
+func (e *StreamEncoder) Close() error {
+	// Always flush, even if there's an error
+	flushErr := e.writer.Flush()
+
+	// If we already have a sticky error, return it
+	if e.err != nil {
+		return e.err
+	}
+
+	// If flush failed, record and return it
+	if flushErr != nil {
+		e.err = flushErr
+		return flushErr
+	}
+
+	// Check if trailer was written
+	if e.state != stateComplete {
+		e.err = ErrTrailerNotWritten
+		return ErrTrailerNotWritten
+	}
+
+	return nil
+}
+
+// State returns the current state of the encoder.
+// This is primarily useful for testing and debugging.
+func (e *StreamEncoder) State() string {
+	return e.state.String()
+}
+
+// Err returns any error that occurred during encoding.
+// Once an error occurs, the encoder stops accepting further writes.
+func (e *StreamEncoder) Err() error {
+	return e.err
+}
+
+// EncodeStreaming is a convenience function that streams a complete document.
+// It's equivalent to calling WriteHeader, WriteRecord for each record, and WriteTrailer.
+// This function exists mainly for API symmetry with the batch Encode function.
+func EncodeStreaming(w io.Writer, doc *gedcom.Document) error {
+	return EncodeStreamingWithOptions(w, doc, DefaultOptions())
+}
+
+// EncodeStreamingWithOptions is like EncodeStreaming but with custom options.
+func EncodeStreamingWithOptions(w io.Writer, doc *gedcom.Document, opts *EncodeOptions) error {
+	enc := NewStreamEncoderWithOptions(w, opts)
+
+	if err := enc.WriteHeader(doc.Header); err != nil {
+		return fmt.Errorf("write header: %w", err)
+	}
+
+	for i, record := range doc.Records {
+		if err := enc.WriteRecord(record); err != nil {
+			return fmt.Errorf("write record %d: %w", i, err)
+		}
+	}
+
+	if err := enc.WriteTrailer(); err != nil {
+		return fmt.Errorf("write trailer: %w", err)
+	}
+
+	if err := enc.Close(); err != nil {
+		return fmt.Errorf("close: %w", err)
+	}
+
+	return nil
+}

--- a/encoder/streaming_test.go
+++ b/encoder/streaming_test.go
@@ -1,0 +1,925 @@
+package encoder
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/cacack/gedcom-go/decoder"
+	"github.com/cacack/gedcom-go/gedcom"
+)
+
+func TestStreamEncoder_BasicFlow(t *testing.T) {
+	var buf bytes.Buffer
+	enc := NewStreamEncoder(&buf)
+
+	// Write header
+	header := &gedcom.Header{
+		Version:  "5.5.1",
+		Encoding: "UTF-8",
+	}
+	if err := enc.WriteHeader(header); err != nil {
+		t.Fatalf("WriteHeader() error = %v", err)
+	}
+	if enc.State() != "HeaderWritten" {
+		t.Errorf("State() = %v, want HeaderWritten", enc.State())
+	}
+
+	// Write records
+	record := &gedcom.Record{
+		XRef: "@I1@",
+		Type: gedcom.RecordTypeIndividual,
+		Tags: []*gedcom.Tag{
+			{Level: 1, Tag: "NAME", Value: "John /Smith/"},
+		},
+	}
+	if err := enc.WriteRecord(record); err != nil {
+		t.Fatalf("WriteRecord() error = %v", err)
+	}
+	if enc.State() != "RecordsWritten" {
+		t.Errorf("State() = %v, want RecordsWritten", enc.State())
+	}
+
+	// Write trailer
+	if err := enc.WriteTrailer(); err != nil {
+		t.Fatalf("WriteTrailer() error = %v", err)
+	}
+	if enc.State() != "Complete" {
+		t.Errorf("State() = %v, want Complete", enc.State())
+	}
+
+	// Close
+	if err := enc.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	// Verify output
+	output := buf.String()
+	expectedLines := []string{
+		"0 HEAD",
+		"1 GEDC",
+		"2 VERS 5.5.1",
+		"1 CHAR UTF-8",
+		"0 @I1@ INDI",
+		"1 NAME John /Smith/",
+		"0 TRLR",
+	}
+	for _, line := range expectedLines {
+		if !strings.Contains(output, line) {
+			t.Errorf("Output missing expected line: %q\nGot:\n%s", line, output)
+		}
+	}
+}
+
+func TestStreamEncoder_EmptyFile(t *testing.T) {
+	var buf bytes.Buffer
+	enc := NewStreamEncoder(&buf)
+
+	// Write header
+	if err := enc.WriteHeader(&gedcom.Header{Version: "5.5"}); err != nil {
+		t.Fatalf("WriteHeader() error = %v", err)
+	}
+
+	// Write trailer immediately (no records)
+	if err := enc.WriteTrailer(); err != nil {
+		t.Fatalf("WriteTrailer() error = %v", err)
+	}
+
+	if err := enc.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "0 HEAD") {
+		t.Error("Output should contain HEAD")
+	}
+	if !strings.Contains(output, "0 TRLR") {
+		t.Error("Output should contain TRLR")
+	}
+}
+
+func TestStreamEncoder_InvalidStateTransitions(t *testing.T) {
+	t.Run("WriteRecord before WriteHeader", func(t *testing.T) {
+		var buf bytes.Buffer
+		enc := NewStreamEncoder(&buf)
+
+		record := &gedcom.Record{XRef: "@I1@", Type: gedcom.RecordTypeIndividual}
+		err := enc.WriteRecord(record)
+		if !errors.Is(err, ErrHeaderNotWritten) {
+			t.Errorf("WriteRecord() error = %v, want ErrHeaderNotWritten", err)
+		}
+	})
+
+	t.Run("WriteHeader twice", func(t *testing.T) {
+		var buf bytes.Buffer
+		enc := NewStreamEncoder(&buf)
+
+		if err := enc.WriteHeader(&gedcom.Header{}); err != nil {
+			t.Fatalf("First WriteHeader() error = %v", err)
+		}
+
+		err := enc.WriteHeader(&gedcom.Header{})
+		if !errors.Is(err, ErrHeaderAlreadyWritten) {
+			t.Errorf("Second WriteHeader() error = %v, want ErrHeaderAlreadyWritten", err)
+		}
+	})
+
+	t.Run("WriteTrailer before WriteHeader", func(t *testing.T) {
+		var buf bytes.Buffer
+		enc := NewStreamEncoder(&buf)
+
+		err := enc.WriteTrailer()
+		if !errors.Is(err, ErrHeaderNotWritten) {
+			t.Errorf("WriteTrailer() error = %v, want ErrHeaderNotWritten", err)
+		}
+	})
+
+	t.Run("WriteTrailer twice", func(t *testing.T) {
+		var buf bytes.Buffer
+		enc := NewStreamEncoder(&buf)
+
+		enc.WriteHeader(&gedcom.Header{})
+		enc.WriteTrailer()
+
+		err := enc.WriteTrailer()
+		if !errors.Is(err, ErrTrailerAlreadyWritten) {
+			t.Errorf("Second WriteTrailer() error = %v, want ErrTrailerAlreadyWritten", err)
+		}
+	})
+
+	t.Run("WriteRecord after WriteTrailer", func(t *testing.T) {
+		var buf bytes.Buffer
+		enc := NewStreamEncoder(&buf)
+
+		enc.WriteHeader(&gedcom.Header{})
+		enc.WriteTrailer()
+
+		record := &gedcom.Record{XRef: "@I1@", Type: gedcom.RecordTypeIndividual}
+		err := enc.WriteRecord(record)
+		if !errors.Is(err, ErrEncodingComplete) {
+			t.Errorf("WriteRecord() error = %v, want ErrEncodingComplete", err)
+		}
+	})
+
+	t.Run("WriteHeader after WriteTrailer", func(t *testing.T) {
+		var buf bytes.Buffer
+		enc := NewStreamEncoder(&buf)
+
+		enc.WriteHeader(&gedcom.Header{})
+		enc.WriteTrailer()
+
+		err := enc.WriteHeader(&gedcom.Header{})
+		if !errors.Is(err, ErrEncodingComplete) {
+			t.Errorf("WriteHeader() error = %v, want ErrEncodingComplete", err)
+		}
+	})
+
+	t.Run("WriteHeader after records written", func(t *testing.T) {
+		var buf bytes.Buffer
+		enc := NewStreamEncoder(&buf)
+
+		enc.WriteHeader(&gedcom.Header{})
+		enc.WriteRecord(&gedcom.Record{XRef: "@I1@", Type: gedcom.RecordTypeIndividual})
+
+		err := enc.WriteHeader(&gedcom.Header{})
+		if !errors.Is(err, ErrHeaderAlreadyWritten) {
+			t.Errorf("WriteHeader() error = %v, want ErrHeaderAlreadyWritten", err)
+		}
+	})
+}
+
+func TestStreamEncoder_CloseWithoutTrailer(t *testing.T) {
+	var buf bytes.Buffer
+	enc := NewStreamEncoder(&buf)
+
+	enc.WriteHeader(&gedcom.Header{})
+
+	err := enc.Close()
+	if !errors.Is(err, ErrTrailerNotWritten) {
+		t.Errorf("Close() error = %v, want ErrTrailerNotWritten", err)
+	}
+}
+
+func TestStreamEncoder_OutputEquivalence(t *testing.T) {
+	// Create a test document
+	doc := &gedcom.Document{
+		Header: &gedcom.Header{
+			Version:      "5.5.1",
+			Encoding:     "UTF-8",
+			SourceSystem: "TestApp",
+			Language:     "English",
+		},
+		Records: []*gedcom.Record{
+			{
+				XRef: "@I1@",
+				Type: gedcom.RecordTypeIndividual,
+				Tags: []*gedcom.Tag{
+					{Level: 1, Tag: "NAME", Value: "John /Smith/"},
+					{Level: 2, Tag: "GIVN", Value: "John"},
+					{Level: 2, Tag: "SURN", Value: "Smith"},
+					{Level: 1, Tag: "SEX", Value: "M"},
+					{Level: 1, Tag: "BIRT"},
+					{Level: 2, Tag: "DATE", Value: "1 JAN 1950"},
+					{Level: 2, Tag: "PLAC", Value: "Boston, MA"},
+				},
+			},
+			{
+				XRef: "@I2@",
+				Type: gedcom.RecordTypeIndividual,
+				Tags: []*gedcom.Tag{
+					{Level: 1, Tag: "NAME", Value: "Jane /Doe/"},
+					{Level: 1, Tag: "SEX", Value: "F"},
+				},
+			},
+			{
+				XRef: "@F1@",
+				Type: gedcom.RecordTypeFamily,
+				Tags: []*gedcom.Tag{
+					{Level: 1, Tag: "HUSB", Value: "@I1@"},
+					{Level: 1, Tag: "WIFE", Value: "@I2@"},
+				},
+			},
+		},
+	}
+
+	// Encode with batch encoder
+	var batchBuf bytes.Buffer
+	if err := Encode(&batchBuf, doc); err != nil {
+		t.Fatalf("Batch Encode() error = %v", err)
+	}
+
+	// Encode with streaming encoder
+	var streamBuf bytes.Buffer
+	enc := NewStreamEncoder(&streamBuf)
+	if err := enc.WriteHeader(doc.Header); err != nil {
+		t.Fatalf("WriteHeader() error = %v", err)
+	}
+	for _, r := range doc.Records {
+		if err := enc.WriteRecord(r); err != nil {
+			t.Fatalf("WriteRecord() error = %v", err)
+		}
+	}
+	if err := enc.WriteTrailer(); err != nil {
+		t.Fatalf("WriteTrailer() error = %v", err)
+	}
+	if err := enc.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	// Compare outputs - they should be byte-for-byte identical
+	if batchBuf.String() != streamBuf.String() {
+		t.Errorf("Streaming output differs from batch output.\nBatch:\n%s\nStreaming:\n%s",
+			batchBuf.String(), streamBuf.String())
+	}
+}
+
+func TestStreamEncoder_WithOptions(t *testing.T) {
+	t.Run("CRLF line endings", func(t *testing.T) {
+		var buf bytes.Buffer
+		opts := &EncodeOptions{
+			LineEnding: "\r\n",
+		}
+		enc := NewStreamEncoderWithOptions(&buf, opts)
+
+		enc.WriteHeader(&gedcom.Header{Version: "5.5"})
+		enc.WriteTrailer()
+		enc.Close()
+
+		output := buf.String()
+		if !strings.Contains(output, "\r\n") {
+			t.Error("Output should contain CRLF line endings")
+		}
+		// Verify we don't have bare LF (which would show as double newline if CRLF is also present)
+		// Every \n should be preceded by \r
+		lines := strings.Split(output, "\r\n")
+		for i, line := range lines[:len(lines)-1] { // All but last (empty after final \r\n)
+			if strings.Contains(line, "\n") {
+				t.Errorf("Line %d contains bare LF: %q", i, line)
+			}
+		}
+	})
+
+	t.Run("nil options uses defaults", func(t *testing.T) {
+		var buf bytes.Buffer
+		enc := NewStreamEncoderWithOptions(&buf, nil)
+
+		enc.WriteHeader(&gedcom.Header{Version: "5.5"})
+		enc.WriteTrailer()
+		enc.Close()
+
+		output := buf.String()
+		if !strings.Contains(output, "\n") {
+			t.Error("Output should contain LF line endings (default)")
+		}
+	})
+}
+
+func TestStreamEncoder_Flush(t *testing.T) {
+	var buf bytes.Buffer
+	enc := NewStreamEncoder(&buf)
+
+	enc.WriteHeader(&gedcom.Header{Version: "5.5"})
+
+	// Flush explicitly
+	if err := enc.Flush(); err != nil {
+		t.Fatalf("Flush() error = %v", err)
+	}
+
+	// Buffer should have content now
+	if buf.Len() == 0 {
+		t.Error("Buffer should have content after Flush()")
+	}
+
+	enc.WriteTrailer()
+	enc.Close()
+}
+
+func TestStreamEncoder_MultipleRecords(t *testing.T) {
+	var buf bytes.Buffer
+	enc := NewStreamEncoder(&buf)
+
+	enc.WriteHeader(&gedcom.Header{Version: "5.5"})
+
+	// Write multiple records
+	for i := 1; i <= 5; i++ {
+		xref := "@I" + string(rune('0'+i)) + "@"
+		record := &gedcom.Record{
+			XRef: xref,
+			Type: gedcom.RecordTypeIndividual,
+			Tags: []*gedcom.Tag{
+				{Level: 1, Tag: "NAME", Value: "Person " + string(rune('A'+i-1))},
+			},
+		}
+		if err := enc.WriteRecord(record); err != nil {
+			t.Fatalf("WriteRecord(%d) error = %v", i, err)
+		}
+	}
+
+	enc.WriteTrailer()
+	enc.Close()
+
+	output := buf.String()
+	for i := 1; i <= 5; i++ {
+		xref := "@I" + string(rune('0'+i)) + "@"
+		if !strings.Contains(output, "0 "+xref+" INDI") {
+			t.Errorf("Output missing record %s", xref)
+		}
+	}
+}
+
+func TestStreamEncoder_RoundTrip(t *testing.T) {
+	// Create a complex document using streaming encoder
+	var buf bytes.Buffer
+	enc := NewStreamEncoder(&buf)
+
+	header := &gedcom.Header{
+		Version:      "5.5.1",
+		Encoding:     "UTF-8",
+		SourceSystem: "StreamTest",
+	}
+	enc.WriteHeader(header)
+
+	// Write individual
+	enc.WriteRecord(&gedcom.Record{
+		XRef: "@I1@",
+		Type: gedcom.RecordTypeIndividual,
+		Tags: []*gedcom.Tag{
+			{Level: 1, Tag: "NAME", Value: "John /Smith/"},
+			{Level: 2, Tag: "GIVN", Value: "John"},
+			{Level: 2, Tag: "SURN", Value: "Smith"},
+			{Level: 1, Tag: "SEX", Value: "M"},
+			{Level: 1, Tag: "BIRT"},
+			{Level: 2, Tag: "DATE", Value: "1 JAN 1950"},
+		},
+	})
+
+	// Write family
+	enc.WriteRecord(&gedcom.Record{
+		XRef: "@F1@",
+		Type: gedcom.RecordTypeFamily,
+		Tags: []*gedcom.Tag{
+			{Level: 1, Tag: "HUSB", Value: "@I1@"},
+		},
+	})
+
+	enc.WriteTrailer()
+	enc.Close()
+
+	// Decode and verify
+	doc, err := decoder.Decode(strings.NewReader(buf.String()))
+	if err != nil {
+		t.Fatalf("Failed to decode streamed output: %v", err)
+	}
+
+	if len(doc.Records) != 2 {
+		t.Errorf("Record count = %d, want 2", len(doc.Records))
+	}
+
+	indi := doc.GetIndividual("@I1@")
+	if indi == nil {
+		t.Fatal("Individual @I1@ not found")
+	}
+	if indi.Sex != "M" {
+		t.Errorf("Individual sex = %q, want %q", indi.Sex, "M")
+	}
+}
+
+// streamFailWriter is a writer that fails after writing a certain number of bytes
+type streamFailWriter struct {
+	failAfterBytes int
+	bytesWritten   int
+}
+
+func (w *streamFailWriter) Write(p []byte) (n int, err error) {
+	if w.bytesWritten >= w.failAfterBytes {
+		return 0, errors.New("simulated write error")
+	}
+	// Write some bytes but may fail mid-write
+	toWrite := len(p)
+	remaining := w.failAfterBytes - w.bytesWritten
+	if toWrite > remaining {
+		toWrite = remaining
+		w.bytesWritten += toWrite
+		return toWrite, errors.New("simulated write error")
+	}
+	w.bytesWritten += toWrite
+	return toWrite, nil
+}
+
+func TestStreamEncoder_WriteErrors(t *testing.T) {
+	t.Run("error during flush propagates", func(t *testing.T) {
+		// Create a writer that fails after some bytes
+		// The buffered writer won't immediately write, so we need to flush
+		w := &streamFailWriter{failAfterBytes: 10}
+		enc := NewStreamEncoder(w)
+
+		// Write header - this goes to buffer first
+		enc.WriteHeader(&gedcom.Header{Version: "5.5"})
+		enc.WriteTrailer()
+
+		// Flush should fail because underlying writer fails
+		err := enc.Flush()
+		if err == nil {
+			// Try Close which also flushes
+			err = enc.Close()
+		}
+
+		// At some point we should get an error
+		if enc.Err() == nil && err == nil {
+			// The buffer might be large enough to hold all data
+			// In that case, only the final flush would fail
+			t.Log("All writes succeeded - buffer was large enough")
+		}
+	})
+
+	t.Run("error on Flush with small buffer triggers error", func(t *testing.T) {
+		// Writer that immediately fails
+		w := &streamFailWriter{failAfterBytes: 0}
+		enc := NewStreamEncoder(w)
+
+		enc.WriteHeader(&gedcom.Header{Version: "5.5"})
+
+		// Force flush to trigger the error
+		err := enc.Flush()
+		if err == nil {
+			t.Error("Flush() should fail when underlying writer fails")
+		}
+
+		// Subsequent flush should return sticky error
+		if enc.Err() == nil {
+			t.Error("Err() should return the error after failed Flush()")
+		}
+	})
+
+	t.Run("error is sticky after failed operation", func(t *testing.T) {
+		w := &streamFailWriter{failAfterBytes: 0}
+		enc := NewStreamEncoder(w)
+
+		enc.WriteHeader(&gedcom.Header{})
+		enc.Flush() // This triggers the error
+
+		// Subsequent operations should fail with sticky error
+		if enc.Err() != nil {
+			err := enc.WriteTrailer()
+			if err == nil {
+				t.Error("WriteTrailer should fail after sticky error")
+			}
+		}
+	})
+
+	t.Run("WriteHeader with sticky error", func(t *testing.T) {
+		w := &streamFailWriter{failAfterBytes: 0}
+		enc := NewStreamEncoder(w)
+
+		enc.WriteHeader(&gedcom.Header{})
+		enc.Flush() // Triggers sticky error
+
+		// WriteHeader should return the sticky error
+		err := enc.WriteHeader(&gedcom.Header{})
+		if err == nil {
+			t.Error("WriteHeader should fail with sticky error")
+		}
+	})
+
+	t.Run("WriteRecord with sticky error", func(t *testing.T) {
+		w := &streamFailWriter{failAfterBytes: 0}
+		enc := NewStreamEncoder(w)
+
+		enc.WriteHeader(&gedcom.Header{})
+		enc.Flush() // Triggers sticky error
+
+		// WriteRecord should return the sticky error
+		record := &gedcom.Record{XRef: "@I1@", Type: gedcom.RecordTypeIndividual}
+		err := enc.WriteRecord(record)
+		if err == nil {
+			t.Error("WriteRecord should fail with sticky error")
+		}
+	})
+
+	t.Run("Close with sticky error", func(t *testing.T) {
+		w := &streamFailWriter{failAfterBytes: 0}
+		enc := NewStreamEncoder(w)
+
+		enc.WriteHeader(&gedcom.Header{})
+		enc.Flush() // Triggers sticky error
+
+		// Close should return the sticky error
+		err := enc.Close()
+		if err == nil {
+			t.Error("Close should fail with sticky error")
+		}
+	})
+
+}
+
+func TestStreamEncoder_Err(t *testing.T) {
+	var buf bytes.Buffer
+	enc := NewStreamEncoder(&buf)
+
+	// Initially no error
+	if enc.Err() != nil {
+		t.Error("Err() should be nil initially")
+	}
+
+	enc.WriteHeader(&gedcom.Header{})
+	enc.WriteTrailer()
+	enc.Close()
+
+	// Still no error after successful operation
+	if enc.Err() != nil {
+		t.Errorf("Err() = %v, want nil after successful operation", enc.Err())
+	}
+}
+
+func TestEncodeStreaming(t *testing.T) {
+	doc := &gedcom.Document{
+		Header: &gedcom.Header{
+			Version:  "5.5.1",
+			Encoding: "UTF-8",
+		},
+		Records: []*gedcom.Record{
+			{
+				XRef: "@I1@",
+				Type: gedcom.RecordTypeIndividual,
+				Tags: []*gedcom.Tag{
+					{Level: 1, Tag: "NAME", Value: "Test /Person/"},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := EncodeStreaming(&buf, doc); err != nil {
+		t.Fatalf("EncodeStreaming() error = %v", err)
+	}
+
+	output := buf.String()
+	expectedLines := []string{
+		"0 HEAD",
+		"0 @I1@ INDI",
+		"1 NAME Test /Person/",
+		"0 TRLR",
+	}
+	for _, line := range expectedLines {
+		if !strings.Contains(output, line) {
+			t.Errorf("Output missing expected line: %q", line)
+		}
+	}
+}
+
+func TestEncodeStreamingWithOptions(t *testing.T) {
+	doc := &gedcom.Document{
+		Header:  &gedcom.Header{Version: "5.5"},
+		Records: []*gedcom.Record{},
+	}
+
+	var buf bytes.Buffer
+	opts := &EncodeOptions{LineEnding: "\r\n"}
+	if err := EncodeStreamingWithOptions(&buf, doc, opts); err != nil {
+		t.Fatalf("EncodeStreamingWithOptions() error = %v", err)
+	}
+
+	if !strings.Contains(buf.String(), "\r\n") {
+		t.Error("Output should contain CRLF line endings")
+	}
+}
+
+func TestEncodeStreamingWithOptions_Errors(t *testing.T) {
+	t.Run("writer fails during encoding", func(t *testing.T) {
+		// Writer that fails immediately - error will be caught during close/flush
+		w := &streamFailWriter{failAfterBytes: 0}
+		doc := &gedcom.Document{
+			Header:  &gedcom.Header{Version: "5.5"},
+			Records: []*gedcom.Record{},
+		}
+
+		err := EncodeStreamingWithOptions(w, doc, DefaultOptions())
+		if err == nil {
+			t.Error("EncodeStreamingWithOptions should fail when writer fails")
+		}
+	})
+
+	t.Run("writer fails with records", func(t *testing.T) {
+		// Writer that allows some bytes but fails during output
+		w := &streamFailWriter{failAfterBytes: 50}
+		doc := &gedcom.Document{
+			Header: &gedcom.Header{Version: "5.5"},
+			Records: []*gedcom.Record{
+				{
+					XRef: "@I1@",
+					Type: gedcom.RecordTypeIndividual,
+					Tags: []*gedcom.Tag{
+						{Level: 1, Tag: "NAME", Value: "Test /Person/"},
+					},
+				},
+			},
+		}
+
+		err := EncodeStreamingWithOptions(w, doc, DefaultOptions())
+		if err == nil {
+			t.Error("EncodeStreamingWithOptions should fail when writer fails")
+		}
+	})
+}
+
+func TestEncodeState_String(t *testing.T) {
+	tests := []struct {
+		state encodeState
+		want  string
+	}{
+		{stateInitial, "Initial"},
+		{stateHeaderWritten, "HeaderWritten"},
+		{stateRecordsWritten, "RecordsWritten"},
+		{stateComplete, "Complete"},
+		{encodeState(99), "Unknown"},
+	}
+
+	for _, tt := range tests {
+		if got := tt.state.String(); got != tt.want {
+			t.Errorf("encodeState(%d).String() = %q, want %q", tt.state, got, tt.want)
+		}
+	}
+}
+
+// TestStreamEncoder_EntityToTags verifies that entities without tags are properly converted
+func TestStreamEncoder_EntityToTags(t *testing.T) {
+	var buf bytes.Buffer
+	enc := NewStreamEncoder(&buf)
+
+	enc.WriteHeader(&gedcom.Header{Version: "5.5.1", Encoding: "UTF-8"})
+
+	// Write record with Entity but no Tags
+	enc.WriteRecord(&gedcom.Record{
+		XRef: "@I1@",
+		Type: gedcom.RecordTypeIndividual,
+		Tags: nil,
+		Entity: &gedcom.Individual{
+			XRef: "@I1@",
+			Names: []*gedcom.PersonalName{
+				{Full: "John /Smith/", Given: "John", Surname: "Smith"},
+			},
+			Sex: "M",
+		},
+	})
+
+	enc.WriteTrailer()
+	enc.Close()
+
+	output := buf.String()
+
+	// Verify entity was converted to tags
+	expectedPatterns := []string{
+		"0 @I1@ INDI",
+		"1 NAME John /Smith/",
+		"2 GIVN John",
+		"2 SURN Smith",
+		"1 SEX M",
+	}
+	for _, pattern := range expectedPatterns {
+		if !strings.Contains(output, pattern) {
+			t.Errorf("Output missing expected pattern: %q\nGot:\n%s", pattern, output)
+		}
+	}
+}
+
+// Benchmark for memory usage verification
+func BenchmarkStreamEncoder_LargeFile(b *testing.B) {
+	// This benchmark verifies constant memory usage
+	// The streaming encoder should use the same amount of memory
+	// regardless of how many records are written
+
+	header := &gedcom.Header{Version: "5.5.1", Encoding: "UTF-8"}
+	record := &gedcom.Record{
+		XRef: "@I1@",
+		Type: gedcom.RecordTypeIndividual,
+		Tags: []*gedcom.Tag{
+			{Level: 1, Tag: "NAME", Value: "Test /Person/"},
+			{Level: 2, Tag: "GIVN", Value: "Test"},
+			{Level: 2, Tag: "SURN", Value: "Person"},
+			{Level: 1, Tag: "SEX", Value: "M"},
+			{Level: 1, Tag: "BIRT"},
+			{Level: 2, Tag: "DATE", Value: "1 JAN 1950"},
+			{Level: 2, Tag: "PLAC", Value: "Boston, Massachusetts, USA"},
+		},
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		var buf bytes.Buffer
+		enc := NewStreamEncoder(&buf)
+
+		enc.WriteHeader(header)
+
+		// Write 1000 records
+		for j := 0; j < 1000; j++ {
+			enc.WriteRecord(record)
+		}
+
+		enc.WriteTrailer()
+		enc.Close()
+	}
+}
+
+// Test that streaming encoder handles all record types
+func TestStreamEncoder_AllRecordTypes(t *testing.T) {
+	var buf bytes.Buffer
+	enc := NewStreamEncoder(&buf)
+
+	enc.WriteHeader(&gedcom.Header{Version: "5.5.1", Encoding: "UTF-8"})
+
+	// Individual
+	enc.WriteRecord(&gedcom.Record{
+		XRef: "@I1@",
+		Type: gedcom.RecordTypeIndividual,
+		Tags: []*gedcom.Tag{{Level: 1, Tag: "NAME", Value: "Test /Person/"}},
+	})
+
+	// Family
+	enc.WriteRecord(&gedcom.Record{
+		XRef: "@F1@",
+		Type: gedcom.RecordTypeFamily,
+		Tags: []*gedcom.Tag{{Level: 1, Tag: "HUSB", Value: "@I1@"}},
+	})
+
+	// Source
+	enc.WriteRecord(&gedcom.Record{
+		XRef: "@S1@",
+		Type: gedcom.RecordTypeSource,
+		Tags: []*gedcom.Tag{{Level: 1, Tag: "TITL", Value: "Test Source"}},
+	})
+
+	// Repository
+	enc.WriteRecord(&gedcom.Record{
+		XRef: "@R1@",
+		Type: gedcom.RecordTypeRepository,
+		Tags: []*gedcom.Tag{{Level: 1, Tag: "NAME", Value: "Test Repository"}},
+	})
+
+	// Submitter
+	enc.WriteRecord(&gedcom.Record{
+		XRef: "@SUBM1@",
+		Type: gedcom.RecordTypeSubmitter,
+		Tags: []*gedcom.Tag{{Level: 1, Tag: "NAME", Value: "Test Submitter"}},
+	})
+
+	// Note
+	enc.WriteRecord(&gedcom.Record{
+		XRef: "@N1@",
+		Type: gedcom.RecordTypeNote,
+		Tags: []*gedcom.Tag{{Level: 1, Tag: "CONT", Value: "Test note content"}},
+	})
+
+	// Media
+	enc.WriteRecord(&gedcom.Record{
+		XRef: "@O1@",
+		Type: gedcom.RecordTypeMedia,
+		Tags: []*gedcom.Tag{{Level: 1, Tag: "FILE", Value: "photo.jpg"}},
+	})
+
+	enc.WriteTrailer()
+	enc.Close()
+
+	output := buf.String()
+
+	// Verify all record types are present
+	expectedPatterns := []string{
+		"0 @I1@ INDI",
+		"0 @F1@ FAM",
+		"0 @S1@ SOUR",
+		"0 @R1@ REPO",
+		"0 @SUBM1@ SUBM",
+		"0 @N1@ NOTE",
+		"0 @O1@ OBJE",
+	}
+	for _, pattern := range expectedPatterns {
+		if !strings.Contains(output, pattern) {
+			t.Errorf("Output missing expected pattern: %q", pattern)
+		}
+	}
+
+	// Verify it's valid GEDCOM
+	doc, err := decoder.Decode(strings.NewReader(output))
+	if err != nil {
+		t.Fatalf("Failed to decode output: %v", err)
+	}
+	if len(doc.Records) != 7 {
+		t.Errorf("Record count = %d, want 7", len(doc.Records))
+	}
+}
+
+// Test that output from streaming matches output from batch for a complex document
+func TestStreamEncoder_ComplexDocumentEquivalence(t *testing.T) {
+	input := `0 HEAD
+1 GEDC
+2 VERS 5.5.1
+1 CHAR UTF-8
+1 SOUR TestApp
+0 @I1@ INDI
+1 NAME John /Doe/
+2 GIVN John
+2 SURN Doe
+1 SEX M
+1 BIRT
+2 DATE 1 JAN 1950
+2 PLAC Boston, MA
+1 FAMC @F1@
+0 @I2@ INDI
+1 NAME Jane /Smith/
+1 SEX F
+1 FAMS @F2@
+0 @F1@ FAM
+1 HUSB @I3@
+1 WIFE @I4@
+1 CHIL @I1@
+0 @F2@ FAM
+1 HUSB @I1@
+1 WIFE @I2@
+1 MARR
+2 DATE 15 JUN 1975
+0 @S1@ SOUR
+1 TITL County Records
+1 AUTH Local Historian
+0 TRLR
+`
+
+	// Decode the input
+	doc, err := decoder.Decode(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("Failed to decode input: %v", err)
+	}
+
+	// Encode with batch encoder
+	var batchBuf bytes.Buffer
+	if err := Encode(&batchBuf, doc); err != nil {
+		t.Fatalf("Batch Encode() error = %v", err)
+	}
+
+	// Encode with streaming encoder
+	var streamBuf bytes.Buffer
+	enc := NewStreamEncoder(&streamBuf)
+	enc.WriteHeader(doc.Header)
+	for _, r := range doc.Records {
+		enc.WriteRecord(r)
+	}
+	enc.WriteTrailer()
+	enc.Close()
+
+	// Compare outputs
+	if batchBuf.String() != streamBuf.String() {
+		t.Errorf("Streaming output differs from batch output.\nBatch length: %d\nStreaming length: %d",
+			batchBuf.Len(), streamBuf.Len())
+		// Show first difference
+		batchLines := strings.Split(batchBuf.String(), "\n")
+		streamLines := strings.Split(streamBuf.String(), "\n")
+		for i := 0; i < len(batchLines) && i < len(streamLines); i++ {
+			if batchLines[i] != streamLines[i] {
+				t.Errorf("First difference at line %d:\nBatch:  %q\nStream: %q",
+					i+1, batchLines[i], streamLines[i])
+				break
+			}
+		}
+	}
+}

--- a/parser/index.go
+++ b/parser/index.go
@@ -1,0 +1,195 @@
+package parser
+
+import (
+	"encoding/gob"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// IndexEntry represents a single record's location in a GEDCOM file.
+type IndexEntry struct {
+	// XRef is the cross-reference identifier (e.g., "@I1@")
+	// Empty for records without XRefs (like HEAD, TRLR)
+	XRef string
+
+	// Type is the record type tag (e.g., "INDI", "FAM", "HEAD")
+	Type string
+
+	// ByteOffset is the starting byte position of this record in the file
+	ByteOffset int64
+
+	// ByteLength is the total number of bytes for this record
+	ByteLength int64
+}
+
+// IndexVersion is the current version of the index format.
+// Increment when making incompatible changes to the index structure.
+const IndexVersion byte = 1
+
+// RecordIndex provides O(1) lookup of records by XRef after an O(n) build phase.
+// The index maps XRef strings to their byte offsets in the original file.
+type RecordIndex struct {
+	// entries maps XRef to IndexEntry for records with XRefs
+	entries map[string]IndexEntry
+
+	// typeEntries maps record types to entries for records without XRefs
+	// Key format: "TYPE" (e.g., "HEAD", "TRLR")
+	typeEntries map[string]IndexEntry
+
+	// encoding is the detected character encoding of the indexed file
+	encoding string
+
+	// version is the index format version
+	version byte
+}
+
+// NewRecordIndex creates an empty RecordIndex.
+func NewRecordIndex() *RecordIndex {
+	return &RecordIndex{
+		entries:     make(map[string]IndexEntry),
+		typeEntries: make(map[string]IndexEntry),
+		version:     IndexVersion,
+	}
+}
+
+// BuildIndex builds an index by scanning the entire file once.
+// The reader should be positioned at the start of the file.
+// After building, the reader position is at EOF.
+func BuildIndex(r io.Reader) (*RecordIndex, error) {
+	idx := NewRecordIndex()
+
+	it := NewRecordIteratorWithOffset(r)
+	for it.Next() {
+		rec := it.Record()
+		entry := IndexEntry{
+			XRef:       rec.XRef,
+			Type:       rec.Type,
+			ByteOffset: rec.ByteOffset,
+			ByteLength: rec.ByteLength,
+		}
+
+		if rec.XRef != "" {
+			idx.entries[rec.XRef] = entry
+		} else {
+			// For records without XRef (HEAD, TRLR), index by type
+			idx.typeEntries[rec.Type] = entry
+		}
+	}
+
+	if err := it.Err(); err != nil {
+		return nil, fmt.Errorf("building index: %w", err)
+	}
+
+	return idx, nil
+}
+
+// Lookup returns the index entry for a given XRef.
+// Returns the entry and true if found, or zero entry and false if not found.
+func (idx *RecordIndex) Lookup(xref string) (IndexEntry, bool) {
+	entry, ok := idx.entries[xref]
+	return entry, ok
+}
+
+// LookupByType returns the index entry for a record type without XRef.
+// This is useful for finding HEAD or TRLR records.
+// Returns the entry and true if found, or zero entry and false if not found.
+func (idx *RecordIndex) LookupByType(recordType string) (IndexEntry, bool) {
+	entry, ok := idx.typeEntries[recordType]
+	return entry, ok
+}
+
+// XRefs returns all XRefs in the index.
+func (idx *RecordIndex) XRefs() []string {
+	xrefs := make([]string, 0, len(idx.entries))
+	for xref := range idx.entries {
+		xrefs = append(xrefs, xref)
+	}
+	return xrefs
+}
+
+// Types returns all record types without XRefs in the index.
+func (idx *RecordIndex) Types() []string {
+	types := make([]string, 0, len(idx.typeEntries))
+	for t := range idx.typeEntries {
+		types = append(types, t)
+	}
+	return types
+}
+
+// Len returns the total number of indexed entries (both XRef and type-based).
+func (idx *RecordIndex) Len() int {
+	return len(idx.entries) + len(idx.typeEntries)
+}
+
+// SetEncoding sets the encoding string for this index.
+// This should be set during index building to record the detected encoding.
+func (idx *RecordIndex) SetEncoding(enc string) {
+	idx.encoding = enc
+}
+
+// Encoding returns the encoding that was detected when the index was built.
+func (idx *RecordIndex) Encoding() string {
+	return idx.encoding
+}
+
+// indexData is the serializable form of RecordIndex for gob encoding.
+type indexData struct {
+	Version     byte
+	Encoding    string
+	Entries     map[string]IndexEntry
+	TypeEntries map[string]IndexEntry
+}
+
+// Save writes the index to the given writer in gob format.
+// The format includes a version byte for future compatibility.
+func (idx *RecordIndex) Save(w io.Writer) error {
+	data := indexData{
+		Version:     idx.version,
+		Encoding:    idx.encoding,
+		Entries:     idx.entries,
+		TypeEntries: idx.typeEntries,
+	}
+
+	enc := gob.NewEncoder(w)
+	if err := enc.Encode(data); err != nil {
+		return fmt.Errorf("encoding index: %w", err)
+	}
+
+	return nil
+}
+
+// ErrIndexVersionMismatch is returned when loading an index with an incompatible version.
+var ErrIndexVersionMismatch = errors.New("index version mismatch")
+
+// LoadIndex reads an index from the given reader.
+// Returns an error if the index version is incompatible.
+func LoadIndex(r io.Reader) (*RecordIndex, error) {
+	var data indexData
+
+	dec := gob.NewDecoder(r)
+	if err := dec.Decode(&data); err != nil {
+		return nil, fmt.Errorf("decoding index: %w", err)
+	}
+
+	if data.Version != IndexVersion {
+		return nil, fmt.Errorf("%w: got %d, want %d", ErrIndexVersionMismatch, data.Version, IndexVersion)
+	}
+
+	idx := &RecordIndex{
+		version:     data.Version,
+		encoding:    data.Encoding,
+		entries:     data.Entries,
+		typeEntries: data.TypeEntries,
+	}
+
+	// Ensure maps are initialized even if empty
+	if idx.entries == nil {
+		idx.entries = make(map[string]IndexEntry)
+	}
+	if idx.typeEntries == nil {
+		idx.typeEntries = make(map[string]IndexEntry)
+	}
+
+	return idx, nil
+}

--- a/parser/index_test.go
+++ b/parser/index_test.go
@@ -1,0 +1,406 @@
+package parser
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestBuildIndex_Basic(t *testing.T) {
+	input := `0 HEAD
+1 SOUR TestSystem
+0 @I1@ INDI
+1 NAME John /Doe/
+0 @I2@ INDI
+1 NAME Jane /Doe/
+0 @F1@ FAM
+1 HUSB @I1@
+1 WIFE @I2@
+0 TRLR`
+
+	idx, err := BuildIndex(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("BuildIndex error: %v", err)
+	}
+
+	// Should have 3 XRef entries
+	if len(idx.entries) != 3 {
+		t.Errorf("Got %d XRef entries, want 3", len(idx.entries))
+	}
+
+	// Should have 2 type entries (HEAD, TRLR)
+	if len(idx.typeEntries) != 2 {
+		t.Errorf("Got %d type entries, want 2", len(idx.typeEntries))
+	}
+}
+
+func TestRecordIndex_Lookup(t *testing.T) {
+	input := `0 HEAD
+1 SOUR Test
+0 @I1@ INDI
+1 NAME John /Doe/
+0 @I2@ INDI
+1 NAME Jane /Doe/
+0 TRLR`
+
+	idx, err := BuildIndex(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("BuildIndex error: %v", err)
+	}
+
+	// Lookup existing XRef
+	entry, ok := idx.Lookup("@I1@")
+	if !ok {
+		t.Error("Expected to find @I1@")
+	}
+	if entry.XRef != "@I1@" {
+		t.Errorf("Entry XRef = %q, want @I1@", entry.XRef)
+	}
+	if entry.Type != "INDI" {
+		t.Errorf("Entry Type = %q, want INDI", entry.Type)
+	}
+
+	// Lookup another XRef
+	entry, ok = idx.Lookup("@I2@")
+	if !ok {
+		t.Error("Expected to find @I2@")
+	}
+	if entry.Type != "INDI" {
+		t.Errorf("Entry Type = %q, want INDI", entry.Type)
+	}
+
+	// Lookup non-existent XRef
+	_, ok = idx.Lookup("@I999@")
+	if ok {
+		t.Error("Should not find @I999@")
+	}
+}
+
+func TestRecordIndex_LookupByType(t *testing.T) {
+	input := `0 HEAD
+1 SOUR Test
+0 @I1@ INDI
+1 NAME John
+0 TRLR`
+
+	idx, err := BuildIndex(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("BuildIndex error: %v", err)
+	}
+
+	// Lookup HEAD
+	entry, ok := idx.LookupByType("HEAD")
+	if !ok {
+		t.Error("Expected to find HEAD")
+	}
+	if entry.Type != "HEAD" {
+		t.Errorf("Entry Type = %q, want HEAD", entry.Type)
+	}
+	if entry.ByteOffset != 0 {
+		t.Errorf("HEAD ByteOffset = %d, want 0", entry.ByteOffset)
+	}
+
+	// Lookup TRLR
+	entry, ok = idx.LookupByType("TRLR")
+	if !ok {
+		t.Error("Expected to find TRLR")
+	}
+	if entry.Type != "TRLR" {
+		t.Errorf("Entry Type = %q, want TRLR", entry.Type)
+	}
+
+	// INDI has XRef, so shouldn't be in typeEntries
+	_, ok = idx.LookupByType("INDI")
+	if ok {
+		t.Error("INDI should not be in type entries (it has XRef)")
+	}
+}
+
+func TestRecordIndex_XRefs(t *testing.T) {
+	input := `0 HEAD
+0 @I1@ INDI
+0 @F1@ FAM
+0 @S1@ SOUR
+0 TRLR`
+
+	idx, err := BuildIndex(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("BuildIndex error: %v", err)
+	}
+
+	xrefs := idx.XRefs()
+	if len(xrefs) != 3 {
+		t.Errorf("Got %d XRefs, want 3", len(xrefs))
+	}
+
+	// Check all expected XRefs are present
+	xrefMap := make(map[string]bool)
+	for _, x := range xrefs {
+		xrefMap[x] = true
+	}
+
+	for _, expected := range []string{"@I1@", "@F1@", "@S1@"} {
+		if !xrefMap[expected] {
+			t.Errorf("XRefs missing %s", expected)
+		}
+	}
+}
+
+func TestRecordIndex_Types(t *testing.T) {
+	input := `0 HEAD
+0 @I1@ INDI
+0 TRLR`
+
+	idx, err := BuildIndex(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("BuildIndex error: %v", err)
+	}
+
+	types := idx.Types()
+	if len(types) != 2 {
+		t.Errorf("Got %d types, want 2", len(types))
+	}
+
+	typeMap := make(map[string]bool)
+	for _, ty := range types {
+		typeMap[ty] = true
+	}
+
+	if !typeMap["HEAD"] {
+		t.Error("Types missing HEAD")
+	}
+	if !typeMap["TRLR"] {
+		t.Error("Types missing TRLR")
+	}
+}
+
+func TestRecordIndex_Len(t *testing.T) {
+	input := `0 HEAD
+0 @I1@ INDI
+0 @I2@ INDI
+0 TRLR`
+
+	idx, err := BuildIndex(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("BuildIndex error: %v", err)
+	}
+
+	// 2 XRef entries + 2 type entries = 4
+	if idx.Len() != 4 {
+		t.Errorf("Len() = %d, want 4", idx.Len())
+	}
+}
+
+func TestRecordIndex_Encoding(t *testing.T) {
+	idx := NewRecordIndex()
+
+	// Default encoding is empty
+	if idx.Encoding() != "" {
+		t.Errorf("Default encoding = %q, want empty", idx.Encoding())
+	}
+
+	// Set encoding
+	idx.SetEncoding("UTF-8")
+	if idx.Encoding() != "UTF-8" {
+		t.Errorf("Encoding() = %q, want UTF-8", idx.Encoding())
+	}
+}
+
+func TestRecordIndex_SaveLoad(t *testing.T) {
+	input := `0 HEAD
+1 SOUR Test
+0 @I1@ INDI
+1 NAME John /Doe/
+0 @F1@ FAM
+1 HUSB @I1@
+0 TRLR`
+
+	// Build index
+	idx, err := BuildIndex(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("BuildIndex error: %v", err)
+	}
+	idx.SetEncoding("UTF-8")
+
+	// Save to buffer
+	var buf bytes.Buffer
+	if err := idx.Save(&buf); err != nil {
+		t.Fatalf("Save error: %v", err)
+	}
+
+	// Load from buffer
+	loadedIdx, err := LoadIndex(&buf)
+	if err != nil {
+		t.Fatalf("LoadIndex error: %v", err)
+	}
+
+	// Verify loaded index matches original
+	if loadedIdx.Encoding() != idx.Encoding() {
+		t.Errorf("Loaded encoding = %q, want %q", loadedIdx.Encoding(), idx.Encoding())
+	}
+
+	if loadedIdx.Len() != idx.Len() {
+		t.Errorf("Loaded Len() = %d, want %d", loadedIdx.Len(), idx.Len())
+	}
+
+	// Verify XRef lookups work
+	for _, xref := range idx.XRefs() {
+		orig, _ := idx.Lookup(xref)
+		loaded, ok := loadedIdx.Lookup(xref)
+		if !ok {
+			t.Errorf("Loaded index missing XRef %s", xref)
+			continue
+		}
+		if loaded.ByteOffset != orig.ByteOffset {
+			t.Errorf("XRef %s: ByteOffset = %d, want %d", xref, loaded.ByteOffset, orig.ByteOffset)
+		}
+		if loaded.ByteLength != orig.ByteLength {
+			t.Errorf("XRef %s: ByteLength = %d, want %d", xref, loaded.ByteLength, orig.ByteLength)
+		}
+	}
+
+	// Verify type lookups work
+	for _, ty := range idx.Types() {
+		orig, _ := idx.LookupByType(ty)
+		loaded, ok := loadedIdx.LookupByType(ty)
+		if !ok {
+			t.Errorf("Loaded index missing type %s", ty)
+			continue
+		}
+		if loaded.ByteOffset != orig.ByteOffset {
+			t.Errorf("Type %s: ByteOffset = %d, want %d", ty, loaded.ByteOffset, orig.ByteOffset)
+		}
+	}
+}
+
+func TestRecordIndex_SaveLoadEmpty(t *testing.T) {
+	idx := NewRecordIndex()
+
+	var buf bytes.Buffer
+	if err := idx.Save(&buf); err != nil {
+		t.Fatalf("Save error: %v", err)
+	}
+
+	loaded, err := LoadIndex(&buf)
+	if err != nil {
+		t.Fatalf("LoadIndex error: %v", err)
+	}
+
+	if loaded.Len() != 0 {
+		t.Errorf("Loaded Len() = %d, want 0", loaded.Len())
+	}
+}
+
+func TestBuildIndex_ParseError(t *testing.T) {
+	input := "0 HEAD\nINVALID LINE\n0 TRLR"
+
+	_, err := BuildIndex(strings.NewReader(input))
+	if err == nil {
+		t.Error("Expected error from invalid input")
+	}
+}
+
+func TestBuildIndex_EmptyInput(t *testing.T) {
+	idx, err := BuildIndex(strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("BuildIndex error: %v", err)
+	}
+
+	if idx.Len() != 0 {
+		t.Errorf("Len() = %d, want 0", idx.Len())
+	}
+}
+
+func TestLoadIndex_InvalidData(t *testing.T) {
+	// Invalid gob data
+	_, err := LoadIndex(strings.NewReader("not valid gob data"))
+	if err == nil {
+		t.Error("Expected error from invalid data")
+	}
+}
+
+func TestRecordIndex_ByteOffsets(t *testing.T) {
+	// Carefully constructed for predictable byte offsets
+	// "0 HEAD\n" = 7 bytes
+	// "1 SOUR Test\n" = 12 bytes
+	// "0 @I1@ INDI\n" = 12 bytes
+	// "1 NAME John\n" = 12 bytes
+	// "0 TRLR\n" = 7 bytes
+	input := "0 HEAD\n1 SOUR Test\n0 @I1@ INDI\n1 NAME John\n0 TRLR\n"
+
+	idx, err := BuildIndex(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("BuildIndex error: %v", err)
+	}
+
+	// HEAD at offset 0
+	headEntry, ok := idx.LookupByType("HEAD")
+	if !ok {
+		t.Fatal("HEAD not found")
+	}
+	if headEntry.ByteOffset != 0 {
+		t.Errorf("HEAD ByteOffset = %d, want 0", headEntry.ByteOffset)
+	}
+	// HEAD + SOUR = 7 + 12 = 19 bytes
+	if headEntry.ByteLength != 19 {
+		t.Errorf("HEAD ByteLength = %d, want 19", headEntry.ByteLength)
+	}
+
+	// @I1@ at offset 19
+	i1Entry, ok := idx.Lookup("@I1@")
+	if !ok {
+		t.Fatal("@I1@ not found")
+	}
+	if i1Entry.ByteOffset != 19 {
+		t.Errorf("@I1@ ByteOffset = %d, want 19", i1Entry.ByteOffset)
+	}
+	// INDI + NAME = 12 + 12 = 24 bytes
+	if i1Entry.ByteLength != 24 {
+		t.Errorf("@I1@ ByteLength = %d, want 24", i1Entry.ByteLength)
+	}
+
+	// TRLR at offset 43
+	trlrEntry, ok := idx.LookupByType("TRLR")
+	if !ok {
+		t.Fatal("TRLR not found")
+	}
+	if trlrEntry.ByteOffset != 43 {
+		t.Errorf("TRLR ByteOffset = %d, want 43", trlrEntry.ByteOffset)
+	}
+}
+
+func TestNewRecordIndex(t *testing.T) {
+	idx := NewRecordIndex()
+
+	if idx.entries == nil {
+		t.Error("entries map not initialized")
+	}
+	if idx.typeEntries == nil {
+		t.Error("typeEntries map not initialized")
+	}
+	if idx.version != IndexVersion {
+		t.Errorf("version = %d, want %d", idx.version, IndexVersion)
+	}
+}
+
+func TestIndexEntry_Fields(t *testing.T) {
+	entry := IndexEntry{
+		XRef:       "@I1@",
+		Type:       "INDI",
+		ByteOffset: 100,
+		ByteLength: 50,
+	}
+
+	if entry.XRef != "@I1@" {
+		t.Errorf("XRef = %q, want @I1@", entry.XRef)
+	}
+	if entry.Type != "INDI" {
+		t.Errorf("Type = %q, want INDI", entry.Type)
+	}
+	if entry.ByteOffset != 100 {
+		t.Errorf("ByteOffset = %d, want 100", entry.ByteOffset)
+	}
+	if entry.ByteLength != 50 {
+		t.Errorf("ByteLength = %d, want 50", entry.ByteLength)
+	}
+}

--- a/parser/iterator.go
+++ b/parser/iterator.go
@@ -1,0 +1,326 @@
+package parser
+
+import (
+	"bufio"
+	"io"
+)
+
+// RawRecord represents a complete GEDCOM record with all its subordinate lines.
+// A record starts at level 0 and includes all following lines until the next level 0.
+type RawRecord struct {
+	// XRef is the optional cross-reference identifier (e.g., "@I1@")
+	XRef string
+
+	// Type is the tag at level 0 (e.g., "INDI", "FAM", "HEAD", "TRLR")
+	Type string
+
+	// Lines contains all parsed lines belonging to this record, including the level-0 line
+	Lines []*Line
+
+	// ByteOffset is the starting byte position of this record in the file
+	ByteOffset int64
+
+	// ByteLength is the total number of bytes for this record
+	ByteLength int64
+}
+
+// RecordIterator provides streaming access to GEDCOM records.
+// It groups lines into records (level-0 boundaries) without loading the entire file into memory.
+type RecordIterator struct {
+	scanner    *bufio.Scanner
+	parser     *Parser
+	current    *RawRecord
+	pending    *Line // Buffered line that belongs to next record
+	pendingLen int   // Byte length of pending line
+	err        error
+	byteOffset int64
+	lineEnding int // Track typical line ending size (1 for LF/CR, 2 for CRLF)
+}
+
+// NewRecordIterator creates a new RecordIterator that reads from the given reader.
+// The reader should already be wrapped with charset.NewReader() for encoding normalization.
+func NewRecordIterator(r io.Reader) *RecordIterator {
+	scanner := bufio.NewScanner(r)
+	scanner.Split(scanGEDCOMLines)
+
+	return &RecordIterator{
+		scanner:    scanner,
+		parser:     NewParser(),
+		lineEnding: 1, // Conservative default
+	}
+}
+
+// Next advances the iterator to the next record.
+// Returns true if a record is available, false when iteration is complete or on error.
+func (it *RecordIterator) Next() bool {
+	if it.err != nil {
+		return false
+	}
+
+	record := &RawRecord{
+		ByteOffset: it.byteOffset,
+	}
+
+	// Use pending line from previous iteration if available
+	if it.pending != nil {
+		record.XRef = it.pending.XRef
+		record.Type = it.pending.Tag
+		record.Lines = append(record.Lines, it.pending)
+		record.ByteOffset = it.byteOffset - int64(it.pendingLen)
+		it.pending = nil
+		it.pendingLen = 0
+	} else if !it.scanNextLine(record) {
+		// Read first line of record
+		return false
+	}
+
+	// Read subordinate lines until next level-0 tag or EOF
+	for it.scanner.Scan() {
+		text := it.scanner.Text()
+		lineLen := len(it.scanner.Bytes()) + it.lineEnding
+
+		line, err := it.parser.ParseLine(text)
+		if err != nil {
+			it.err = err
+			return false
+		}
+
+		if line.Level == 0 {
+			// This line belongs to next record - buffer it
+			it.pending = line
+			it.pendingLen = lineLen
+			break
+		}
+
+		record.Lines = append(record.Lines, line)
+		it.byteOffset += int64(lineLen)
+	}
+
+	if err := it.scanner.Err(); err != nil {
+		it.err = err
+		return false
+	}
+
+	// Calculate byte length
+	record.ByteLength = it.byteOffset - record.ByteOffset
+
+	// Empty record means we've reached EOF without any lines
+	if len(record.Lines) == 0 {
+		return false
+	}
+
+	it.current = record
+	return true
+}
+
+// scanNextLine reads and parses the first line of a new record.
+func (it *RecordIterator) scanNextLine(record *RawRecord) bool {
+	if !it.scanner.Scan() {
+		if err := it.scanner.Err(); err != nil {
+			it.err = err
+		}
+		return false
+	}
+
+	text := it.scanner.Text()
+	lineLen := len(it.scanner.Bytes()) + it.lineEnding
+
+	line, err := it.parser.ParseLine(text)
+	if err != nil {
+		it.err = err
+		return false
+	}
+
+	record.XRef = line.XRef
+	record.Type = line.Tag
+	record.Lines = append(record.Lines, line)
+	it.byteOffset += int64(lineLen)
+
+	return true
+}
+
+// Record returns the current record.
+// Returns nil if Next() has not been called or returned false.
+func (it *RecordIterator) Record() *RawRecord {
+	return it.current
+}
+
+// Err returns any error encountered during iteration.
+// Should be checked after Next() returns false.
+func (it *RecordIterator) Err() error {
+	return it.err
+}
+
+// RecordIteratorWithOffset creates a RecordIterator that tracks accurate byte offsets.
+// This is used when building an index and needs precise offset tracking.
+type RecordIteratorWithOffset struct {
+	reader  *bufio.Reader
+	parser  *Parser
+	current *RawRecord
+	pending *lineWithPos
+	err     error
+	bytePos int64 // Current byte position
+}
+
+// lineWithPos holds a parsed line with its byte position.
+type lineWithPos struct {
+	line    *Line
+	pos     int64
+	byteLen int64
+}
+
+// NewRecordIteratorWithOffset creates an iterator with accurate byte offset tracking.
+func NewRecordIteratorWithOffset(r io.Reader) *RecordIteratorWithOffset {
+	return &RecordIteratorWithOffset{
+		reader: bufio.NewReader(r),
+		parser: NewParser(),
+	}
+}
+
+// readLine reads a single line with its byte position and length.
+func (it *RecordIteratorWithOffset) readLine() (*lineWithPos, error) {
+	startPos := it.bytePos
+
+	// Read until line terminator
+	lineBytes, err := readGEDCOMLine(it.reader)
+	if err != nil {
+		return nil, err
+	}
+
+	byteLen := int64(len(lineBytes))
+	it.bytePos += byteLen
+
+	// Parse the line (strip line endings for parsing)
+	text := string(trimLineEnding(lineBytes))
+	line, err := it.parser.ParseLine(text)
+	if err != nil {
+		return nil, err
+	}
+
+	return &lineWithPos{
+		line:    line,
+		pos:     startPos,
+		byteLen: byteLen,
+	}, nil
+}
+
+// trimLineEnding removes CR, LF, or CRLF from the end of a byte slice.
+func trimLineEnding(b []byte) []byte {
+	n := len(b)
+	if n > 0 && b[n-1] == '\n' {
+		n--
+		if n > 0 && b[n-1] == '\r' {
+			n--
+		}
+	} else if n > 0 && b[n-1] == '\r' {
+		n--
+	}
+	return b[:n]
+}
+
+// readGEDCOMLine reads bytes until a line terminator (CR, LF, or CRLF).
+// Returns the line including the terminator(s).
+func readGEDCOMLine(r *bufio.Reader) ([]byte, error) {
+	var line []byte
+
+	for {
+		b, err := r.ReadByte()
+		if err != nil {
+			if err == io.EOF && len(line) > 0 {
+				return line, nil
+			}
+			return nil, err
+		}
+
+		line = append(line, b)
+
+		if b == '\n' {
+			return line, nil
+		}
+		if b == '\r' {
+			// Check for CRLF
+			next, err := r.Peek(1)
+			if err == nil && len(next) > 0 && next[0] == '\n' {
+				lf, _ := r.ReadByte()
+				line = append(line, lf)
+			}
+			return line, nil
+		}
+	}
+}
+
+// Next advances the iterator to the next record.
+func (it *RecordIteratorWithOffset) Next() bool {
+	if it.err != nil {
+		return false
+	}
+
+	record := &RawRecord{}
+
+	// Use pending line from previous iteration
+	if it.pending != nil {
+		record.XRef = it.pending.line.XRef
+		record.Type = it.pending.line.Tag
+		record.Lines = append(record.Lines, it.pending.line)
+		record.ByteOffset = it.pending.pos
+		it.pending = nil
+	} else {
+		// Read first line
+		lp, err := it.readLine()
+		if err != nil {
+			if err != io.EOF {
+				it.err = err
+			}
+			return false
+		}
+
+		record.XRef = lp.line.XRef
+		record.Type = lp.line.Tag
+		record.Lines = append(record.Lines, lp.line)
+		record.ByteOffset = lp.pos
+	}
+
+	// Read subordinate lines
+	for {
+		lp, err := it.readLine()
+		if err != nil {
+			if err != io.EOF {
+				it.err = err
+				return false
+			}
+			break // EOF - finish current record
+		}
+
+		if lp.line.Level == 0 {
+			// This line belongs to next record
+			it.pending = lp
+			break
+		}
+
+		record.Lines = append(record.Lines, lp.line)
+	}
+
+	if len(record.Lines) == 0 {
+		return false
+	}
+
+	// Calculate byte length
+	if it.pending != nil {
+		record.ByteLength = it.pending.pos - record.ByteOffset
+	} else {
+		record.ByteLength = it.bytePos - record.ByteOffset
+	}
+
+	it.current = record
+	return true
+}
+
+// Record returns the current record.
+func (it *RecordIteratorWithOffset) Record() *RawRecord {
+	return it.current
+}
+
+// Err returns any error encountered during iteration.
+func (it *RecordIteratorWithOffset) Err() error {
+	return it.err
+}

--- a/parser/iterator_test.go
+++ b/parser/iterator_test.go
@@ -1,0 +1,520 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRecordIterator_BasicIteration(t *testing.T) {
+	input := `0 HEAD
+1 SOUR TestSystem
+1 GEDC
+2 VERS 5.5
+0 @I1@ INDI
+1 NAME John /Doe/
+2 GIVN John
+2 SURN Doe
+0 @I2@ INDI
+1 NAME Jane /Doe/
+0 TRLR`
+
+	it := NewRecordIterator(strings.NewReader(input))
+
+	// Record 1: HEAD
+	if !it.Next() {
+		t.Fatalf("Expected first record, got none. Err: %v", it.Err())
+	}
+	rec := it.Record()
+	if rec.Type != "HEAD" {
+		t.Errorf("First record Type = %q, want HEAD", rec.Type)
+	}
+	if rec.XRef != "" {
+		t.Errorf("HEAD record should have no XRef, got %q", rec.XRef)
+	}
+	if len(rec.Lines) != 4 {
+		t.Errorf("HEAD record has %d lines, want 4", len(rec.Lines))
+	}
+
+	// Record 2: @I1@ INDI
+	if !it.Next() {
+		t.Fatalf("Expected second record, got none. Err: %v", it.Err())
+	}
+	rec = it.Record()
+	if rec.Type != "INDI" {
+		t.Errorf("Second record Type = %q, want INDI", rec.Type)
+	}
+	if rec.XRef != "@I1@" {
+		t.Errorf("Second record XRef = %q, want @I1@", rec.XRef)
+	}
+	if len(rec.Lines) != 4 {
+		t.Errorf("@I1@ record has %d lines, want 4", len(rec.Lines))
+	}
+
+	// Record 3: @I2@ INDI
+	if !it.Next() {
+		t.Fatalf("Expected third record, got none. Err: %v", it.Err())
+	}
+	rec = it.Record()
+	if rec.Type != "INDI" {
+		t.Errorf("Third record Type = %q, want INDI", rec.Type)
+	}
+	if rec.XRef != "@I2@" {
+		t.Errorf("Third record XRef = %q, want @I2@", rec.XRef)
+	}
+
+	// Record 4: TRLR
+	if !it.Next() {
+		t.Fatalf("Expected fourth record, got none. Err: %v", it.Err())
+	}
+	rec = it.Record()
+	if rec.Type != "TRLR" {
+		t.Errorf("Fourth record Type = %q, want TRLR", rec.Type)
+	}
+
+	// No more records
+	if it.Next() {
+		t.Error("Expected no more records")
+	}
+	if it.Err() != nil {
+		t.Errorf("Unexpected error: %v", it.Err())
+	}
+}
+
+func TestRecordIterator_EmptyInput(t *testing.T) {
+	it := NewRecordIterator(strings.NewReader(""))
+
+	if it.Next() {
+		t.Error("Expected no records for empty input")
+	}
+	if it.Err() != nil {
+		t.Errorf("Unexpected error: %v", it.Err())
+	}
+}
+
+func TestRecordIterator_SingleRecord(t *testing.T) {
+	input := "0 HEAD\n1 SOUR Test"
+
+	it := NewRecordIterator(strings.NewReader(input))
+
+	if !it.Next() {
+		t.Fatalf("Expected one record, got none. Err: %v", it.Err())
+	}
+
+	rec := it.Record()
+	if rec.Type != "HEAD" {
+		t.Errorf("Record Type = %q, want HEAD", rec.Type)
+	}
+	if len(rec.Lines) != 2 {
+		t.Errorf("Record has %d lines, want 2", len(rec.Lines))
+	}
+
+	if it.Next() {
+		t.Error("Expected no more records")
+	}
+}
+
+func TestRecordIterator_LineNumbers(t *testing.T) {
+	input := `0 HEAD
+1 SOUR Test
+0 TRLR`
+
+	it := NewRecordIterator(strings.NewReader(input))
+
+	if !it.Next() {
+		t.Fatal("Expected first record")
+	}
+	rec := it.Record()
+	if rec.Lines[0].LineNumber != 1 {
+		t.Errorf("First line number = %d, want 1", rec.Lines[0].LineNumber)
+	}
+	if rec.Lines[1].LineNumber != 2 {
+		t.Errorf("Second line number = %d, want 2", rec.Lines[1].LineNumber)
+	}
+
+	if !it.Next() {
+		t.Fatal("Expected second record")
+	}
+	rec = it.Record()
+	if rec.Lines[0].LineNumber != 3 {
+		t.Errorf("TRLR line number = %d, want 3", rec.Lines[0].LineNumber)
+	}
+}
+
+func TestRecordIterator_CRLFLineEndings(t *testing.T) {
+	input := "0 HEAD\r\n1 SOUR Test\r\n0 TRLR\r\n"
+
+	it := NewRecordIterator(strings.NewReader(input))
+
+	count := 0
+	for it.Next() {
+		count++
+	}
+	if it.Err() != nil {
+		t.Fatalf("Unexpected error: %v", it.Err())
+	}
+	if count != 2 {
+		t.Errorf("Got %d records, want 2", count)
+	}
+}
+
+func TestRecordIterator_CROnlyLineEndings(t *testing.T) {
+	input := "0 HEAD\r1 SOUR Test\r0 TRLR\r"
+
+	it := NewRecordIterator(strings.NewReader(input))
+
+	count := 0
+	for it.Next() {
+		count++
+	}
+	if it.Err() != nil {
+		t.Fatalf("Unexpected error: %v", it.Err())
+	}
+	if count != 2 {
+		t.Errorf("Got %d records, want 2", count)
+	}
+}
+
+func TestRecordIterator_ParseError(t *testing.T) {
+	// Invalid level number in subordinate line
+	// The error occurs while reading subordinate lines of HEAD
+	input := "0 HEAD\nX INVALID\n0 TRLR"
+
+	it := NewRecordIterator(strings.NewReader(input))
+
+	// The parse error on "X INVALID" occurs while reading HEAD's subordinate lines
+	// This causes Next() to return false with an error
+	if it.Next() {
+		t.Error("Expected iteration to stop on parse error")
+	}
+	if it.Err() == nil {
+		t.Error("Expected error from invalid level")
+	}
+}
+
+func TestRecordIterator_ParseError_SecondRecord(t *testing.T) {
+	// Parse error in the second record (after successfully returning first)
+	input := "0 HEAD\n0 @I1@ INDI\nX INVALID\n0 TRLR"
+
+	it := NewRecordIterator(strings.NewReader(input))
+
+	// First record (HEAD) should be returned successfully
+	if !it.Next() {
+		t.Fatal("Expected first record")
+	}
+	if it.Record().Type != "HEAD" {
+		t.Errorf("First record Type = %q, want HEAD", it.Record().Type)
+	}
+
+	// Second record should fail during subordinate line parsing
+	if it.Next() {
+		t.Error("Expected iteration to stop on parse error")
+	}
+	if it.Err() == nil {
+		t.Error("Expected error from invalid level")
+	}
+}
+
+func TestRecordIterator_MatchesFullParse(t *testing.T) {
+	input := `0 HEAD
+1 GEDC
+2 VERS 5.5
+0 @I1@ INDI
+1 NAME John /Smith/
+2 GIVN John
+2 SURN Smith
+1 SEX M
+0 @F1@ FAM
+1 HUSB @I1@
+0 TRLR`
+
+	// Full parse
+	p := NewParser()
+	fullLines, err := p.Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("Full parse error: %v", err)
+	}
+
+	// Iterator
+	it := NewRecordIterator(strings.NewReader(input))
+	var iteratedLines []*Line
+	for it.Next() {
+		iteratedLines = append(iteratedLines, it.Record().Lines...)
+	}
+	if it.Err() != nil {
+		t.Fatalf("Iterator error: %v", it.Err())
+	}
+
+	// Compare
+	if len(iteratedLines) != len(fullLines) {
+		t.Fatalf("Iterator got %d lines, full parse got %d", len(iteratedLines), len(fullLines))
+	}
+
+	for i := range fullLines {
+		if iteratedLines[i].Level != fullLines[i].Level {
+			t.Errorf("Line %d: Level = %d, want %d", i, iteratedLines[i].Level, fullLines[i].Level)
+		}
+		if iteratedLines[i].Tag != fullLines[i].Tag {
+			t.Errorf("Line %d: Tag = %q, want %q", i, iteratedLines[i].Tag, fullLines[i].Tag)
+		}
+		if iteratedLines[i].Value != fullLines[i].Value {
+			t.Errorf("Line %d: Value = %q, want %q", i, iteratedLines[i].Value, fullLines[i].Value)
+		}
+		if iteratedLines[i].XRef != fullLines[i].XRef {
+			t.Errorf("Line %d: XRef = %q, want %q", i, iteratedLines[i].XRef, fullLines[i].XRef)
+		}
+		if iteratedLines[i].LineNumber != fullLines[i].LineNumber {
+			t.Errorf("Line %d: LineNumber = %d, want %d", i, iteratedLines[i].LineNumber, fullLines[i].LineNumber)
+		}
+	}
+}
+
+func TestRecordIteratorWithOffset_ByteOffsets(t *testing.T) {
+	// Each line is carefully crafted for predictable byte lengths
+	// "0 HEAD\n" = 7 bytes
+	// "1 SOUR Test\n" = 12 bytes
+	// "0 TRLR\n" = 7 bytes
+	input := "0 HEAD\n1 SOUR Test\n0 TRLR\n"
+
+	it := NewRecordIteratorWithOffset(strings.NewReader(input))
+
+	// First record: HEAD
+	if !it.Next() {
+		t.Fatalf("Expected first record. Err: %v", it.Err())
+	}
+	rec := it.Record()
+	if rec.ByteOffset != 0 {
+		t.Errorf("HEAD ByteOffset = %d, want 0", rec.ByteOffset)
+	}
+	// HEAD + SOUR = 7 + 12 = 19 bytes
+	if rec.ByteLength != 19 {
+		t.Errorf("HEAD ByteLength = %d, want 19", rec.ByteLength)
+	}
+
+	// Second record: TRLR
+	if !it.Next() {
+		t.Fatalf("Expected second record. Err: %v", it.Err())
+	}
+	rec = it.Record()
+	if rec.ByteOffset != 19 {
+		t.Errorf("TRLR ByteOffset = %d, want 19", rec.ByteOffset)
+	}
+	if rec.ByteLength != 7 {
+		t.Errorf("TRLR ByteLength = %d, want 7", rec.ByteLength)
+	}
+
+	if it.Next() {
+		t.Error("Expected no more records")
+	}
+}
+
+func TestRecordIteratorWithOffset_EmptyInput(t *testing.T) {
+	it := NewRecordIteratorWithOffset(strings.NewReader(""))
+
+	if it.Next() {
+		t.Error("Expected no records for empty input")
+	}
+	if it.Err() != nil {
+		t.Errorf("Unexpected error: %v", it.Err())
+	}
+}
+
+func TestRecordIteratorWithOffset_CRLFOffsets(t *testing.T) {
+	// "0 HEAD\r\n" = 8 bytes
+	// "1 SOUR Test\r\n" = 13 bytes
+	// "0 TRLR\r\n" = 8 bytes
+	input := "0 HEAD\r\n1 SOUR Test\r\n0 TRLR\r\n"
+
+	it := NewRecordIteratorWithOffset(strings.NewReader(input))
+
+	if !it.Next() {
+		t.Fatalf("Expected first record. Err: %v", it.Err())
+	}
+	rec := it.Record()
+	if rec.ByteOffset != 0 {
+		t.Errorf("HEAD ByteOffset = %d, want 0", rec.ByteOffset)
+	}
+	// HEAD + SOUR = 8 + 13 = 21 bytes
+	if rec.ByteLength != 21 {
+		t.Errorf("HEAD ByteLength = %d, want 21", rec.ByteLength)
+	}
+
+	if !it.Next() {
+		t.Fatalf("Expected second record. Err: %v", it.Err())
+	}
+	rec = it.Record()
+	if rec.ByteOffset != 21 {
+		t.Errorf("TRLR ByteOffset = %d, want 21", rec.ByteOffset)
+	}
+}
+
+func TestRecordIteratorWithOffset_MultipleRecords(t *testing.T) {
+	input := `0 HEAD
+1 GEDC
+2 VERS 5.5
+0 @I1@ INDI
+1 NAME John /Doe/
+0 @I2@ INDI
+1 NAME Jane /Doe/
+0 TRLR
+`
+
+	it := NewRecordIteratorWithOffset(strings.NewReader(input))
+
+	records := make([]*RawRecord, 0)
+	for it.Next() {
+		// Make a copy since Record() may be reused
+		rec := it.Record()
+		records = append(records, &RawRecord{
+			XRef:       rec.XRef,
+			Type:       rec.Type,
+			Lines:      rec.Lines,
+			ByteOffset: rec.ByteOffset,
+			ByteLength: rec.ByteLength,
+		})
+	}
+
+	if it.Err() != nil {
+		t.Fatalf("Unexpected error: %v", it.Err())
+	}
+
+	if len(records) != 4 {
+		t.Fatalf("Got %d records, want 4", len(records))
+	}
+
+	// Verify records are contiguous
+	var lastEnd int64
+	for i, rec := range records {
+		if rec.ByteOffset != lastEnd {
+			t.Errorf("Record %d: ByteOffset = %d, expected %d (gap in offsets)", i, rec.ByteOffset, lastEnd)
+		}
+		lastEnd = rec.ByteOffset + rec.ByteLength
+	}
+}
+
+func TestRecordIteratorWithOffset_ParseError(t *testing.T) {
+	// Invalid line occurs while reading HEAD's subordinate lines
+	input := "0 HEAD\nINVALID LINE\n0 TRLR\n"
+
+	it := NewRecordIteratorWithOffset(strings.NewReader(input))
+
+	// The parse error on "INVALID LINE" occurs while reading HEAD's subordinate lines
+	// This causes Next() to return false with an error
+	if it.Next() {
+		t.Error("Expected iteration to stop on parse error")
+	}
+	if it.Err() == nil {
+		t.Error("Expected parse error")
+	}
+}
+
+func TestRecordIteratorWithOffset_ParseError_SecondRecord(t *testing.T) {
+	// Parse error in the second record
+	input := "0 HEAD\n0 @I1@ INDI\nINVALID LINE\n0 TRLR\n"
+
+	it := NewRecordIteratorWithOffset(strings.NewReader(input))
+
+	// First record (HEAD) should be returned successfully
+	if !it.Next() {
+		t.Fatal("Expected first record")
+	}
+	if it.Record().Type != "HEAD" {
+		t.Errorf("First record Type = %q, want HEAD", it.Record().Type)
+	}
+
+	// Second record should fail during subordinate line parsing
+	if it.Next() {
+		t.Error("Expected iteration to stop on parse error")
+	}
+	if it.Err() == nil {
+		t.Error("Expected parse error")
+	}
+}
+
+func TestRawRecord_Fields(t *testing.T) {
+	input := "0 @I1@ INDI\n1 NAME John /Doe/\n"
+
+	it := NewRecordIterator(strings.NewReader(input))
+	if !it.Next() {
+		t.Fatal("Expected one record")
+	}
+
+	rec := it.Record()
+	if rec.XRef != "@I1@" {
+		t.Errorf("XRef = %q, want @I1@", rec.XRef)
+	}
+	if rec.Type != "INDI" {
+		t.Errorf("Type = %q, want INDI", rec.Type)
+	}
+	if len(rec.Lines) != 2 {
+		t.Errorf("Lines count = %d, want 2", len(rec.Lines))
+	}
+}
+
+func TestRecordIterator_NoTrailingNewline(t *testing.T) {
+	// File without trailing newline
+	input := "0 HEAD\n1 SOUR Test\n0 TRLR"
+
+	it := NewRecordIterator(strings.NewReader(input))
+
+	count := 0
+	for it.Next() {
+		count++
+	}
+	if it.Err() != nil {
+		t.Fatalf("Unexpected error: %v", it.Err())
+	}
+	if count != 2 {
+		t.Errorf("Got %d records, want 2", count)
+	}
+}
+
+func TestRecordIteratorWithOffset_NoTrailingNewline(t *testing.T) {
+	input := "0 HEAD\n1 SOUR Test\n0 TRLR"
+
+	it := NewRecordIteratorWithOffset(strings.NewReader(input))
+
+	count := 0
+	for it.Next() {
+		count++
+	}
+	if it.Err() != nil {
+		t.Fatalf("Unexpected error: %v", it.Err())
+	}
+	if count != 2 {
+		t.Errorf("Got %d records, want 2", count)
+	}
+}
+
+func TestRecordIterator_RecordWithoutXRef(t *testing.T) {
+	// Some valid GEDCOM records don't have XRefs (like HEAD, TRLR, SUBM without pointer)
+	input := "0 HEAD\n1 CHAR UTF-8\n0 @S1@ SUBM\n1 NAME Submitter\n0 TRLR"
+
+	it := NewRecordIterator(strings.NewReader(input))
+
+	// HEAD - no XRef
+	if !it.Next() {
+		t.Fatal("Expected HEAD record")
+	}
+	rec := it.Record()
+	if rec.XRef != "" {
+		t.Errorf("HEAD XRef = %q, want empty", rec.XRef)
+	}
+
+	// SUBM - has XRef
+	if !it.Next() {
+		t.Fatal("Expected SUBM record")
+	}
+	rec = it.Record()
+	if rec.XRef != "@S1@" {
+		t.Errorf("SUBM XRef = %q, want @S1@", rec.XRef)
+	}
+
+	// TRLR - no XRef
+	if !it.Next() {
+		t.Fatal("Expected TRLR record")
+	}
+	rec = it.Record()
+	if rec.XRef != "" {
+		t.Errorf("TRLR XRef = %q, want empty", rec.XRef)
+	}
+}

--- a/parser/lazy.go
+++ b/parser/lazy.go
@@ -1,0 +1,201 @@
+package parser
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// ErrNoIndex is returned when attempting to use indexed operations without an index.
+var ErrNoIndex = errors.New("no index available: call BuildIndex or LoadIndex first")
+
+// ErrRecordNotFound is returned when a record cannot be found.
+var ErrRecordNotFound = errors.New("record not found")
+
+// LazyParser provides lazy/incremental parsing of GEDCOM files.
+// It combines streaming iteration with indexed random access for efficient
+// partial file processing.
+type LazyParser struct {
+	rs    io.ReadSeeker
+	index *RecordIndex
+}
+
+// NewLazyParser creates a new LazyParser from an io.ReadSeeker.
+// The reader must support seeking for indexed access operations.
+func NewLazyParser(rs io.ReadSeeker) *LazyParser {
+	return &LazyParser{
+		rs: rs,
+	}
+}
+
+// BuildIndex scans the entire file to build an index for O(1) record lookup.
+// After calling BuildIndex, use FindRecord for efficient random access.
+// The reader is rewound to the beginning after building the index.
+func (p *LazyParser) BuildIndex() error {
+	// Seek to beginning
+	if _, err := p.rs.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("seeking to start: %w", err)
+	}
+
+	// Build index
+	idx, err := BuildIndex(p.rs)
+	if err != nil {
+		return err
+	}
+
+	p.index = idx
+
+	// Rewind for subsequent operations
+	if _, err := p.rs.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("rewinding after index build: %w", err)
+	}
+
+	return nil
+}
+
+// LoadIndex loads a pre-built index from the given reader.
+// Using a pre-built index avoids the O(n) scan of BuildIndex.
+func (p *LazyParser) LoadIndex(r io.Reader) error {
+	idx, err := LoadIndex(r)
+	if err != nil {
+		return err
+	}
+
+	p.index = idx
+	return nil
+}
+
+// SaveIndex writes the current index to the given writer.
+// Returns ErrNoIndex if no index has been built or loaded.
+func (p *LazyParser) SaveIndex(w io.Writer) error {
+	if p.index == nil {
+		return ErrNoIndex
+	}
+
+	return p.index.Save(w)
+}
+
+// HasIndex returns true if an index is available.
+func (p *LazyParser) HasIndex() bool {
+	return p.index != nil
+}
+
+// Index returns the current index, or nil if none is loaded.
+func (p *LazyParser) Index() *RecordIndex {
+	return p.index
+}
+
+// FindRecord locates and parses a specific record by XRef.
+// Requires an index to be built or loaded first.
+// Returns ErrNoIndex if no index is available.
+// Returns ErrRecordNotFound if the XRef is not in the index.
+func (p *LazyParser) FindRecord(xref string) (*RawRecord, error) {
+	if p.index == nil {
+		return nil, ErrNoIndex
+	}
+
+	entry, ok := p.index.Lookup(xref)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrRecordNotFound, xref)
+	}
+
+	return p.readRecordAt(entry)
+}
+
+// FindRecordByType locates and parses a record by type (for records without XRef).
+// This is useful for finding HEAD or TRLR records.
+// Requires an index to be built or loaded first.
+func (p *LazyParser) FindRecordByType(recordType string) (*RawRecord, error) {
+	if p.index == nil {
+		return nil, ErrNoIndex
+	}
+
+	entry, ok := p.index.LookupByType(recordType)
+	if !ok {
+		return nil, fmt.Errorf("%w: type %s", ErrRecordNotFound, recordType)
+	}
+
+	return p.readRecordAt(entry)
+}
+
+// readRecordAt seeks to the given entry and parses the record.
+func (p *LazyParser) readRecordAt(entry IndexEntry) (*RawRecord, error) {
+	// Seek to record position
+	if _, err := p.rs.Seek(entry.ByteOffset, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("seeking to record: %w", err)
+	}
+
+	// Read exactly the bytes for this record
+	limitedReader := io.LimitReader(p.rs, entry.ByteLength)
+
+	// Parse the record
+	record := &RawRecord{
+		ByteOffset: entry.ByteOffset,
+		ByteLength: entry.ByteLength,
+	}
+
+	parser := NewParser()
+	scanner := bufio.NewScanner(limitedReader)
+	scanner.Split(scanGEDCOMLines)
+
+	for scanner.Scan() {
+		line, err := parser.ParseLine(scanner.Text())
+		if err != nil {
+			return nil, fmt.Errorf("parsing line: %w", err)
+		}
+
+		if len(record.Lines) == 0 {
+			record.XRef = line.XRef
+			record.Type = line.Tag
+		}
+
+		record.Lines = append(record.Lines, line)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scanning record: %w", err)
+	}
+
+	return record, nil
+}
+
+// Iterate returns a RecordIterator for streaming through records.
+// The iterator starts from the current position of the reader.
+// For full file iteration, seek to the beginning first.
+func (p *LazyParser) Iterate() *RecordIterator {
+	return NewRecordIterator(p.rs)
+}
+
+// IterateFrom seeks to the given byte offset and returns an iterator.
+// This allows resuming iteration from a known position.
+func (p *LazyParser) IterateFrom(offset int64) (*RecordIterator, error) {
+	if _, err := p.rs.Seek(offset, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("seeking to offset: %w", err)
+	}
+
+	return NewRecordIterator(p.rs), nil
+}
+
+// IterateAll seeks to the beginning and returns an iterator for all records.
+func (p *LazyParser) IterateAll() (*RecordIterator, error) {
+	return p.IterateFrom(0)
+}
+
+// XRefs returns all XRefs in the index.
+// Returns nil if no index is available.
+func (p *LazyParser) XRefs() []string {
+	if p.index == nil {
+		return nil
+	}
+	return p.index.XRefs()
+}
+
+// RecordCount returns the total number of indexed records.
+// Returns 0 if no index is available.
+func (p *LazyParser) RecordCount() int {
+	if p.index == nil {
+		return 0
+	}
+	return p.index.Len()
+}

--- a/parser/lazy_test.go
+++ b/parser/lazy_test.go
@@ -1,0 +1,638 @@
+package parser
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// stringReadSeeker wraps a string as an io.ReadSeeker
+type stringReadSeeker struct {
+	*strings.Reader
+}
+
+func newStringReadSeeker(s string) *stringReadSeeker {
+	return &stringReadSeeker{strings.NewReader(s)}
+}
+
+func TestNewLazyParser(t *testing.T) {
+	input := "0 HEAD\n0 TRLR\n"
+	rs := newStringReadSeeker(input)
+
+	lp := NewLazyParser(rs)
+	if lp == nil {
+		t.Fatal("NewLazyParser returned nil")
+	}
+	if lp.HasIndex() {
+		t.Error("New LazyParser should not have index")
+	}
+}
+
+func TestLazyParser_BuildIndex(t *testing.T) {
+	input := `0 HEAD
+1 SOUR Test
+0 @I1@ INDI
+1 NAME John /Doe/
+0 @I2@ INDI
+1 NAME Jane /Doe/
+0 TRLR`
+
+	rs := newStringReadSeeker(input)
+	lp := NewLazyParser(rs)
+
+	if err := lp.BuildIndex(); err != nil {
+		t.Fatalf("BuildIndex error: %v", err)
+	}
+
+	if !lp.HasIndex() {
+		t.Error("HasIndex should return true after BuildIndex")
+	}
+
+	if lp.Index() == nil {
+		t.Error("Index() should not return nil after BuildIndex")
+	}
+
+	// Should have 4 records: HEAD, @I1@, @I2@, TRLR
+	if lp.RecordCount() != 4 {
+		t.Errorf("RecordCount() = %d, want 4", lp.RecordCount())
+	}
+
+	// Check XRefs
+	xrefs := lp.XRefs()
+	if len(xrefs) != 2 {
+		t.Errorf("Got %d XRefs, want 2", len(xrefs))
+	}
+}
+
+func TestLazyParser_FindRecord(t *testing.T) {
+	input := `0 HEAD
+1 SOUR Test
+0 @I1@ INDI
+1 NAME John /Doe/
+2 GIVN John
+2 SURN Doe
+0 @I2@ INDI
+1 NAME Jane /Doe/
+0 TRLR`
+
+	rs := newStringReadSeeker(input)
+	lp := NewLazyParser(rs)
+
+	if err := lp.BuildIndex(); err != nil {
+		t.Fatalf("BuildIndex error: %v", err)
+	}
+
+	// Find @I1@
+	rec, err := lp.FindRecord("@I1@")
+	if err != nil {
+		t.Fatalf("FindRecord(@I1@) error: %v", err)
+	}
+
+	if rec.XRef != "@I1@" {
+		t.Errorf("Record XRef = %q, want @I1@", rec.XRef)
+	}
+	if rec.Type != "INDI" {
+		t.Errorf("Record Type = %q, want INDI", rec.Type)
+	}
+	if len(rec.Lines) != 4 {
+		t.Errorf("Record has %d lines, want 4", len(rec.Lines))
+	}
+
+	// Verify line content
+	if rec.Lines[0].Tag != "INDI" {
+		t.Errorf("First line Tag = %q, want INDI", rec.Lines[0].Tag)
+	}
+	if rec.Lines[1].Tag != "NAME" || rec.Lines[1].Value != "John /Doe/" {
+		t.Errorf("NAME line = %q %q, want NAME John /Doe/", rec.Lines[1].Tag, rec.Lines[1].Value)
+	}
+
+	// Find @I2@
+	rec, err = lp.FindRecord("@I2@")
+	if err != nil {
+		t.Fatalf("FindRecord(@I2@) error: %v", err)
+	}
+	if rec.XRef != "@I2@" {
+		t.Errorf("Record XRef = %q, want @I2@", rec.XRef)
+	}
+}
+
+func TestLazyParser_FindRecord_NotFound(t *testing.T) {
+	input := "0 HEAD\n0 @I1@ INDI\n0 TRLR"
+	rs := newStringReadSeeker(input)
+	lp := NewLazyParser(rs)
+
+	if err := lp.BuildIndex(); err != nil {
+		t.Fatalf("BuildIndex error: %v", err)
+	}
+
+	_, err := lp.FindRecord("@I999@")
+	if err == nil {
+		t.Error("Expected error for non-existent record")
+	}
+	if !errors.Is(err, ErrRecordNotFound) {
+		t.Errorf("Expected ErrRecordNotFound, got: %v", err)
+	}
+}
+
+func TestLazyParser_FindRecord_NoIndex(t *testing.T) {
+	input := "0 HEAD\n0 TRLR"
+	rs := newStringReadSeeker(input)
+	lp := NewLazyParser(rs)
+
+	_, err := lp.FindRecord("@I1@")
+	if err == nil {
+		t.Error("Expected error without index")
+	}
+	if !errors.Is(err, ErrNoIndex) {
+		t.Errorf("Expected ErrNoIndex, got: %v", err)
+	}
+}
+
+func TestLazyParser_FindRecordByType(t *testing.T) {
+	input := `0 HEAD
+1 SOUR Test
+1 GEDC
+2 VERS 5.5
+0 @I1@ INDI
+1 NAME John
+0 TRLR`
+
+	rs := newStringReadSeeker(input)
+	lp := NewLazyParser(rs)
+
+	if err := lp.BuildIndex(); err != nil {
+		t.Fatalf("BuildIndex error: %v", err)
+	}
+
+	// Find HEAD
+	rec, err := lp.FindRecordByType("HEAD")
+	if err != nil {
+		t.Fatalf("FindRecordByType(HEAD) error: %v", err)
+	}
+
+	if rec.Type != "HEAD" {
+		t.Errorf("Record Type = %q, want HEAD", rec.Type)
+	}
+	if len(rec.Lines) != 4 {
+		t.Errorf("HEAD has %d lines, want 4", len(rec.Lines))
+	}
+
+	// Find TRLR
+	rec, err = lp.FindRecordByType("TRLR")
+	if err != nil {
+		t.Fatalf("FindRecordByType(TRLR) error: %v", err)
+	}
+	if rec.Type != "TRLR" {
+		t.Errorf("Record Type = %q, want TRLR", rec.Type)
+	}
+}
+
+func TestLazyParser_FindRecordByType_NotFound(t *testing.T) {
+	input := "0 HEAD\n0 TRLR"
+	rs := newStringReadSeeker(input)
+	lp := NewLazyParser(rs)
+
+	if err := lp.BuildIndex(); err != nil {
+		t.Fatalf("BuildIndex error: %v", err)
+	}
+
+	_, err := lp.FindRecordByType("SUBM")
+	if err == nil {
+		t.Error("Expected error for non-existent type")
+	}
+	if !errors.Is(err, ErrRecordNotFound) {
+		t.Errorf("Expected ErrRecordNotFound, got: %v", err)
+	}
+}
+
+func TestLazyParser_SaveLoadIndex(t *testing.T) {
+	input := `0 HEAD
+0 @I1@ INDI
+1 NAME John
+0 @I2@ INDI
+1 NAME Jane
+0 TRLR`
+
+	rs := newStringReadSeeker(input)
+	lp := NewLazyParser(rs)
+
+	if err := lp.BuildIndex(); err != nil {
+		t.Fatalf("BuildIndex error: %v", err)
+	}
+
+	// Save index
+	var buf bytes.Buffer
+	if err := lp.SaveIndex(&buf); err != nil {
+		t.Fatalf("SaveIndex error: %v", err)
+	}
+
+	// Create new parser and load index
+	rs2 := newStringReadSeeker(input)
+	lp2 := NewLazyParser(rs2)
+
+	if err := lp2.LoadIndex(&buf); err != nil {
+		t.Fatalf("LoadIndex error: %v", err)
+	}
+
+	if !lp2.HasIndex() {
+		t.Error("Should have index after LoadIndex")
+	}
+
+	// Verify loaded index works
+	rec, err := lp2.FindRecord("@I1@")
+	if err != nil {
+		t.Fatalf("FindRecord after LoadIndex error: %v", err)
+	}
+	if rec.XRef != "@I1@" {
+		t.Errorf("Record XRef = %q, want @I1@", rec.XRef)
+	}
+}
+
+func TestLazyParser_SaveIndex_NoIndex(t *testing.T) {
+	rs := newStringReadSeeker("0 HEAD\n0 TRLR")
+	lp := NewLazyParser(rs)
+
+	var buf bytes.Buffer
+	err := lp.SaveIndex(&buf)
+	if err == nil {
+		t.Error("Expected error when saving without index")
+	}
+	if !errors.Is(err, ErrNoIndex) {
+		t.Errorf("Expected ErrNoIndex, got: %v", err)
+	}
+}
+
+func TestLazyParser_Iterate(t *testing.T) {
+	input := `0 HEAD
+1 SOUR Test
+0 @I1@ INDI
+1 NAME John
+0 TRLR`
+
+	rs := newStringReadSeeker(input)
+	lp := NewLazyParser(rs)
+
+	it := lp.Iterate()
+
+	count := 0
+	for it.Next() {
+		count++
+	}
+	if it.Err() != nil {
+		t.Fatalf("Iterator error: %v", it.Err())
+	}
+
+	if count != 3 {
+		t.Errorf("Iterated %d records, want 3", count)
+	}
+}
+
+func TestLazyParser_IterateAll(t *testing.T) {
+	input := `0 HEAD
+0 @I1@ INDI
+0 TRLR`
+
+	rs := newStringReadSeeker(input)
+	lp := NewLazyParser(rs)
+
+	// Read some data first to move position
+	buf := make([]byte, 10)
+	_, _ = rs.Read(buf)
+
+	// IterateAll should seek to beginning
+	it, err := lp.IterateAll()
+	if err != nil {
+		t.Fatalf("IterateAll error: %v", err)
+	}
+
+	count := 0
+	for it.Next() {
+		count++
+	}
+	if count != 3 {
+		t.Errorf("Iterated %d records, want 3", count)
+	}
+}
+
+func TestLazyParser_IterateFrom(t *testing.T) {
+	// "0 HEAD\n" = 7 bytes
+	// "1 SOUR Test\n" = 12 bytes
+	// HEAD record ends at offset 19
+	// "0 @I1@ INDI\n" starts at 19
+	input := "0 HEAD\n1 SOUR Test\n0 @I1@ INDI\n1 NAME John\n0 TRLR\n"
+
+	rs := newStringReadSeeker(input)
+	lp := NewLazyParser(rs)
+
+	// Build index to get offsets
+	if err := lp.BuildIndex(); err != nil {
+		t.Fatalf("BuildIndex error: %v", err)
+	}
+
+	entry, _ := lp.Index().Lookup("@I1@")
+
+	// Iterate from @I1@
+	it, err := lp.IterateFrom(entry.ByteOffset)
+	if err != nil {
+		t.Fatalf("IterateFrom error: %v", err)
+	}
+
+	if !it.Next() {
+		t.Fatal("Expected at least one record")
+	}
+
+	rec := it.Record()
+	if rec.XRef != "@I1@" {
+		t.Errorf("First record XRef = %q, want @I1@", rec.XRef)
+	}
+}
+
+func TestLazyParser_XRefs_NoIndex(t *testing.T) {
+	rs := newStringReadSeeker("0 HEAD\n0 TRLR")
+	lp := NewLazyParser(rs)
+
+	xrefs := lp.XRefs()
+	if xrefs != nil {
+		t.Errorf("XRefs without index should be nil, got %v", xrefs)
+	}
+}
+
+func TestLazyParser_RecordCount_NoIndex(t *testing.T) {
+	rs := newStringReadSeeker("0 HEAD\n0 TRLR")
+	lp := NewLazyParser(rs)
+
+	if lp.RecordCount() != 0 {
+		t.Errorf("RecordCount without index = %d, want 0", lp.RecordCount())
+	}
+}
+
+func TestLazyParser_FindRecordByType_NoIndex(t *testing.T) {
+	rs := newStringReadSeeker("0 HEAD\n0 TRLR")
+	lp := NewLazyParser(rs)
+
+	_, err := lp.FindRecordByType("HEAD")
+	if !errors.Is(err, ErrNoIndex) {
+		t.Errorf("Expected ErrNoIndex, got: %v", err)
+	}
+}
+
+func TestLazyParser_MultipleFinds(t *testing.T) {
+	input := `0 HEAD
+1 SOUR Test
+0 @I1@ INDI
+1 NAME John
+0 @I2@ INDI
+1 NAME Jane
+0 @F1@ FAM
+1 HUSB @I1@
+1 WIFE @I2@
+0 TRLR`
+
+	rs := newStringReadSeeker(input)
+	lp := NewLazyParser(rs)
+
+	if err := lp.BuildIndex(); err != nil {
+		t.Fatalf("BuildIndex error: %v", err)
+	}
+
+	// Find records in non-sequential order
+	rec, err := lp.FindRecord("@F1@")
+	if err != nil {
+		t.Fatalf("FindRecord(@F1@) error: %v", err)
+	}
+	if rec.Type != "FAM" {
+		t.Errorf("@F1@ Type = %q, want FAM", rec.Type)
+	}
+
+	rec, err = lp.FindRecord("@I1@")
+	if err != nil {
+		t.Fatalf("FindRecord(@I1@) error: %v", err)
+	}
+	if rec.Type != "INDI" {
+		t.Errorf("@I1@ Type = %q, want INDI", rec.Type)
+	}
+
+	rec, err = lp.FindRecord("@I2@")
+	if err != nil {
+		t.Fatalf("FindRecord(@I2@) error: %v", err)
+	}
+	if rec.XRef != "@I2@" {
+		t.Errorf("Record XRef = %q, want @I2@", rec.XRef)
+	}
+}
+
+func TestLazyParser_IterateAfterFind(t *testing.T) {
+	input := `0 HEAD
+0 @I1@ INDI
+1 NAME John
+0 @I2@ INDI
+1 NAME Jane
+0 TRLR`
+
+	rs := newStringReadSeeker(input)
+	lp := NewLazyParser(rs)
+
+	if err := lp.BuildIndex(); err != nil {
+		t.Fatalf("BuildIndex error: %v", err)
+	}
+
+	// Find a record first
+	_, err := lp.FindRecord("@I2@")
+	if err != nil {
+		t.Fatalf("FindRecord error: %v", err)
+	}
+
+	// Then iterate all
+	it, err := lp.IterateAll()
+	if err != nil {
+		t.Fatalf("IterateAll error: %v", err)
+	}
+
+	count := 0
+	for it.Next() {
+		count++
+	}
+	if count != 4 {
+		t.Errorf("Iterated %d records after Find, want 4", count)
+	}
+}
+
+func TestLazyParser_FindRecordMatchesFullParse(t *testing.T) {
+	input := `0 HEAD
+1 GEDC
+2 VERS 5.5
+0 @I1@ INDI
+1 NAME John /Smith/
+2 GIVN John
+2 SURN Smith
+1 SEX M
+1 BIRT
+2 DATE 1 JAN 1950
+0 TRLR`
+
+	// Full parse to get expected record
+	p := NewParser()
+	fullLines, err := p.Parse(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("Full parse error: %v", err)
+	}
+
+	// Find @I1@ record lines from full parse
+	var expectedLines []*Line
+	inI1 := false
+	for _, line := range fullLines {
+		if line.Level == 0 {
+			if line.XRef == "@I1@" {
+				inI1 = true
+			} else if inI1 {
+				break
+			}
+		}
+		if inI1 {
+			expectedLines = append(expectedLines, line)
+		}
+	}
+
+	// Lazy parse and find
+	rs := newStringReadSeeker(input)
+	lp := NewLazyParser(rs)
+
+	if err := lp.BuildIndex(); err != nil {
+		t.Fatalf("BuildIndex error: %v", err)
+	}
+
+	rec, err := lp.FindRecord("@I1@")
+	if err != nil {
+		t.Fatalf("FindRecord error: %v", err)
+	}
+
+	// Compare lines
+	if len(rec.Lines) != len(expectedLines) {
+		t.Fatalf("Got %d lines, want %d", len(rec.Lines), len(expectedLines))
+	}
+
+	for i := range expectedLines {
+		if rec.Lines[i].Level != expectedLines[i].Level {
+			t.Errorf("Line %d: Level = %d, want %d", i, rec.Lines[i].Level, expectedLines[i].Level)
+		}
+		if rec.Lines[i].Tag != expectedLines[i].Tag {
+			t.Errorf("Line %d: Tag = %q, want %q", i, rec.Lines[i].Tag, expectedLines[i].Tag)
+		}
+		if rec.Lines[i].Value != expectedLines[i].Value {
+			t.Errorf("Line %d: Value = %q, want %q", i, rec.Lines[i].Value, expectedLines[i].Value)
+		}
+	}
+}
+
+// errorSeeker is a ReadSeeker that returns errors on Seek
+type errorSeeker struct {
+	io.Reader
+}
+
+func (e *errorSeeker) Seek(offset int64, whence int) (int64, error) {
+	return 0, errors.New("seek error")
+}
+
+func TestLazyParser_BuildIndex_SeekError(t *testing.T) {
+	es := &errorSeeker{Reader: strings.NewReader("0 HEAD\n0 TRLR\n")}
+	lp := NewLazyParser(es)
+
+	err := lp.BuildIndex()
+	if err == nil {
+		t.Error("Expected error from seek failure")
+	}
+}
+
+func TestLazyParser_IterateFrom_SeekError(t *testing.T) {
+	es := &errorSeeker{Reader: strings.NewReader("0 HEAD\n0 TRLR\n")}
+	lp := NewLazyParser(es)
+
+	_, err := lp.IterateFrom(10)
+	if err == nil {
+		t.Error("Expected error from seek failure")
+	}
+}
+
+func TestLazyParser_LoadIndex_InvalidData(t *testing.T) {
+	rs := newStringReadSeeker("0 HEAD\n0 TRLR\n")
+	lp := NewLazyParser(rs)
+
+	err := lp.LoadIndex(strings.NewReader("invalid gob data"))
+	if err == nil {
+		t.Error("Expected error from invalid index data")
+	}
+}
+
+func TestLazyParser_EmptyFile(t *testing.T) {
+	rs := newStringReadSeeker("")
+	lp := NewLazyParser(rs)
+
+	if err := lp.BuildIndex(); err != nil {
+		t.Fatalf("BuildIndex error: %v", err)
+	}
+
+	if lp.RecordCount() != 0 {
+		t.Errorf("RecordCount = %d, want 0", lp.RecordCount())
+	}
+}
+
+func TestLazyParser_CRLFLineEndings(t *testing.T) {
+	input := "0 HEAD\r\n1 SOUR Test\r\n0 @I1@ INDI\r\n1 NAME John\r\n0 TRLR\r\n"
+	rs := newStringReadSeeker(input)
+	lp := NewLazyParser(rs)
+
+	if err := lp.BuildIndex(); err != nil {
+		t.Fatalf("BuildIndex error: %v", err)
+	}
+
+	// Verify record lookup works with CRLF
+	rec, err := lp.FindRecord("@I1@")
+	if err != nil {
+		t.Fatalf("FindRecord error: %v", err)
+	}
+	if rec.XRef != "@I1@" {
+		t.Errorf("Record XRef = %q, want @I1@", rec.XRef)
+	}
+	if len(rec.Lines) != 2 {
+		t.Errorf("Record has %d lines, want 2", len(rec.Lines))
+	}
+}
+
+func TestLazyParser_CROnlyLineEndings(t *testing.T) {
+	input := "0 HEAD\r1 SOUR Test\r0 @I1@ INDI\r1 NAME John\r0 TRLR\r"
+	rs := newStringReadSeeker(input)
+	lp := NewLazyParser(rs)
+
+	if err := lp.BuildIndex(); err != nil {
+		t.Fatalf("BuildIndex error: %v", err)
+	}
+
+	rec, err := lp.FindRecord("@I1@")
+	if err != nil {
+		t.Fatalf("FindRecord error: %v", err)
+	}
+	if rec.XRef != "@I1@" {
+		t.Errorf("Record XRef = %q, want @I1@", rec.XRef)
+	}
+}
+
+func TestLazyParser_MixedLineEndings(t *testing.T) {
+	// Mix of CRLF, LF, and CR
+	input := "0 HEAD\r\n1 SOUR Test\n0 @I1@ INDI\r1 NAME John\n0 TRLR\r\n"
+	rs := newStringReadSeeker(input)
+	lp := NewLazyParser(rs)
+
+	if err := lp.BuildIndex(); err != nil {
+		t.Fatalf("BuildIndex error: %v", err)
+	}
+
+	rec, err := lp.FindRecord("@I1@")
+	if err != nil {
+		t.Fatalf("FindRecord error: %v", err)
+	}
+	if rec.XRef != "@I1@" {
+		t.Errorf("Record XRef = %q, want @I1@", rec.XRef)
+	}
+}

--- a/validator/streaming.go
+++ b/validator/streaming.go
@@ -1,0 +1,406 @@
+// streaming.go provides streaming validation for memory-efficient GEDCOM processing.
+//
+// The StreamingValidator validates records incrementally as they are parsed,
+// without requiring a complete Document in memory. This enables:
+//   - Validating files larger than available memory
+//   - Detecting errors early (fail-fast)
+//   - Tracking cross-references for eventual consistency checking
+//
+// Memory usage is proportional to the number of unique XRefs, not the total file size.
+//
+// # Basic Usage
+//
+//	sv := validator.NewStreamingValidator(validator.StreamingOptions{})
+//	var issues []validator.Issue
+//
+//	// Process records as they are parsed
+//	for _, record := range doc.Records {
+//	    issues = append(issues, sv.ValidateRecord(record)...)
+//	}
+//
+//	// Check cross-reference consistency
+//	issues = append(issues, sv.Finalize()...)
+
+package validator
+
+import (
+	"fmt"
+
+	"github.com/cacack/gedcom-go/gedcom"
+)
+
+// StreamingOptions configures the StreamingValidator behavior.
+type StreamingOptions struct {
+	// DateLogic configures date logic validation thresholds.
+	// If nil, default values are used.
+	DateLogic *DateLogicConfig
+
+	// Strictness controls which severity levels are included in results.
+	// Default: StrictnessNormal (errors and warnings).
+	Strictness Strictness
+}
+
+// usageLocation records where an XRef is referenced.
+type usageLocation struct {
+	// RecordXRef is the XRef of the record containing the reference.
+	RecordXRef string
+
+	// Context describes where the reference appears (e.g., "HUSB", "WIFE", "FAMC").
+	Context string
+
+	// Field provides additional detail about the reference location.
+	Field string
+
+	// Index is the position in a list (for CHIL, ChildInFamilies, etc.).
+	Index int
+}
+
+// StreamingValidator validates GEDCOM records incrementally without requiring
+// a complete Document in memory. Cross-reference validation is deferred until
+// Finalize() is called.
+type StreamingValidator struct {
+	opts StreamingOptions
+
+	// seenXRefs tracks all declared XRefs (record identifiers).
+	seenXRefs map[string]struct{}
+
+	// usedXRefs maps each referenced XRef to where it's used.
+	usedXRefs map[string][]usageLocation
+
+	// xrefTypes maps XRefs to their record types for context-aware validation.
+	xrefTypes map[string]gedcom.RecordType
+
+	// dateLogic provides date validation for individual records.
+	dateLogic *DateLogicValidator
+}
+
+// NewStreamingValidator creates a new StreamingValidator with the given options.
+// If opts is the zero value, default options are used.
+func NewStreamingValidator(opts StreamingOptions) *StreamingValidator {
+	return &StreamingValidator{
+		opts:      opts,
+		seenXRefs: make(map[string]struct{}),
+		usedXRefs: make(map[string][]usageLocation),
+		xrefTypes: make(map[string]gedcom.RecordType),
+		dateLogic: NewDateLogicValidator(opts.DateLogic),
+	}
+}
+
+// ValidateRecord validates a single record and returns immediate issues.
+// Cross-reference issues are deferred to Finalize().
+//
+// This method:
+//   - Registers the record's XRef as declared
+//   - Validates record structure and entity-specific rules
+//   - Collects XRef references for deferred validation
+//   - Returns immediate issues (malformed dates, invalid structure, etc.)
+func (sv *StreamingValidator) ValidateRecord(record *gedcom.Record) []Issue {
+	if record == nil {
+		return nil
+	}
+
+	var issues []Issue
+
+	// Register this record's XRef as declared
+	if record.XRef != "" {
+		sv.seenXRefs[record.XRef] = struct{}{}
+		sv.xrefTypes[record.XRef] = record.Type
+	}
+
+	// Validate based on record type
+	switch record.Type {
+	case gedcom.RecordTypeIndividual:
+		if ind, ok := record.GetIndividual(); ok && ind != nil {
+			issues = append(issues, sv.validateIndividual(ind)...)
+		}
+	case gedcom.RecordTypeFamily:
+		if fam, ok := record.GetFamily(); ok && fam != nil {
+			issues = append(issues, sv.validateFamily(fam)...)
+		}
+	case gedcom.RecordTypeSource:
+		if src, ok := record.GetSource(); ok && src != nil {
+			sv.collectSourceReferences(src)
+		}
+	}
+
+	return sv.filterByStrictness(issues)
+}
+
+// validateIndividual validates an Individual record and collects XRef references.
+func (sv *StreamingValidator) validateIndividual(ind *gedcom.Individual) []Issue {
+	var issues []Issue
+
+	// Validate date logic (death before birth, etc.) - these are immediate issues
+	// Note: We can only do individual-level checks without a Document.
+	// Parent-child checks require a full document and are not supported in streaming mode.
+	if issue := sv.dateLogic.checkDeathBeforeBirth(ind); issue != nil {
+		issues = append(issues, *issue)
+	}
+
+	// Collect FAMC references
+	for i, link := range ind.ChildInFamilies {
+		if link.FamilyXRef != "" {
+			sv.usedXRefs[link.FamilyXRef] = append(sv.usedXRefs[link.FamilyXRef], usageLocation{
+				RecordXRef: ind.XRef,
+				Context:    "FAMC",
+				Field:      fmt.Sprintf("ChildInFamilies[%d]", i),
+				Index:      i,
+			})
+		}
+	}
+
+	// Collect FAMS references
+	for i, famXRef := range ind.SpouseInFamilies {
+		if famXRef != "" {
+			sv.usedXRefs[famXRef] = append(sv.usedXRefs[famXRef], usageLocation{
+				RecordXRef: ind.XRef,
+				Context:    "FAMS",
+				Field:      fmt.Sprintf("SpouseInFamilies[%d]", i),
+				Index:      i,
+			})
+		}
+	}
+
+	// Collect SOUR references from individual
+	for i, citation := range ind.SourceCitations {
+		if citation != nil && citation.SourceXRef != "" {
+			sv.usedXRefs[citation.SourceXRef] = append(sv.usedXRefs[citation.SourceXRef], usageLocation{
+				RecordXRef: ind.XRef,
+				Context:    "SOUR",
+				Field:      fmt.Sprintf("SourceCitations[%d]", i),
+				Index:      i,
+			})
+		}
+	}
+
+	// Collect NOTE references
+	for i, noteXRef := range ind.Notes {
+		if noteXRef != "" {
+			sv.usedXRefs[noteXRef] = append(sv.usedXRefs[noteXRef], usageLocation{
+				RecordXRef: ind.XRef,
+				Context:    "NOTE",
+				Field:      fmt.Sprintf("Notes[%d]", i),
+				Index:      i,
+			})
+		}
+	}
+
+	// Collect ASSO references
+	for i, assoc := range ind.Associations {
+		if assoc != nil && assoc.IndividualXRef != "" {
+			sv.usedXRefs[assoc.IndividualXRef] = append(sv.usedXRefs[assoc.IndividualXRef], usageLocation{
+				RecordXRef: ind.XRef,
+				Context:    "ASSO",
+				Field:      fmt.Sprintf("Associations[%d]", i),
+				Index:      i,
+			})
+		}
+	}
+
+	return issues
+}
+
+// validateFamily validates a Family record and collects XRef references.
+// Currently only collects references; validation rules may be added later.
+//
+//nolint:unparam // Returns nil now but signature kept for future validation rules
+func (sv *StreamingValidator) validateFamily(fam *gedcom.Family) []Issue {
+	// Collect HUSB reference
+	if fam.Husband != "" {
+		sv.usedXRefs[fam.Husband] = append(sv.usedXRefs[fam.Husband], usageLocation{
+			RecordXRef: fam.XRef,
+			Context:    "HUSB",
+			Field:      "Husband",
+			Index:      0,
+		})
+	}
+
+	// Collect WIFE reference
+	if fam.Wife != "" {
+		sv.usedXRefs[fam.Wife] = append(sv.usedXRefs[fam.Wife], usageLocation{
+			RecordXRef: fam.XRef,
+			Context:    "WIFE",
+			Field:      "Wife",
+			Index:      0,
+		})
+	}
+
+	// Collect CHIL references
+	for i, childXRef := range fam.Children {
+		if childXRef != "" {
+			sv.usedXRefs[childXRef] = append(sv.usedXRefs[childXRef], usageLocation{
+				RecordXRef: fam.XRef,
+				Context:    "CHIL",
+				Field:      fmt.Sprintf("Children[%d]", i),
+				Index:      i,
+			})
+		}
+	}
+
+	// Collect SOUR references from family
+	for i, citation := range fam.SourceCitations {
+		if citation != nil && citation.SourceXRef != "" {
+			sv.usedXRefs[citation.SourceXRef] = append(sv.usedXRefs[citation.SourceXRef], usageLocation{
+				RecordXRef: fam.XRef,
+				Context:    "SOUR",
+				Field:      fmt.Sprintf("SourceCitations[%d]", i),
+				Index:      i,
+			})
+		}
+	}
+
+	// Collect NOTE references
+	for i, noteXRef := range fam.Notes {
+		if noteXRef != "" {
+			sv.usedXRefs[noteXRef] = append(sv.usedXRefs[noteXRef], usageLocation{
+				RecordXRef: fam.XRef,
+				Context:    "NOTE",
+				Field:      fmt.Sprintf("Notes[%d]", i),
+				Index:      i,
+			})
+		}
+	}
+
+	return nil
+}
+
+// collectSourceReferences collects XRef references from a Source record.
+func (sv *StreamingValidator) collectSourceReferences(src *gedcom.Source) {
+	// Collect REPO reference
+	if src.RepositoryRef != "" {
+		sv.usedXRefs[src.RepositoryRef] = append(sv.usedXRefs[src.RepositoryRef], usageLocation{
+			RecordXRef: src.XRef,
+			Context:    "REPO",
+			Field:      "RepositoryRef",
+			Index:      0,
+		})
+	}
+
+	// Collect NOTE references
+	for i, noteXRef := range src.Notes {
+		if noteXRef != "" {
+			sv.usedXRefs[noteXRef] = append(sv.usedXRefs[noteXRef], usageLocation{
+				RecordXRef: src.XRef,
+				Context:    "NOTE",
+				Field:      fmt.Sprintf("Notes[%d]", i),
+				Index:      i,
+			})
+		}
+	}
+}
+
+// Finalize completes validation and returns cross-reference issues.
+// This method should be called after all records have been validated with ValidateRecord.
+//
+// Returns issues for:
+//   - Orphaned references (XRefs used but never declared)
+func (sv *StreamingValidator) Finalize() []Issue {
+	var issues []Issue
+
+	// Check for orphaned references
+	for xref, usages := range sv.usedXRefs {
+		if _, exists := sv.seenXRefs[xref]; !exists {
+			// XRef is used but was never declared
+			for _, usage := range usages {
+				issues = append(issues, sv.createOrphanedReferenceIssue(xref, usage))
+			}
+		}
+	}
+
+	return sv.filterByStrictness(issues)
+}
+
+// createOrphanedReferenceIssue creates an issue for an orphaned reference.
+func (sv *StreamingValidator) createOrphanedReferenceIssue(xref string, usage usageLocation) Issue {
+	var code string
+	var message string
+
+	switch usage.Context {
+	case "FAMC":
+		code = CodeOrphanedFAMC
+		message = fmt.Sprintf("FAMC reference to non-existent family %s", xref)
+	case "FAMS":
+		code = CodeOrphanedFAMS
+		message = fmt.Sprintf("FAMS reference to non-existent family %s", xref)
+	case "HUSB":
+		code = CodeOrphanedHUSB
+		message = fmt.Sprintf("HUSB reference to non-existent individual %s", xref)
+	case "WIFE":
+		code = CodeOrphanedWIFE
+		message = fmt.Sprintf("WIFE reference to non-existent individual %s", xref)
+	case "CHIL":
+		code = CodeOrphanedCHIL
+		message = fmt.Sprintf("CHIL reference to non-existent individual %s", xref)
+	case "SOUR":
+		code = CodeOrphanedSOUR
+		message = fmt.Sprintf("SOUR reference to non-existent source %s", xref)
+	default:
+		// Generic orphaned reference for NOTE, ASSO, REPO, etc.
+		code = "ORPHANED_" + usage.Context
+		message = fmt.Sprintf("%s reference to non-existent record %s", usage.Context, xref)
+	}
+
+	return NewIssue(SeverityError, code, message, usage.RecordXRef).
+		WithRelatedXRef(xref).
+		WithDetail("reference_type", usage.Context).
+		WithDetail("field", usage.Field)
+}
+
+// Reset clears all internal state, allowing the validator to be reused.
+func (sv *StreamingValidator) Reset() {
+	sv.seenXRefs = make(map[string]struct{})
+	sv.usedXRefs = make(map[string][]usageLocation)
+	sv.xrefTypes = make(map[string]gedcom.RecordType)
+}
+
+// filterByStrictness filters issues based on the configured strictness level.
+func (sv *StreamingValidator) filterByStrictness(issues []Issue) []Issue {
+	if len(issues) == 0 {
+		return issues
+	}
+
+	switch sv.opts.Strictness {
+	case StrictnessRelaxed:
+		// Only errors
+		var result []Issue
+		for _, issue := range issues {
+			if issue.Severity == SeverityError {
+				result = append(result, issue)
+			}
+		}
+		return result
+	case StrictnessNormal:
+		// Errors and warnings
+		var result []Issue
+		for _, issue := range issues {
+			if issue.Severity == SeverityError || issue.Severity == SeverityWarning {
+				result = append(result, issue)
+			}
+		}
+		return result
+	case StrictnessStrict:
+		// All issues
+		return issues
+	default:
+		// Default to normal strictness
+		var result []Issue
+		for _, issue := range issues {
+			if issue.Severity == SeverityError || issue.Severity == SeverityWarning {
+				result = append(result, issue)
+			}
+		}
+		return result
+	}
+}
+
+// SeenXRefCount returns the number of declared XRefs tracked by the validator.
+// This is useful for memory usage monitoring.
+func (sv *StreamingValidator) SeenXRefCount() int {
+	return len(sv.seenXRefs)
+}
+
+// UsedXRefCount returns the number of unique XRefs referenced by records.
+// This is useful for memory usage monitoring.
+func (sv *StreamingValidator) UsedXRefCount() int {
+	return len(sv.usedXRefs)
+}

--- a/validator/streaming_test.go
+++ b/validator/streaming_test.go
@@ -1,0 +1,1046 @@
+package validator
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/cacack/gedcom-go/gedcom"
+)
+
+func TestNewStreamingValidator(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+	if sv == nil {
+		t.Error("NewStreamingValidator() returned nil")
+	}
+	if sv.seenXRefs == nil {
+		t.Error("seenXRefs map not initialized")
+	}
+	if sv.usedXRefs == nil {
+		t.Error("usedXRefs map not initialized")
+	}
+	if sv.xrefTypes == nil {
+		t.Error("xrefTypes map not initialized")
+	}
+	if sv.dateLogic == nil {
+		t.Error("dateLogic validator not initialized")
+	}
+}
+
+func TestNewStreamingValidator_WithOptions(t *testing.T) {
+	opts := StreamingOptions{
+		DateLogic: &DateLogicConfig{
+			MaxReasonableAge: 100,
+		},
+		Strictness: StrictnessStrict,
+	}
+	sv := NewStreamingValidator(opts)
+
+	if sv.opts.Strictness != StrictnessStrict {
+		t.Errorf("Expected Strictness StrictnessStrict, got %v", sv.opts.Strictness)
+	}
+}
+
+func TestStreamingValidator_ValidateRecord_NilRecord(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+	issues := sv.ValidateRecord(nil)
+	if issues != nil {
+		t.Errorf("ValidateRecord(nil) should return nil, got %d issues", len(issues))
+	}
+}
+
+func TestStreamingValidator_ValidateRecord_ValidIndividual(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+
+	ind := &gedcom.Individual{
+		XRef:  "@I1@",
+		Names: []*gedcom.PersonalName{{Full: "John /Doe/"}},
+	}
+	record := &gedcom.Record{
+		XRef:   "@I1@",
+		Type:   gedcom.RecordTypeIndividual,
+		Entity: ind,
+	}
+
+	issues := sv.ValidateRecord(record)
+	if len(issues) != 0 {
+		t.Errorf("Expected 0 issues for valid individual, got %d", len(issues))
+	}
+
+	// Verify XRef was registered
+	if _, exists := sv.seenXRefs["@I1@"]; !exists {
+		t.Error("XRef @I1@ should be registered in seenXRefs")
+	}
+}
+
+func TestStreamingValidator_ValidateRecord_RegistersXRefs(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+
+	// Create records with various XRefs
+	records := []*gedcom.Record{
+		{XRef: "@I1@", Type: gedcom.RecordTypeIndividual, Entity: &gedcom.Individual{XRef: "@I1@"}},
+		{XRef: "@I2@", Type: gedcom.RecordTypeIndividual, Entity: &gedcom.Individual{XRef: "@I2@"}},
+		{XRef: "@F1@", Type: gedcom.RecordTypeFamily, Entity: &gedcom.Family{XRef: "@F1@"}},
+		{XRef: "@S1@", Type: gedcom.RecordTypeSource, Entity: &gedcom.Source{XRef: "@S1@"}},
+	}
+
+	for _, record := range records {
+		sv.ValidateRecord(record)
+	}
+
+	// Verify all XRefs were registered
+	expectedXRefs := []string{"@I1@", "@I2@", "@F1@", "@S1@"}
+	for _, xref := range expectedXRefs {
+		if _, exists := sv.seenXRefs[xref]; !exists {
+			t.Errorf("XRef %s should be registered in seenXRefs", xref)
+		}
+	}
+
+	// Verify record types were registered
+	if sv.xrefTypes["@I1@"] != gedcom.RecordTypeIndividual {
+		t.Errorf("Expected @I1@ type Individual, got %v", sv.xrefTypes["@I1@"])
+	}
+	if sv.xrefTypes["@F1@"] != gedcom.RecordTypeFamily {
+		t.Errorf("Expected @F1@ type Family, got %v", sv.xrefTypes["@F1@"])
+	}
+}
+
+func TestStreamingValidator_ValidateRecord_CollectsFAMC(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+
+	ind := &gedcom.Individual{
+		XRef: "@I1@",
+		ChildInFamilies: []gedcom.FamilyLink{
+			{FamilyXRef: "@F1@"},
+			{FamilyXRef: "@F2@"},
+		},
+	}
+	record := &gedcom.Record{
+		XRef:   "@I1@",
+		Type:   gedcom.RecordTypeIndividual,
+		Entity: ind,
+	}
+
+	sv.ValidateRecord(record)
+
+	// Verify FAMC references were collected
+	if len(sv.usedXRefs["@F1@"]) != 1 {
+		t.Errorf("Expected 1 usage for @F1@, got %d", len(sv.usedXRefs["@F1@"]))
+	}
+	if len(sv.usedXRefs["@F2@"]) != 1 {
+		t.Errorf("Expected 1 usage for @F2@, got %d", len(sv.usedXRefs["@F2@"]))
+	}
+
+	// Verify usage details
+	usage := sv.usedXRefs["@F1@"][0]
+	if usage.RecordXRef != "@I1@" {
+		t.Errorf("Expected RecordXRef @I1@, got %s", usage.RecordXRef)
+	}
+	if usage.Context != "FAMC" {
+		t.Errorf("Expected Context FAMC, got %s", usage.Context)
+	}
+	if usage.Field != "ChildInFamilies[0]" {
+		t.Errorf("Expected Field ChildInFamilies[0], got %s", usage.Field)
+	}
+}
+
+func TestStreamingValidator_ValidateRecord_CollectsFAMS(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+
+	ind := &gedcom.Individual{
+		XRef:             "@I1@",
+		SpouseInFamilies: []string{"@F1@", "@F2@"},
+	}
+	record := &gedcom.Record{
+		XRef:   "@I1@",
+		Type:   gedcom.RecordTypeIndividual,
+		Entity: ind,
+	}
+
+	sv.ValidateRecord(record)
+
+	// Verify FAMS references were collected
+	if len(sv.usedXRefs["@F1@"]) != 1 {
+		t.Errorf("Expected 1 usage for @F1@, got %d", len(sv.usedXRefs["@F1@"]))
+	}
+
+	usage := sv.usedXRefs["@F1@"][0]
+	if usage.Context != "FAMS" {
+		t.Errorf("Expected Context FAMS, got %s", usage.Context)
+	}
+}
+
+func TestStreamingValidator_ValidateRecord_CollectsSOUR(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+
+	ind := &gedcom.Individual{
+		XRef: "@I1@",
+		SourceCitations: []*gedcom.SourceCitation{
+			{SourceXRef: "@S1@"},
+			{SourceXRef: "@S2@"},
+		},
+	}
+	record := &gedcom.Record{
+		XRef:   "@I1@",
+		Type:   gedcom.RecordTypeIndividual,
+		Entity: ind,
+	}
+
+	sv.ValidateRecord(record)
+
+	// Verify SOUR references were collected
+	if len(sv.usedXRefs["@S1@"]) != 1 {
+		t.Errorf("Expected 1 usage for @S1@, got %d", len(sv.usedXRefs["@S1@"]))
+	}
+
+	usage := sv.usedXRefs["@S1@"][0]
+	if usage.Context != "SOUR" {
+		t.Errorf("Expected Context SOUR, got %s", usage.Context)
+	}
+}
+
+func TestStreamingValidator_ValidateRecord_CollectsHUSBWIFECHIL(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+
+	fam := &gedcom.Family{
+		XRef:     "@F1@",
+		Husband:  "@I1@",
+		Wife:     "@I2@",
+		Children: []string{"@I3@", "@I4@"},
+	}
+	record := &gedcom.Record{
+		XRef:   "@F1@",
+		Type:   gedcom.RecordTypeFamily,
+		Entity: fam,
+	}
+
+	sv.ValidateRecord(record)
+
+	// Verify HUSB reference
+	if len(sv.usedXRefs["@I1@"]) != 1 {
+		t.Errorf("Expected 1 usage for @I1@, got %d", len(sv.usedXRefs["@I1@"]))
+	}
+	if sv.usedXRefs["@I1@"][0].Context != "HUSB" {
+		t.Errorf("Expected Context HUSB, got %s", sv.usedXRefs["@I1@"][0].Context)
+	}
+
+	// Verify WIFE reference
+	if len(sv.usedXRefs["@I2@"]) != 1 {
+		t.Errorf("Expected 1 usage for @I2@, got %d", len(sv.usedXRefs["@I2@"]))
+	}
+	if sv.usedXRefs["@I2@"][0].Context != "WIFE" {
+		t.Errorf("Expected Context WIFE, got %s", sv.usedXRefs["@I2@"][0].Context)
+	}
+
+	// Verify CHIL references
+	if len(sv.usedXRefs["@I3@"]) != 1 {
+		t.Errorf("Expected 1 usage for @I3@, got %d", len(sv.usedXRefs["@I3@"]))
+	}
+	if sv.usedXRefs["@I3@"][0].Context != "CHIL" {
+		t.Errorf("Expected Context CHIL, got %s", sv.usedXRefs["@I3@"][0].Context)
+	}
+}
+
+func TestStreamingValidator_ValidateRecord_DeathBeforeBirth(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+
+	// Create individual with death before birth
+	ind := &gedcom.Individual{
+		XRef: "@I1@",
+		Events: []*gedcom.Event{
+			{Type: gedcom.EventBirth, Date: "1900", ParsedDate: &gedcom.Date{Year: 1900, Original: "1900"}},
+			{Type: gedcom.EventDeath, Date: "1850", ParsedDate: &gedcom.Date{Year: 1850, Original: "1850"}},
+		},
+	}
+	record := &gedcom.Record{
+		XRef:   "@I1@",
+		Type:   gedcom.RecordTypeIndividual,
+		Entity: ind,
+	}
+
+	issues := sv.ValidateRecord(record)
+
+	if len(issues) != 1 {
+		t.Fatalf("Expected 1 issue for death before birth, got %d", len(issues))
+	}
+
+	if issues[0].Code != CodeDeathBeforeBirth {
+		t.Errorf("Expected code %s, got %s", CodeDeathBeforeBirth, issues[0].Code)
+	}
+	if issues[0].Severity != SeverityError {
+		t.Errorf("Expected severity ERROR, got %s", issues[0].Severity)
+	}
+}
+
+func TestStreamingValidator_ValidateRecord_SkipsEmptyXRefs(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+
+	ind := &gedcom.Individual{
+		XRef: "@I1@",
+		ChildInFamilies: []gedcom.FamilyLink{
+			{FamilyXRef: ""},     // Empty - should be skipped
+			{FamilyXRef: "@F1@"}, // Valid
+		},
+		SpouseInFamilies: []string{"", "@F2@"}, // First empty, second valid
+		SourceCitations: []*gedcom.SourceCitation{
+			nil,                  // Nil - should be skipped
+			{SourceXRef: ""},     // Empty - should be skipped
+			{SourceXRef: "@S1@"}, // Valid
+		},
+	}
+	record := &gedcom.Record{
+		XRef:   "@I1@",
+		Type:   gedcom.RecordTypeIndividual,
+		Entity: ind,
+	}
+
+	sv.ValidateRecord(record)
+
+	// Should only have 3 used XRefs: @F1@, @F2@, @S1@
+	if len(sv.usedXRefs) != 3 {
+		t.Errorf("Expected 3 used XRefs, got %d", len(sv.usedXRefs))
+	}
+}
+
+func TestStreamingValidator_Finalize_NoOrphanedReferences(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+
+	// Create valid linked structure
+	ind1 := &gedcom.Individual{XRef: "@I1@", SpouseInFamilies: []string{"@F1@"}}
+	ind2 := &gedcom.Individual{XRef: "@I2@", SpouseInFamilies: []string{"@F1@"}}
+	ind3 := &gedcom.Individual{XRef: "@I3@", ChildInFamilies: []gedcom.FamilyLink{{FamilyXRef: "@F1@"}}}
+	fam := &gedcom.Family{XRef: "@F1@", Husband: "@I1@", Wife: "@I2@", Children: []string{"@I3@"}}
+
+	sv.ValidateRecord(&gedcom.Record{XRef: "@I1@", Type: gedcom.RecordTypeIndividual, Entity: ind1})
+	sv.ValidateRecord(&gedcom.Record{XRef: "@I2@", Type: gedcom.RecordTypeIndividual, Entity: ind2})
+	sv.ValidateRecord(&gedcom.Record{XRef: "@I3@", Type: gedcom.RecordTypeIndividual, Entity: ind3})
+	sv.ValidateRecord(&gedcom.Record{XRef: "@F1@", Type: gedcom.RecordTypeFamily, Entity: fam})
+
+	issues := sv.Finalize()
+
+	if len(issues) != 0 {
+		t.Errorf("Expected 0 issues for valid references, got %d", len(issues))
+		for _, issue := range issues {
+			t.Logf("  Issue: %s", issue.String())
+		}
+	}
+}
+
+func TestStreamingValidator_Finalize_OrphanedFAMC(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+
+	ind := &gedcom.Individual{
+		XRef:            "@I1@",
+		ChildInFamilies: []gedcom.FamilyLink{{FamilyXRef: "@F999@"}}, // Non-existent family
+	}
+	sv.ValidateRecord(&gedcom.Record{XRef: "@I1@", Type: gedcom.RecordTypeIndividual, Entity: ind})
+
+	issues := sv.Finalize()
+
+	if len(issues) != 1 {
+		t.Fatalf("Expected 1 issue, got %d", len(issues))
+	}
+
+	issue := issues[0]
+	if issue.Code != CodeOrphanedFAMC {
+		t.Errorf("Expected code %s, got %s", CodeOrphanedFAMC, issue.Code)
+	}
+	if issue.RecordXRef != "@I1@" {
+		t.Errorf("Expected RecordXRef @I1@, got %s", issue.RecordXRef)
+	}
+	if issue.RelatedXRef != "@F999@" {
+		t.Errorf("Expected RelatedXRef @F999@, got %s", issue.RelatedXRef)
+	}
+}
+
+func TestStreamingValidator_Finalize_OrphanedFAMS(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+
+	ind := &gedcom.Individual{
+		XRef:             "@I1@",
+		SpouseInFamilies: []string{"@F999@"}, // Non-existent family
+	}
+	sv.ValidateRecord(&gedcom.Record{XRef: "@I1@", Type: gedcom.RecordTypeIndividual, Entity: ind})
+
+	issues := sv.Finalize()
+
+	if len(issues) != 1 {
+		t.Fatalf("Expected 1 issue, got %d", len(issues))
+	}
+
+	if issues[0].Code != CodeOrphanedFAMS {
+		t.Errorf("Expected code %s, got %s", CodeOrphanedFAMS, issues[0].Code)
+	}
+}
+
+func TestStreamingValidator_Finalize_OrphanedHUSB(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+
+	fam := &gedcom.Family{
+		XRef:    "@F1@",
+		Husband: "@I999@", // Non-existent individual
+	}
+	sv.ValidateRecord(&gedcom.Record{XRef: "@F1@", Type: gedcom.RecordTypeFamily, Entity: fam})
+
+	issues := sv.Finalize()
+
+	if len(issues) != 1 {
+		t.Fatalf("Expected 1 issue, got %d", len(issues))
+	}
+
+	if issues[0].Code != CodeOrphanedHUSB {
+		t.Errorf("Expected code %s, got %s", CodeOrphanedHUSB, issues[0].Code)
+	}
+}
+
+func TestStreamingValidator_Finalize_OrphanedWIFE(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+
+	fam := &gedcom.Family{
+		XRef: "@F1@",
+		Wife: "@I999@", // Non-existent individual
+	}
+	sv.ValidateRecord(&gedcom.Record{XRef: "@F1@", Type: gedcom.RecordTypeFamily, Entity: fam})
+
+	issues := sv.Finalize()
+
+	if len(issues) != 1 {
+		t.Fatalf("Expected 1 issue, got %d", len(issues))
+	}
+
+	if issues[0].Code != CodeOrphanedWIFE {
+		t.Errorf("Expected code %s, got %s", CodeOrphanedWIFE, issues[0].Code)
+	}
+}
+
+func TestStreamingValidator_Finalize_OrphanedCHIL(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+
+	fam := &gedcom.Family{
+		XRef:     "@F1@",
+		Children: []string{"@I999@"}, // Non-existent individual
+	}
+	sv.ValidateRecord(&gedcom.Record{XRef: "@F1@", Type: gedcom.RecordTypeFamily, Entity: fam})
+
+	issues := sv.Finalize()
+
+	if len(issues) != 1 {
+		t.Fatalf("Expected 1 issue, got %d", len(issues))
+	}
+
+	if issues[0].Code != CodeOrphanedCHIL {
+		t.Errorf("Expected code %s, got %s", CodeOrphanedCHIL, issues[0].Code)
+	}
+}
+
+func TestStreamingValidator_Finalize_OrphanedSOUR(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+
+	ind := &gedcom.Individual{
+		XRef:            "@I1@",
+		SourceCitations: []*gedcom.SourceCitation{{SourceXRef: "@S999@"}}, // Non-existent source
+	}
+	sv.ValidateRecord(&gedcom.Record{XRef: "@I1@", Type: gedcom.RecordTypeIndividual, Entity: ind})
+
+	issues := sv.Finalize()
+
+	if len(issues) != 1 {
+		t.Fatalf("Expected 1 issue, got %d", len(issues))
+	}
+
+	if issues[0].Code != CodeOrphanedSOUR {
+		t.Errorf("Expected code %s, got %s", CodeOrphanedSOUR, issues[0].Code)
+	}
+}
+
+func TestStreamingValidator_Finalize_MultipleOrphanedReferences(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+
+	// Create records with multiple orphaned references
+	ind := &gedcom.Individual{
+		XRef:             "@I1@",
+		ChildInFamilies:  []gedcom.FamilyLink{{FamilyXRef: "@F999@"}},
+		SpouseInFamilies: []string{"@F998@"},
+		SourceCitations:  []*gedcom.SourceCitation{{SourceXRef: "@S999@"}},
+	}
+	fam := &gedcom.Family{
+		XRef:     "@F1@",
+		Husband:  "@I999@",
+		Wife:     "@I998@",
+		Children: []string{"@I997@"},
+	}
+
+	sv.ValidateRecord(&gedcom.Record{XRef: "@I1@", Type: gedcom.RecordTypeIndividual, Entity: ind})
+	sv.ValidateRecord(&gedcom.Record{XRef: "@F1@", Type: gedcom.RecordTypeFamily, Entity: fam})
+
+	issues := sv.Finalize()
+
+	// Should have 6 orphaned references:
+	// FAMC @F999@, FAMS @F998@, SOUR @S999@, HUSB @I999@, WIFE @I998@, CHIL @I997@
+	if len(issues) != 6 {
+		t.Errorf("Expected 6 issues, got %d", len(issues))
+		for _, issue := range issues {
+			t.Logf("  Issue: %s", issue.String())
+		}
+	}
+
+	// Count by code
+	counts := make(map[string]int)
+	for _, issue := range issues {
+		counts[issue.Code]++
+	}
+
+	expectedCounts := map[string]int{
+		CodeOrphanedFAMC: 1,
+		CodeOrphanedFAMS: 1,
+		CodeOrphanedSOUR: 1,
+		CodeOrphanedHUSB: 1,
+		CodeOrphanedWIFE: 1,
+		CodeOrphanedCHIL: 1,
+	}
+
+	for code, expected := range expectedCounts {
+		if counts[code] != expected {
+			t.Errorf("Expected %d %s issues, got %d", expected, code, counts[code])
+		}
+	}
+}
+
+func TestStreamingValidator_Reset(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+
+	// Add some data
+	ind := &gedcom.Individual{
+		XRef:             "@I1@",
+		SpouseInFamilies: []string{"@F1@"},
+	}
+	sv.ValidateRecord(&gedcom.Record{XRef: "@I1@", Type: gedcom.RecordTypeIndividual, Entity: ind})
+
+	// Verify data was added
+	if len(sv.seenXRefs) == 0 {
+		t.Error("seenXRefs should have data before reset")
+	}
+	if len(sv.usedXRefs) == 0 {
+		t.Error("usedXRefs should have data before reset")
+	}
+
+	// Reset
+	sv.Reset()
+
+	// Verify data was cleared
+	if len(sv.seenXRefs) != 0 {
+		t.Error("seenXRefs should be empty after reset")
+	}
+	if len(sv.usedXRefs) != 0 {
+		t.Error("usedXRefs should be empty after reset")
+	}
+	if len(sv.xrefTypes) != 0 {
+		t.Error("xrefTypes should be empty after reset")
+	}
+}
+
+func TestStreamingValidator_Reset_CanBeReused(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+
+	// First file: has orphaned reference
+	ind1 := &gedcom.Individual{
+		XRef:             "@I1@",
+		SpouseInFamilies: []string{"@F999@"},
+	}
+	sv.ValidateRecord(&gedcom.Record{XRef: "@I1@", Type: gedcom.RecordTypeIndividual, Entity: ind1})
+	issues1 := sv.Finalize()
+
+	if len(issues1) != 1 {
+		t.Errorf("First file: expected 1 issue, got %d", len(issues1))
+	}
+
+	// Reset for second file
+	sv.Reset()
+
+	// Second file: valid references
+	ind2 := &gedcom.Individual{
+		XRef:             "@I1@",
+		SpouseInFamilies: []string{"@F1@"},
+	}
+	fam := &gedcom.Family{XRef: "@F1@", Husband: "@I1@"}
+
+	sv.ValidateRecord(&gedcom.Record{XRef: "@I1@", Type: gedcom.RecordTypeIndividual, Entity: ind2})
+	sv.ValidateRecord(&gedcom.Record{XRef: "@F1@", Type: gedcom.RecordTypeFamily, Entity: fam})
+	issues2 := sv.Finalize()
+
+	if len(issues2) != 0 {
+		t.Errorf("Second file: expected 0 issues, got %d", len(issues2))
+		for _, issue := range issues2 {
+			t.Logf("  Issue: %s", issue.String())
+		}
+	}
+}
+
+func TestStreamingValidator_SeenXRefCount(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+
+	if sv.SeenXRefCount() != 0 {
+		t.Error("SeenXRefCount should be 0 initially")
+	}
+
+	// Add records
+	sv.ValidateRecord(&gedcom.Record{XRef: "@I1@", Type: gedcom.RecordTypeIndividual, Entity: &gedcom.Individual{XRef: "@I1@"}})
+	sv.ValidateRecord(&gedcom.Record{XRef: "@I2@", Type: gedcom.RecordTypeIndividual, Entity: &gedcom.Individual{XRef: "@I2@"}})
+	sv.ValidateRecord(&gedcom.Record{XRef: "@F1@", Type: gedcom.RecordTypeFamily, Entity: &gedcom.Family{XRef: "@F1@"}})
+
+	if sv.SeenXRefCount() != 3 {
+		t.Errorf("SeenXRefCount should be 3, got %d", sv.SeenXRefCount())
+	}
+}
+
+func TestStreamingValidator_UsedXRefCount(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+
+	if sv.UsedXRefCount() != 0 {
+		t.Error("UsedXRefCount should be 0 initially")
+	}
+
+	// Add individual with references
+	ind := &gedcom.Individual{
+		XRef:             "@I1@",
+		SpouseInFamilies: []string{"@F1@", "@F2@"},
+		SourceCitations:  []*gedcom.SourceCitation{{SourceXRef: "@S1@"}},
+	}
+	sv.ValidateRecord(&gedcom.Record{XRef: "@I1@", Type: gedcom.RecordTypeIndividual, Entity: ind})
+
+	// Should have 3 unique used XRefs: @F1@, @F2@, @S1@
+	if sv.UsedXRefCount() != 3 {
+		t.Errorf("UsedXRefCount should be 3, got %d", sv.UsedXRefCount())
+	}
+}
+
+func TestStreamingValidator_MemoryUsage(t *testing.T) {
+	// Test that memory usage is proportional to unique XRefs, not record count
+	sv := NewStreamingValidator(StreamingOptions{})
+
+	// Create 1000 individuals, all referencing the same family
+	for i := 0; i < 1000; i++ {
+		xref := fmt.Sprintf("@I%d@", i)
+		ind := &gedcom.Individual{
+			XRef:             xref,
+			SpouseInFamilies: []string{"@F1@"}, // All reference same family
+		}
+		sv.ValidateRecord(&gedcom.Record{XRef: xref, Type: gedcom.RecordTypeIndividual, Entity: ind})
+	}
+
+	// Should have 1000 seen XRefs (one per individual)
+	if sv.SeenXRefCount() != 1000 {
+		t.Errorf("SeenXRefCount should be 1000, got %d", sv.SeenXRefCount())
+	}
+
+	// But only 1 used XRef (@F1@) - memory is O(unique XRefs), not O(records)
+	if sv.UsedXRefCount() != 1 {
+		t.Errorf("UsedXRefCount should be 1, got %d", sv.UsedXRefCount())
+	}
+
+	// The @F1@ usage should have 1000 entries though
+	if len(sv.usedXRefs["@F1@"]) != 1000 {
+		t.Errorf("@F1@ should have 1000 usages, got %d", len(sv.usedXRefs["@F1@"]))
+	}
+}
+
+func TestStreamingValidator_Strictness_Relaxed(t *testing.T) {
+	// Note: Currently StreamingValidator only produces ERROR severity issues
+	// from date logic validation and cross-reference checking.
+	// This test verifies the strictness filtering works correctly.
+	sv := NewStreamingValidator(StreamingOptions{Strictness: StrictnessRelaxed})
+
+	// Death before birth produces ERROR
+	ind := &gedcom.Individual{
+		XRef: "@I1@",
+		Events: []*gedcom.Event{
+			{Type: gedcom.EventBirth, ParsedDate: &gedcom.Date{Year: 1900, Original: "1900"}},
+			{Type: gedcom.EventDeath, ParsedDate: &gedcom.Date{Year: 1850, Original: "1850"}},
+		},
+	}
+	issues := sv.ValidateRecord(&gedcom.Record{XRef: "@I1@", Type: gedcom.RecordTypeIndividual, Entity: ind})
+
+	// ERROR issues should be included in relaxed mode
+	if len(issues) != 1 {
+		t.Errorf("Expected 1 ERROR issue in relaxed mode, got %d", len(issues))
+	}
+}
+
+func TestStreamingValidator_Strictness_FiltersWarnings(t *testing.T) {
+	// Test that strictness filtering is applied to Finalize() results
+	sv := NewStreamingValidator(StreamingOptions{Strictness: StrictnessRelaxed})
+
+	// Add orphaned reference (produces ERROR)
+	ind := &gedcom.Individual{XRef: "@I1@", SpouseInFamilies: []string{"@F999@"}}
+	sv.ValidateRecord(&gedcom.Record{XRef: "@I1@", Type: gedcom.RecordTypeIndividual, Entity: ind})
+
+	issues := sv.Finalize()
+
+	// Should still get the ERROR-level orphaned reference issue
+	if len(issues) != 1 {
+		t.Errorf("Expected 1 issue, got %d", len(issues))
+	}
+}
+
+func TestStreamingValidator_EquivalenceToBatchValidator(t *testing.T) {
+	// Test that streaming validation produces equivalent results to batch validation
+	// for the same document
+
+	// Create a test document
+	doc := newTestDocument()
+
+	// Valid individuals and families
+	ind1 := &gedcom.Individual{XRef: "@I1@", SpouseInFamilies: []string{"@F1@"}}
+	ind2 := &gedcom.Individual{XRef: "@I2@", SpouseInFamilies: []string{"@F1@"}}
+	ind3 := &gedcom.Individual{XRef: "@I3@", ChildInFamilies: []gedcom.FamilyLink{{FamilyXRef: "@F1@"}}}
+	fam := &gedcom.Family{XRef: "@F1@", Husband: "@I1@", Wife: "@I2@", Children: []string{"@I3@"}}
+	src := &gedcom.Source{XRef: "@S1@"}
+
+	// Add valid source citation
+	ind1.SourceCitations = []*gedcom.SourceCitation{{SourceXRef: "@S1@"}}
+
+	// Add orphaned references
+	ind1.ChildInFamilies = []gedcom.FamilyLink{{FamilyXRef: "@F999@"}} // Orphaned FAMC
+
+	addIndividual(doc, ind1)
+	addIndividual(doc, ind2)
+	addIndividual(doc, ind3)
+	addFamily(doc, fam)
+	addSource(doc, src)
+
+	// Batch validation
+	batchV := NewReferenceValidator()
+	batchIssues := batchV.Validate(doc)
+
+	// Streaming validation
+	streamV := NewStreamingValidator(StreamingOptions{})
+	for _, record := range doc.Records {
+		streamV.ValidateRecord(record)
+	}
+	streamIssues := streamV.Finalize()
+
+	// Compare results
+	// Both should find the same orphaned FAMC reference
+	if len(batchIssues) != len(streamIssues) {
+		t.Errorf("Issue count mismatch: batch=%d, streaming=%d", len(batchIssues), len(streamIssues))
+		t.Log("Batch issues:")
+		for _, issue := range batchIssues {
+			t.Logf("  %s", issue.String())
+		}
+		t.Log("Streaming issues:")
+		for _, issue := range streamIssues {
+			t.Logf("  %s", issue.String())
+		}
+		return
+	}
+
+	// Sort issues by code and RecordXRef for comparison
+	sortIssues := func(issues []Issue) {
+		sort.Slice(issues, func(i, j int) bool {
+			if issues[i].Code != issues[j].Code {
+				return issues[i].Code < issues[j].Code
+			}
+			return issues[i].RecordXRef < issues[j].RecordXRef
+		})
+	}
+
+	sortIssues(batchIssues)
+	sortIssues(streamIssues)
+
+	for i := range batchIssues {
+		if batchIssues[i].Code != streamIssues[i].Code {
+			t.Errorf("Code mismatch at %d: batch=%s, streaming=%s", i, batchIssues[i].Code, streamIssues[i].Code)
+		}
+		if batchIssues[i].RecordXRef != streamIssues[i].RecordXRef {
+			t.Errorf("RecordXRef mismatch at %d: batch=%s, streaming=%s", i, batchIssues[i].RecordXRef, streamIssues[i].RecordXRef)
+		}
+		if batchIssues[i].RelatedXRef != streamIssues[i].RelatedXRef {
+			t.Errorf("RelatedXRef mismatch at %d: batch=%s, streaming=%s", i, batchIssues[i].RelatedXRef, streamIssues[i].RelatedXRef)
+		}
+	}
+}
+
+func TestStreamingValidator_EmptyFamilyReferences(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+
+	// Family with empty references - should not create issues
+	fam := &gedcom.Family{
+		XRef:     "@F1@",
+		Husband:  "",           // Empty
+		Wife:     "",           // Empty
+		Children: []string{""}, // Empty child reference
+	}
+	sv.ValidateRecord(&gedcom.Record{XRef: "@F1@", Type: gedcom.RecordTypeFamily, Entity: fam})
+
+	issues := sv.Finalize()
+
+	if len(issues) != 0 {
+		t.Errorf("Expected 0 issues for empty references, got %d", len(issues))
+		for _, issue := range issues {
+			t.Logf("  Issue: %s", issue.String())
+		}
+	}
+}
+
+func TestStreamingValidator_NoteReferences(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+
+	ind := &gedcom.Individual{
+		XRef:  "@I1@",
+		Notes: []string{"@N1@", "@N999@"}, // Second is orphaned
+	}
+	sv.ValidateRecord(&gedcom.Record{XRef: "@I1@", Type: gedcom.RecordTypeIndividual, Entity: ind})
+	sv.ValidateRecord(&gedcom.Record{XRef: "@N1@", Type: gedcom.RecordTypeNote, Entity: &gedcom.Note{XRef: "@N1@"}})
+
+	issues := sv.Finalize()
+
+	if len(issues) != 1 {
+		t.Fatalf("Expected 1 issue for orphaned NOTE, got %d", len(issues))
+	}
+
+	if issues[0].Details["reference_type"] != "NOTE" {
+		t.Errorf("Expected reference_type NOTE, got %s", issues[0].Details["reference_type"])
+	}
+}
+
+func TestStreamingValidator_AssociationReferences(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+
+	ind := &gedcom.Individual{
+		XRef: "@I1@",
+		Associations: []*gedcom.Association{
+			{IndividualXRef: "@I2@"},   // Valid
+			{IndividualXRef: "@I999@"}, // Orphaned
+		},
+	}
+	sv.ValidateRecord(&gedcom.Record{XRef: "@I1@", Type: gedcom.RecordTypeIndividual, Entity: ind})
+	sv.ValidateRecord(&gedcom.Record{XRef: "@I2@", Type: gedcom.RecordTypeIndividual, Entity: &gedcom.Individual{XRef: "@I2@"}})
+
+	issues := sv.Finalize()
+
+	if len(issues) != 1 {
+		t.Fatalf("Expected 1 issue for orphaned ASSO, got %d", len(issues))
+	}
+
+	if issues[0].Details["reference_type"] != "ASSO" {
+		t.Errorf("Expected reference_type ASSO, got %s", issues[0].Details["reference_type"])
+	}
+}
+
+func TestStreamingValidator_SourceRepositoryReference(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+
+	src := &gedcom.Source{
+		XRef:          "@S1@",
+		RepositoryRef: "@R999@", // Orphaned repository reference
+	}
+	sv.ValidateRecord(&gedcom.Record{XRef: "@S1@", Type: gedcom.RecordTypeSource, Entity: src})
+
+	issues := sv.Finalize()
+
+	if len(issues) != 1 {
+		t.Fatalf("Expected 1 issue for orphaned REPO, got %d", len(issues))
+	}
+
+	if issues[0].Details["reference_type"] != "REPO" {
+		t.Errorf("Expected reference_type REPO, got %s", issues[0].Details["reference_type"])
+	}
+}
+
+func TestStreamingValidator_FamilyNoteReferences(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+
+	fam := &gedcom.Family{
+		XRef:  "@F1@",
+		Notes: []string{"@N999@"}, // Orphaned note
+	}
+	sv.ValidateRecord(&gedcom.Record{XRef: "@F1@", Type: gedcom.RecordTypeFamily, Entity: fam})
+
+	issues := sv.Finalize()
+
+	if len(issues) != 1 {
+		t.Fatalf("Expected 1 issue for orphaned NOTE in family, got %d", len(issues))
+	}
+
+	if issues[0].RecordXRef != "@F1@" {
+		t.Errorf("Expected RecordXRef @F1@, got %s", issues[0].RecordXRef)
+	}
+}
+
+func TestStreamingValidator_FamilySourceReferences(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+
+	fam := &gedcom.Family{
+		XRef:            "@F1@",
+		SourceCitations: []*gedcom.SourceCitation{{SourceXRef: "@S999@"}}, // Orphaned source
+	}
+	sv.ValidateRecord(&gedcom.Record{XRef: "@F1@", Type: gedcom.RecordTypeFamily, Entity: fam})
+
+	issues := sv.Finalize()
+
+	if len(issues) != 1 {
+		t.Fatalf("Expected 1 issue for orphaned SOUR in family, got %d", len(issues))
+	}
+
+	if issues[0].Code != CodeOrphanedSOUR {
+		t.Errorf("Expected code %s, got %s", CodeOrphanedSOUR, issues[0].Code)
+	}
+}
+
+func TestStreamingValidator_SourceNoteReferences(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+
+	src := &gedcom.Source{
+		XRef:  "@S1@",
+		Notes: []string{"@N999@"}, // Orphaned note
+	}
+	sv.ValidateRecord(&gedcom.Record{XRef: "@S1@", Type: gedcom.RecordTypeSource, Entity: src})
+
+	issues := sv.Finalize()
+
+	if len(issues) != 1 {
+		t.Fatalf("Expected 1 issue for orphaned NOTE in source, got %d", len(issues))
+	}
+
+	if issues[0].RecordXRef != "@S1@" {
+		t.Errorf("Expected RecordXRef @S1@, got %s", issues[0].RecordXRef)
+	}
+}
+
+func TestStreamingValidator_RecordWithNoXRef(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+
+	// Record with empty XRef (shouldn't crash)
+	record := &gedcom.Record{
+		XRef:   "",
+		Type:   gedcom.RecordTypeIndividual,
+		Entity: &gedcom.Individual{XRef: ""},
+	}
+
+	// Should not panic
+	issues := sv.ValidateRecord(record)
+
+	if len(issues) != 0 {
+		t.Errorf("Expected 0 issues for record with no XRef, got %d", len(issues))
+	}
+
+	// Empty XRef should not be added to seenXRefs
+	if _, exists := sv.seenXRefs[""]; exists {
+		t.Error("Empty XRef should not be added to seenXRefs")
+	}
+}
+
+func TestStreamingValidator_NilEntity(t *testing.T) {
+	sv := NewStreamingValidator(StreamingOptions{})
+
+	// Record with nil Entity (shouldn't crash)
+	record := &gedcom.Record{
+		XRef:   "@I1@",
+		Type:   gedcom.RecordTypeIndividual,
+		Entity: nil,
+	}
+
+	// Should not panic
+	issues := sv.ValidateRecord(record)
+
+	if len(issues) != 0 {
+		t.Errorf("Expected 0 issues for record with nil Entity, got %d", len(issues))
+	}
+
+	// XRef should still be registered even with nil Entity
+	if _, exists := sv.seenXRefs["@I1@"]; !exists {
+		t.Error("XRef should be registered even with nil Entity")
+	}
+}
+
+func TestStreamingValidator_filterByStrictness_AllBranches(t *testing.T) {
+	// Create test issues with different severities
+	errorIssue := NewIssue(SeverityError, "TEST_ERROR", "Error issue", "@I1@")
+	warningIssue := NewIssue(SeverityWarning, "TEST_WARNING", "Warning issue", "@I1@")
+	infoIssue := NewIssue(SeverityInfo, "TEST_INFO", "Info issue", "@I1@")
+	allIssues := []Issue{errorIssue, warningIssue, infoIssue}
+
+	tests := []struct {
+		name          string
+		strictness    Strictness
+		inputIssues   []Issue
+		expectedCount int
+	}{
+		{
+			name:          "relaxed with all severities",
+			strictness:    StrictnessRelaxed,
+			inputIssues:   allIssues,
+			expectedCount: 1, // Only errors
+		},
+		{
+			name:          "normal with all severities",
+			strictness:    StrictnessNormal,
+			inputIssues:   allIssues,
+			expectedCount: 2, // Errors and warnings
+		},
+		{
+			name:          "strict with all severities",
+			strictness:    StrictnessStrict,
+			inputIssues:   allIssues,
+			expectedCount: 3, // All issues
+		},
+		{
+			name:          "empty issues",
+			strictness:    StrictnessNormal,
+			inputIssues:   []Issue{},
+			expectedCount: 0, // Empty returns empty
+		},
+		{
+			name:          "default (zero value) strictness",
+			strictness:    Strictness(99), // Invalid value triggers default
+			inputIssues:   allIssues,
+			expectedCount: 2, // Defaults to normal
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sv := NewStreamingValidator(StreamingOptions{Strictness: tt.strictness})
+			result := sv.filterByStrictness(tt.inputIssues)
+
+			if len(result) != tt.expectedCount {
+				t.Errorf("Expected %d issues, got %d", tt.expectedCount, len(result))
+			}
+		})
+	}
+}
+
+func TestStreamingValidator_Strictness_Normal(t *testing.T) {
+	// Test that Normal strictness filters out Info but keeps Error and Warning
+	sv := NewStreamingValidator(StreamingOptions{Strictness: StrictnessNormal})
+
+	// Add orphaned reference (produces ERROR)
+	ind := &gedcom.Individual{XRef: "@I1@", SpouseInFamilies: []string{"@F999@"}}
+	sv.ValidateRecord(&gedcom.Record{XRef: "@I1@", Type: gedcom.RecordTypeIndividual, Entity: ind})
+
+	issues := sv.Finalize()
+
+	// Should get the ERROR-level orphaned reference issue
+	if len(issues) != 1 {
+		t.Errorf("Expected 1 issue, got %d", len(issues))
+	}
+	if len(issues) > 0 && issues[0].Severity != SeverityError {
+		t.Errorf("Expected ERROR severity, got %s", issues[0].Severity)
+	}
+}
+
+func TestStreamingValidator_Strictness_Strict(t *testing.T) {
+	// Test that Strict strictness includes all issues
+	sv := NewStreamingValidator(StreamingOptions{Strictness: StrictnessStrict})
+
+	// Add orphaned reference (produces ERROR)
+	ind := &gedcom.Individual{XRef: "@I1@", SpouseInFamilies: []string{"@F999@"}}
+	sv.ValidateRecord(&gedcom.Record{XRef: "@I1@", Type: gedcom.RecordTypeIndividual, Entity: ind})
+
+	issues := sv.Finalize()
+
+	// Should get the ERROR-level orphaned reference issue
+	if len(issues) != 1 {
+		t.Errorf("Expected 1 issue, got %d", len(issues))
+	}
+}


### PR DESCRIPTION
## Summary

Implements memory-efficient streaming APIs for handling very large GEDCOM files (1M+ records):

- **Streaming Encoder** (#45) - Write records incrementally with O(1) memory
- **Streaming Validator** (#103) - Validate records incrementally with deferred cross-reference checking
- **Incremental Parser** (#46) - Stream records and build indexes for O(1) random access

## Changes

### New Files (10)
- `encoder/streaming.go` + tests - StreamEncoder with state machine
- `validator/streaming.go` + tests - StreamingValidator with two-phase validation
- `parser/iterator.go` + tests - RecordIterator for streaming
- `parser/index.go` + tests - RecordIndex for O(1) lookup
- `parser/lazy.go` + tests - LazyParser combining both

### Documentation Updates (3)
- `FEATURES.md` - New sections for all streaming APIs
- `README.md` - Added streaming support to features list
- `docs/PERFORMANCE.md` - Added benchmarks and recommendations

## Test plan

- [x] All pre-commit checks pass (lint, vet, tests)
- [x] Per-package coverage ≥85% (all packages: 92-100%)
- [x] Streaming encoder output matches batch encoder
- [x] Streaming validator results match batch validator
- [x] Iterator output matches full parse output

## Performance

| API | Memory | Use Case |
|-----|--------|----------|
| Stream Encoder | O(1) | Generate large files |
| Stream Validator | O(unique XRefs) | Validate large files |
| Record Iterator | O(1) per record | Single-pass processing |
| Lazy Parser | O(index entries) | Random access |

Closes #45
Closes #103
Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)