### PR TITLE
Add Options types for Encode and Validate operations

### DIFF
--- a/encoder/options.go
+++ b/encoder/options.go
@@ -1,5 +1,7 @@
 package encoder
 
+import "github.com/cacack/gedcom-go/gedcom"
+
 // DefaultMaxLineLength is the recommended maximum line length for GEDCOM files.
 // GEDCOM spec recommends lines not exceed 255 characters total.
 // We use 248 to account for level number, space, tag, and delimiter overhead.
@@ -18,14 +20,25 @@ type EncodeOptions struct {
 	// DisableLineWrap disables automatic CONC splitting for long lines.
 	// When true, lines exceeding MaxLineLength will not be split.
 	DisableLineWrap bool
+
+	// TargetVersion specifies the GEDCOM version to target for output.
+	// This can affect header generation and tag validity.
+	// If empty, the version from the document header is preserved.
+	TargetVersion gedcom.Version
+
+	// PreserveUnknownTags controls whether custom/unknown tags are included
+	// in the output. Custom tags are typically underscore-prefixed (e.g., _CUSTOM).
+	// Default: true (preserve all tags)
+	PreserveUnknownTags bool
 }
 
 // DefaultOptions returns the default encoding options.
 func DefaultOptions() *EncodeOptions {
 	return &EncodeOptions{
-		LineEnding:      "\n",
-		MaxLineLength:   DefaultMaxLineLength,
-		DisableLineWrap: false,
+		LineEnding:          "\n",
+		MaxLineLength:       DefaultMaxLineLength,
+		DisableLineWrap:     false,
+		PreserveUnknownTags: true,
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements all options requested in #156, enhancing the API with explicit options types for Encode and Validate operations.

## Changes

### EncodeOptions (encoder/options.go)
- **TargetVersion** (`gedcom.Version`) - Override the output GEDCOM version in header
- **PreserveUnknownTags** (`bool`, default: `true`) - Control whether custom/underscore-prefixed tags are included in output

### ValidatorConfig (validator/validator.go)
- **MaxErrors** (`int`, default: `0` = unlimited) - Limit number of issues returned for early termination
- **SkipRules** (`[]string`) - Exclude specific validation rules by their error code

## Testing

- All new options have comprehensive tests
- Coverage: encoder 97.7%, validator 98.0%
- All existing tests pass

## Usage Examples

```go
// Encoder: Target specific version and filter custom tags
opts := &encoder.EncodeOptions{
    TargetVersion:       gedcom.Version70,
    PreserveUnknownTags: false,
}
encoder.EncodeWithOptions(w, doc, opts)

// Validator: Limit errors and skip specific rules
config := &validator.ValidatorConfig{
    MaxErrors: 10,
    SkipRules: []string{"W001", "I002"},
}
v := validator.NewWithConfig(config)
issues := v.ValidateAll(doc)
```

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TargetVersion option to override the encoded header version and control VERS output
  * PreserveUnknownTags option (default: true) to keep or filter custom/unknown tags during encoding
  * MaxErrors configuration to limit reported validation issues
  * SkipRules configuration to exclude specific validation issue codes

* **Tests**
  * Comprehensive test coverage for encoding options, tag handling, and validator behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->