### PR TITLE
Exempt Dependabot PRs from title format check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,12 @@ jobs:
             exit 0
           fi
 
+          # Exempt Dependabot PRs (they use conventional commit format by default)
+          if [[ "${{ github.event.pull_request.user.login }}" == "dependabot[bot]" ]]; then
+            echo "✅ Dependabot PR exempt from title check"
+            exit 0
+          fi
+
           PATTERN="^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?!?:"
           if echo "$TITLE" | grep -qE "$PATTERN"; then
             echo "::error::PR title should NOT use conventional commit format."


### PR DESCRIPTION
## Summary
- Add exemption for `dependabot[bot]` user to PR title validation
- Allows Dependabot auto-generated conventional commit titles (e.g., `ci: bump foo from X to Y`)
- Fixes failing PR #116

## Test plan
- [ ] Verify this PR passes the PR Title Check
- [ ] After merge, verify PR #116 passes when rebased

🤖 Generated with [Claude Code](https://claude.com/claude-code)