### PR TITLE
Handle UTF-8 buffer boundary correctly

### DIFF
--- a/charset/charset.go
+++ b/charset/charset.go
@@ -97,6 +97,10 @@ type utf8Reader struct {
 }
 
 func (u *utf8Reader) Read(p []byte) (n int, err error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
 	// Return buffered BOM bytes first if any
 	if n, ok := u.readBuffered(p); ok {
 		return n, nil


### PR DESCRIPTION
## Problem

When reading GEDCOM files containing multi-byte UTF-8 characters (such as German umlauts ö, ü, ä, ß), the charset reader could report false "invalid UTF-8" errors. This occurred when the underlying reader returned data in chunks that split multi-byte sequences across read boundaries.

For example, the German text "Viele Grüße" contains the 2-byte UTF-8 sequence `ü` (0xC3 0xBC). If the reader returned `Gr` + `0xC3` in one read and `0xBC` + `ße` in the next, the validation would incorrectly reject the incomplete sequence.

## Solution

Add a pending bytes mechanism to accumulate incomplete UTF-8 sequences between reads:

- Track incomplete sequences at the end of each read in a `pending` buffer
- Prepend pending bytes to the next read before validation
- Only validate complete UTF-8 sequences
- Report incomplete sequences at EOF as invalid UTF-8

## Changes

- `charset/charset.go`: Add `pending` field and `findLastCompleteUTF8()` function
- `charset/charset_test.go`: Add tests for buffer boundary handling

## Test Plan

- [x] Existing tests pass
- [x] New tests cover 2-byte, 3-byte, and 4-byte UTF-8 boundary splits
- [x] New tests cover small output buffer scenarios
- [x] New tests verify incomplete sequences at EOF are rejected
- [x] Coverage maintained at 92%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / Improvements**
  * Improved streaming UTF‑8 handling: incomplete multi‑byte sequences are buffered across reads, validated at sequence boundaries, emitted in order, and EOF with leftover partial sequences now returns an error after valid bytes are delivered. BOM handling and position tracking preserved.

* **Tests**
  * Expanded coverage for UTF‑8 boundary conditions, small/tiny buffers, chunked/fragmented input, LATIN‑1, ANSEL and mixed‑encoding scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->