### PR TITLE
Implement SNOTE (Shared Note) for GEDCOM 7.0

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -156,6 +156,43 @@ if doc.Schema != nil {
 
 The schema is parsed from the GEDCOM 7.0 header's SCHMA structure and stored in `Document.Schema`. For GEDCOM 5.5/5.5.1 files, `Document.Schema` is nil.
 
+### Shared Notes (SNOTE)
+
+GEDCOM 7.0 shared notes are distinct from inline NOTE tags, supporting MIME types, language tags, and translations for multi-language note content.
+
+```go
+// Access shared notes
+for _, snote := range doc.SharedNotes() {
+    fmt.Println(snote.XRef)      // "@N1@"
+    fmt.Println(snote.Text)      // "Note content"
+    fmt.Println(snote.MIME)      // "text/html"
+    fmt.Println(snote.Language)  // "en"
+
+    // Access translations
+    for _, tran := range snote.Translations {
+        fmt.Println(tran.Value)     // "Translated content"
+        fmt.Println(tran.Language)  // "es"
+        fmt.Println(tran.MIME)      // "text/plain"
+    }
+}
+
+// Lookup by XRef
+snote := doc.GetSharedNote("@N1@")
+```
+
+| Field | Description |
+|-------|-------------|
+| XRef | Cross-reference identifier |
+| Text | Note content |
+| MIME | Media type (text/plain, text/html) |
+| Language | BCP 47 language tag |
+| Translations | Translated versions with their own MIME/Language |
+| SourceCitations | Source citations on the note |
+| ExternalIDs | External identifiers (EXID) |
+| ChangeDate | Last modification date |
+
+Supported on: Document (as top-level records accessible via `SharedNotes()` and `GetSharedNote()`)
+
 ## Character Encoding
 
 | Encoding | Status | Notes |

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -75,9 +75,16 @@ func writeHeader(w io.Writer, header *gedcom.Header, opts *EncodeOptions) error 
 
 func writeRecord(w io.Writer, record *gedcom.Record, opts *EncodeOptions) error {
 	// Write record line
+	// Some records (NOTE, SNOTE) have a value on the level 0 line
 	if record.XRef != "" {
-		if _, err := fmt.Fprintf(w, "0 %s %s%s", record.XRef, record.Type, opts.LineEnding); err != nil {
-			return err
+		if record.Value != "" {
+			if _, err := fmt.Fprintf(w, "0 %s %s %s%s", record.XRef, record.Type, record.Value, opts.LineEnding); err != nil {
+				return err
+			}
+		} else {
+			if _, err := fmt.Fprintf(w, "0 %s %s%s", record.XRef, record.Type, opts.LineEnding); err != nil {
+				return err
+			}
 		}
 	} else {
 		if _, err := fmt.Fprintf(w, "0 %s%s", record.Type, opts.LineEnding); err != nil {

--- a/gedcom/document.go
+++ b/gedcom/document.go
@@ -200,3 +200,27 @@ func (d *Document) MediaObjects() []*MediaObject {
 	}
 	return objects
 }
+
+// GetSharedNote returns the shared note record with the given XRef.
+// Returns nil if not found or if the record is not a shared note.
+func (d *Document) GetSharedNote(xref string) *SharedNote {
+	record := d.GetRecord(xref)
+	if record == nil {
+		return nil
+	}
+	if snote, ok := record.GetSharedNote(); ok {
+		return snote
+	}
+	return nil
+}
+
+// SharedNotes returns all shared note records in the document (GEDCOM 7.0).
+func (d *Document) SharedNotes() []*SharedNote {
+	var notes []*SharedNote
+	for _, record := range d.Records {
+		if snote, ok := record.GetSharedNote(); ok {
+			notes = append(notes, snote)
+		}
+	}
+	return notes
+}

--- a/gedcom/record.go
+++ b/gedcom/record.go
@@ -24,6 +24,9 @@ const (
 
 	// RecordTypeSubmitter represents a submitter (SUBM)
 	RecordTypeSubmitter RecordType = "SUBM"
+
+	// RecordTypeSharedNote represents a shared note (SNOTE, GEDCOM 7.0)
+	RecordTypeSharedNote RecordType = "SNOTE"
 )
 
 // Record represents a top-level GEDCOM record with a cross-reference identifier.
@@ -116,6 +119,19 @@ func (r *Record) GetNote() (*Note, bool) {
 func (r *Record) GetMediaObject() (*MediaObject, bool) {
 	if media, ok := r.Entity.(*MediaObject); ok {
 		return media, true
+	}
+	return nil, false
+}
+
+// IsSharedNote returns true if this record is a shared note record (GEDCOM 7.0).
+func (r *Record) IsSharedNote() bool {
+	return r.Type == RecordTypeSharedNote
+}
+
+// GetSharedNote returns the record as a SharedNote if it's the correct type.
+func (r *Record) GetSharedNote() (*SharedNote, bool) {
+	if snote, ok := r.Entity.(*SharedNote); ok {
+		return snote, true
 	}
 	return nil, false
 }

--- a/gedcom/shared_note.go
+++ b/gedcom/shared_note.go
@@ -1,0 +1,47 @@
+package gedcom
+
+// SharedNote represents a GEDCOM 7.0 shared note record (SNOTE).
+// Unlike regular NOTE records, shared notes support MIME types, language tags,
+// and translations for internationalization.
+type SharedNote struct {
+	// XRef is the cross-reference identifier for this shared note
+	XRef string
+
+	// Text is the note content
+	Text string
+
+	// MIME is the media type of the text content (e.g., "text/plain", "text/html")
+	MIME string
+
+	// Language is the BCP 47 language tag for the text (e.g., "en", "de", "zh-Hans")
+	Language string
+
+	// Translations contains alternative representations of this note in different languages
+	Translations []*SharedNoteTranslation
+
+	// SourceCitations are source citations with page/quality details
+	SourceCitations []*SourceCitation
+
+	// ExternalIDs are external identifiers (EXID tags, GEDCOM 7.0).
+	// Links this record to external systems like FamilySearch, Ancestry, etc.
+	ExternalIDs []*ExternalID
+
+	// ChangeDate is when the record was last modified (CHAN tag)
+	ChangeDate *ChangeDate
+
+	// Tags contains all raw tags for this shared note (for unknown/custom tags)
+	Tags []*Tag
+}
+
+// SharedNoteTranslation represents a translation of a shared note into another language.
+// This mirrors the Transliteration pattern used for PersonalName.
+type SharedNoteTranslation struct {
+	// Value is the translated text content
+	Value string
+
+	// MIME is the media type of the translated text (e.g., "text/plain", "text/html")
+	MIME string
+
+	// Language is the BCP 47 language tag for this translation (e.g., "en", "de", "zh-Hans")
+	Language string
+}


### PR DESCRIPTION
## Summary

Implements GEDCOM 7.0 SNOTE (Shared Note) as a distinct entity type, separate from inline NOTE tags.

- Add `SharedNote` and `SharedNoteTranslation` types with MIME, Language, and translation support
- Implement `parseSharedNote()` decoder handling all SNOTE subordinates (MIME, LANG, TRAN, SOUR, EXID, CHAN)
- Implement `sharedNoteToTags()` encoder for round-trip fidelity
- Add `Document.GetSharedNote()` and `Document.SharedNotes()` accessors
- Comprehensive test coverage (decoder: 94.3%, encoder: 97.6%)
- Update FEATURES.md documentation

## Test plan

- [x] Parse SNOTE with basic text
- [x] Parse SNOTE with MIME type (text/plain, text/html)
- [x] Parse SNOTE with LANG tag (BCP 47)
- [x] Parse SNOTE with TRAN subordinates including nested MIME/LANG
- [x] Parse SNOTE with SourceCitations, ExternalIDs, ChangeDate
- [x] Document.GetSharedNote() lookup via XRefMap
- [x] Document.SharedNotes() iteration
- [x] Round-trip fidelity (decode -> encode -> decode)
- [x] Real file parsing (testdata/gedcom-7.0/familysearch-examples/notes-1.ged)
- [x] Per-package coverage ≥85%

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)