### PR TITLE
Add project health documentation and health check skills

### DIFF
--- a/.claude/skills/audit-docs/SKILL.md
+++ b/.claude/skills/audit-docs/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: audit-docs
+description: Audit documentation for drift, dead links, and stale content
+user_invocable: true
+context: fork
+agent: Explore
+---
+
+# Documentation Drift Audit
+
+Audit project documentation for accuracy, completeness, and internal consistency.
+
+## Checks to Perform
+
+### 1. Package Tree Accuracy
+Compare the package list in CLAUDE.md's "Package Structure" section against the actual Go packages:
+- Run `ls -d */` in the repo root to find actual packages (directories with .go files)
+- Flag any packages in CLAUDE.md that don't exist
+- Flag any real packages missing from CLAUDE.md
+
+### 2. FEATURES.md Spot-Check
+Pick 3 features claimed in FEATURES.md and verify they exist:
+- Search for the exported symbols mentioned (types, functions)
+- Check that code examples reference real API signatures
+- Flag any features that appear to be missing or renamed
+
+### 3. TESTING.md Critical Paths
+Verify critical path functions listed in docs/TESTING.md exist:
+- Search for each function name in the corresponding package
+- Flag functions that have been renamed or removed
+- Check that test files exist for the listed functions
+
+### 4. ADR List Accuracy
+Compare the ADR table in CLAUDE.md against actual files in docs/adr/:
+- List files in docs/adr/
+- Flag any ADRs in CLAUDE.md not backed by a file
+- Flag any ADR files not listed in CLAUDE.md
+
+### 5. README.md Version Claims
+Check that version support claims match actual code:
+- Search for version constants in the codebase
+- Verify version detection code handles claimed versions
+
+### 6. Dead Internal Links
+Scan all markdown files for internal links and verify targets exist:
+- Check relative links like `[text](./path)` and `[text](path)`
+- Check anchor links like `[text](#section)`
+- Flag any broken links
+
+## Output Format
+
+```
+## Documentation Drift Audit
+
+### Summary
+| Check | Status | Findings |
+|-------|--------|----------|
+| Package tree | ... | ... |
+| FEATURES.md | ... | ... |
+| TESTING.md | ... | ... |
+| ADR list | ... | ... |
+| Version claims | ... | ... |
+| Dead links | ... | ... |
+
+### Details
+[Detailed findings per check]
+
+### Recommendations
+[Top items to fix, ordered by severity]
+```

--- a/.claude/skills/check-debt/SKILL.md
+++ b/.claude/skills/check-debt/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: check-debt
+description: Inventory technical debt across the codebase
+user_invocable: true
+context: fork
+agent: Explore
+---
+
+# Technical Debt Inventory
+
+Scan for technical debt indicators and prioritize them by impact.
+
+## Checks to Perform
+
+### 1. TODO/FIXME/HACK Comments
+Search all .go files for debt markers:
+- `TODO`, `FIXME`, `HACK`, `XXX`, `NOCOMMIT`
+- Group by package with counts
+- Include the comment text for context
+
+### 2. Long Functions
+Find functions exceeding 100 lines (refactoring candidates):
+- Search for `func ` declarations and measure line counts
+- List functions over 100 lines with their package and line count
+- Note any over 200 lines as high-priority
+
+### 3. Open GitHub Issues
+Summarize open issues by effort/value labels:
+- Run `gh issue list --state open --json number,title,labels`
+- Group by effort label (low/medium/high)
+- Highlight any high-value items that haven't been started
+
+### 4. Coverage Gaps
+Check for packages below the 85% threshold:
+- Run `go test -cover ./...` and parse output
+- Flag any package below 85%
+- Note packages close to the threshold (85-88%)
+
+### 5. IDEAS.md Staleness
+Review IDEAS.md for items that may have been implemented:
+- Check if any ideas already exist as features in the codebase
+- Flag ideas that duplicate open issues
+- Note any ideas with no clear path forward
+
+## Output Format
+
+```
+## Technical Debt Inventory
+
+### Summary
+| Category | Count | Severity |
+|----------|-------|----------|
+| TODO/FIXME comments | ... | ... |
+| Long functions | ... | ... |
+| Open issues | ... | ... |
+| Coverage gaps | ... | ... |
+| Stale ideas | ... | ... |
+
+### Details
+[Findings grouped by category]
+
+### Top 5 Items to Address
+[Prioritized by impact and effort]
+```

--- a/.claude/skills/check-invariants/SKILL.md
+++ b/.claude/skills/check-invariants/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: check-invariants
+description: Spot-check that code matches ADR invariants
+user_invocable: true
+context: fork
+agent: Explore
+---
+
+# ADR Invariant Spot-Checks
+
+Verify that the codebase honors the architectural decisions documented in docs/adr/. Each ADR establishes invariants that must hold.
+
+## Checks to Perform
+
+### ADR-001: Custom Date Struct
+- Verify `gedcom.Date` struct has fields for partial dates (Day, Month, Year can be zero)
+- Verify modifier fields exist (Modifier, IsBC, DualYear, Phrase)
+- Verify calendar type field exists (Calendar)
+- Check that `ParseDate()` preserves the original string
+
+### ADR-002: XRef Resolution via Strings
+- Verify family linkage fields (Husband, Wife, Children, FamilyChild, FamilySpouse) are string types, not pointer types
+- Verify `Document.XRefMap` exists for O(1) lookup
+- Verify `GetIndividual()`, `GetFamily()` etc. use the map
+
+### ADR-003: Lossless Dual Storage
+- Verify `Record` has both a typed `Data` field and raw `Children`/`Tags` field
+- Verify entities (Individual, Family, etc.) preserve raw tags
+- Spot-check that unknown/vendor tags survive a decode
+
+### ADR-004: Encoding Detection Cascade
+- Verify charset package implements BOM detection
+- Verify header-based encoding detection exists
+- Verify UTF-8 fallback is the default
+
+### ADR-005: Version Detection Strategy
+- Verify version package checks header first
+- Verify tag-based heuristic fallback exists
+- Verify all three versions (5.5, 5.5.1, 7.0) are detected
+
+### ADR-006: Line Continuation Handling
+- Verify CONT handling in parser or decoder (newline insertion)
+- Verify CONC handling (concatenation without newline)
+- Check that multiline text round-trips correctly
+
+### ADR-007: Error Transparency
+- Verify error types include LineNumber or line context
+- Grep for `panic(` in non-test library code — should be zero occurrences
+- Verify errors use `fmt.Errorf` with `%w` for wrapping
+
+### ADR-008: Validator Architecture
+- Verify validators are composable (not one monolithic function)
+- Check for configurable validation (strictness levels, options)
+- Verify individual validation functions can be called independently
+
+## Output Format
+
+```
+## ADR Invariant Check
+
+### Summary
+| ADR | Status | Notes |
+|-----|--------|-------|
+| 001 - Custom Date | ... | ... |
+| 002 - XRef Strings | ... | ... |
+| 003 - Dual Storage | ... | ... |
+| 004 - Encoding Cascade | ... | ... |
+| 005 - Version Detection | ... | ... |
+| 006 - Line Continuation | ... | ... |
+| 007 - Error Transparency | ... | ... |
+| 008 - Validator Architecture | ... | ... |
+
+### Details
+[Findings per ADR with code references]
+
+### Violations Found
+[Any invariant violations, with file:line references]
+```

--- a/.claude/skills/check-patterns/SKILL.md
+++ b/.claude/skills/check-patterns/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: check-patterns
+description: Check code pattern consistency across the codebase
+user_invocable: true
+context: fork
+agent: Explore
+---
+
+# Code Pattern Consistency Check
+
+Verify that the codebase follows consistent Go patterns and project conventions.
+
+## Checks to Perform
+
+### 1. Error Handling Patterns
+Spot-check 3 .go files (non-test) for error wrapping:
+- Look for `fmt.Errorf` with `%w` verb (preferred pattern)
+- Flag any bare `errors.New()` that should include context
+- Flag any errors that swallow context (no wrapping)
+
+### 2. Table-Driven Tests
+Spot-check 3 _test.go files for table-driven test patterns:
+- Look for `[]struct` test case definitions
+- Look for `t.Run(` subtest execution
+- Flag test files with repetitive non-table patterns
+
+### 3. Godoc Coverage
+Check that all exported types and functions have doc comments:
+- Search for `^func [A-Z]` and `^type [A-Z]` declarations
+- Verify the preceding line is a `//` comment
+- Report any undocumented exports (sample 2-3 packages)
+
+### 4. Package doc.go Files
+Verify every package has a doc.go file:
+- List all Go packages (directories with .go files)
+- Check for doc.go in each
+- Flag any missing doc.go files
+
+### 5. Interface Usage in Public APIs
+Spot-check that public APIs use io.Reader/io.Writer interfaces:
+- Check decoder's main entry point accepts io.Reader
+- Check encoder's main entry point accepts io.Writer
+- Flag any public functions that take concrete types (e.g., *os.File)
+
+### 6. No Panics in Library Code
+Grep for `panic(` in all non-test .go files:
+- Exclude _test.go files
+- Exclude any in main packages (if CLI exists)
+- Report any found with file:line references
+
+## Output Format
+
+```
+## Code Pattern Consistency
+
+### Summary
+| Pattern | Status | Findings |
+|---------|--------|----------|
+| Error handling | ... | ... |
+| Table-driven tests | ... | ... |
+| Godoc coverage | ... | ... |
+| doc.go files | ... | ... |
+| Interface APIs | ... | ... |
+| No panics | ... | ... |
+
+### Details
+[Findings per pattern with code references]
+
+### Recommendations
+[Inconsistencies to address, ordered by importance]
+```

--- a/.claude/skills/check-phase/SKILL.md
+++ b/.claude/skills/check-phase/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: check-phase
+description: Assess alignment with the current roadmap phase
+user_invocable: true
+context: fork
+agent: Explore
+---
+
+# Phase Alignment Assessment
+
+Check whether recent work aligns with the current roadmap phase (Phase 1: API Polish & Stability).
+
+## Checks to Perform
+
+### 1. Recent Commit Categorization
+Review the last 20 commits on main:
+- Run `git log --oneline -20`
+- Categorize each as Phase 1, Phase 2, Phase 3, or Maintenance based on docs/ROADMAP.md
+- Calculate percentage of work in each phase
+
+### 2. Phase 1 Issue Progress
+Check status of Phase 1 issues from docs/ROADMAP.md:
+- #156 — Options types for Encode and Validate
+- #135 — Place parsing helpers
+- #141 — Vendor test data (Legacy Family Tree)
+- #44 — CLI tool for GEDCOM validation
+- Report which are open, closed, or in progress
+
+### 3. Phase Leakage Detection
+Look for signs of Phase 2/3 work happening before Phase 1 is complete:
+- Check recent commits for merge/diff/export features (Phase 2)
+- Check for GEDZip, builder API, or plugin work (Phase 3)
+- Flag any premature work with context
+
+### 4. Downstream Consumer Alignment
+Check if work is being driven by real downstream usage:
+- Look at recent commits for references to my-family or consumer needs
+- Check if features added map to downstream requirements
+- Flag any speculative features not tied to real needs
+
+## Output Format
+
+```
+## Phase Alignment Assessment
+
+### Current Phase: Phase 1 — API Polish & Stability
+
+### Recent Work Distribution
+| Phase | Commits | Percentage |
+|-------|---------|------------|
+| Phase 1 | ... | ... |
+| Phase 2 | ... | ... |
+| Phase 3 | ... | ... |
+| Maintenance | ... | ... |
+
+### Phase 1 Issue Status
+| Issue | Title | Status |
+|-------|-------|--------|
+| #156 | Options types | ... |
+| #135 | Place parsing | ... |
+| #141 | Vendor test data | ... |
+| #44 | CLI tool | ... |
+
+### Phase Leakage
+[Any premature Phase 2/3 work detected]
+
+### Recommendations
+[Suggestions for staying focused on the current phase]
+```

--- a/.claude/skills/check-tests/SKILL.md
+++ b/.claude/skills/check-tests/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: check-tests
+description: Analyze test quality and coverage patterns
+user_invocable: true
+context: fork
+agent: Explore
+---
+
+# Test Quality Analysis
+
+Assess test quality beyond simple coverage numbers — edge cases, patterns, and completeness.
+
+## Checks to Perform
+
+### 1. Edge Case Coverage
+Spot-check 3 test files for coverage of error and boundary conditions:
+- Do tests include invalid/malformed inputs?
+- Are nil, empty, and zero values tested?
+- Are boundary conditions covered (max values, overflow)?
+
+### 2. Table-Driven Test Usage
+Check that multi-case functions use table-driven patterns:
+- Search for test functions with more than 3 similar assertion blocks
+- These are candidates for table-driven refactoring
+- Report files that would benefit from the pattern
+
+### 3. Round-Trip Tests
+Verify decode-encode-decode cycles exist:
+- Search for round-trip or roundtrip in test files
+- Check that encoder tests verify output can be re-decoded
+- Flag any encode/decode paths without round-trip verification
+
+### 4. Error Message Quality
+Spot-check 3 test files for error message assertions:
+- Do tests check error message content (not just `!= nil`)?
+- Are error types checked with `errors.Is()` or `errors.As()`?
+- Flag tests that only check `err != nil` without message validation
+
+### 5. Critical Path Coverage
+Cross-reference docs/TESTING.md critical paths with actual tests:
+- For each critical function listed, verify a dedicated test exists
+- Check that the test covers the "Required Tests" column
+- Flag any critical paths without sufficient test coverage
+
+### 6. Missing Test Files
+Find .go files without corresponding _test.go files:
+- List all non-test .go files (excluding doc.go, generated files)
+- Check for corresponding _test.go
+- Flag any missing test files (excluding trivially small files)
+
+## Output Format
+
+```
+## Test Quality Analysis
+
+### Summary
+| Dimension | Status | Findings |
+|-----------|--------|----------|
+| Edge cases | ... | ... |
+| Table-driven | ... | ... |
+| Round-trip tests | ... | ... |
+| Error messages | ... | ... |
+| Critical paths | ... | ... |
+| Missing test files | ... | ... |
+
+### Details
+[Findings per dimension with file references]
+
+### Recommendations
+[Top items to improve test quality]
+```

--- a/.claude/skills/health-check/SKILL.md
+++ b/.claude/skills/health-check/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: health-check
+description: Run all project health checks and produce a unified report
+user_invocable: true
+---
+
+# Project Health Check
+
+Orchestrate all six health check dimensions and aggregate results into a unified report.
+
+## Execution
+
+Launch all six checks as parallel subagents using the Task tool with `subagent_type: Explore`:
+
+1. **audit-docs** — Documentation drift audit
+2. **check-debt** — Technical debt inventory
+3. **check-invariants** — ADR invariant spot-checks
+4. **check-patterns** — Code pattern consistency
+5. **check-phase** — Phase alignment assessment
+6. **check-tests** — Test quality analysis
+
+For each subagent, use the Skill tool to invoke the corresponding skill (e.g., `/audit-docs`, `/check-debt`, etc.).
+
+Wait for all six to complete, then aggregate their findings.
+
+## Output Format
+
+```
+# Project Health Report
+
+## Dashboard
+| Dimension | Status | Key Finding |
+|-----------|--------|-------------|
+| Documentation | ... | ... |
+| Technical Debt | ... | ... |
+| ADR Invariants | ... | ... |
+| Code Patterns | ... | ... |
+| Phase Alignment | ... | ... |
+| Test Quality | ... | ... |
+
+## Detailed Findings
+
+### Documentation
+[Summary from audit-docs]
+
+### Technical Debt
+[Summary from check-debt]
+
+### ADR Invariants
+[Summary from check-invariants]
+
+### Code Patterns
+[Summary from check-patterns]
+
+### Phase Alignment
+[Summary from check-phase]
+
+### Test Quality
+[Summary from check-tests]
+
+## Top Recommendations
+1. ...
+2. ...
+3. ...
+4. ...
+5. ...
+
+## What's Going Well
+- ...
+- ...
+- ...
+```
+
+## Status Indicators
+
+Use these status indicators in the dashboard:
+- **PASS** — No issues found
+- **WARN** — Minor issues that should be addressed
+- **FAIL** — Significant issues requiring attention

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,16 +99,12 @@ testdata/
 
 See `docs/TESTING.md` for critical paths that require 100% coverage.
 
-## Core Principles
+## Strategic Context
 
-This project follows six core principles that guide all development decisions:
+- **[docs/ETHOS.md](docs/ETHOS.md)** — Vision, core principles, differentiators, anti-patterns
+- **[docs/ROADMAP.md](docs/ROADMAP.md)** — Phased feature plan (Phase 1 is current priority)
 
-1. **Library-First Design**: Every feature as a well-defined, independently testable library component
-2. **API Clarity**: Public APIs prioritize simplicity with comprehensive godoc, io.Reader/Writer interfaces
-3. **Test Coverage (NON-NEGOTIABLE)**: Minimum 85% coverage, TDD approach, table-driven tests
-4. **Version Support**: Auto-detect and support GEDCOM 5.5, 5.5.1, and 7.0 with roundtrip fidelity
-5. **Error Transparency**: All errors include line numbers, context, and never panic
-6. **Lossless Representation (NON-NEGOTIABLE)**: Preserve original values, partial data, calendar-specific dates
+Two principles are **NON-NEGOTIABLE**: Test Coverage (≥85%) and Lossless Representation. See ETHOS.md for all six core principles.
 
 ## Documentation Structure
 
@@ -117,6 +113,8 @@ This project follows six core principles that guide all development decisions:
 - **IDEAS.md**: Unvetted ideas and rough concepts (create when needed)
 - **GitHub Issues**: Single source of truth for planned work
 - **docs/**: Implementation reference material
+  - `ETHOS.md` - Vision, core principles, differentiators, anti-patterns
+  - `ROADMAP.md` - Phased feature plan (Phase 1 is current priority)
   - `API_STABILITY.md` - API compatibility guarantees and versioning policy
   - `TESTING.md` - Test coverage requirements and critical paths
   - `GEDCOM_VERSIONS.md` - GEDCOM version differences (5.5, 5.5.1, 7.0)

--- a/docs/ETHOS.md
+++ b/docs/ETHOS.md
@@ -1,0 +1,89 @@
+# Project Ethos
+
+The guiding philosophy and strategic vision for gedcom-go. For the phased feature plan, see [ROADMAP.md](./ROADMAP.md).
+
+---
+
+## Vision Statement
+
+The reference Go library for GEDCOM processing — **correct**, **complete**, and **pleasant to use**.
+
+---
+
+## Core Differentiators
+
+### 1. Lossless Representation
+Preserve every detail from the original file: partial dates, calendar-specific formats, vendor extensions, unknown tags. Data in equals data out.
+
+### 2. Multi-Version Support
+Auto-detect and handle GEDCOM 5.5, 5.5.1, and 7.0 transparently. Roundtrip fidelity across versions.
+
+### 3. Real-World Compatibility
+Handle files from Ancestry, FamilySearch, RootsMagic, Gramps, and other vendors — including their quirks and extensions.
+
+### 4. Zero Dependencies
+Standard library only. No dependency trees to audit, no version conflicts for consumers.
+
+### 5. Streaming & Performance
+Process multi-million record files with constant memory. Indexed random access without loading everything.
+
+---
+
+## Core Principles
+
+These six principles guide all development decisions:
+
+1. **Library-First Design**: Every feature as a well-defined, independently testable library component
+2. **API Clarity**: Public APIs prioritize simplicity with comprehensive godoc, io.Reader/Writer interfaces
+3. **Test Coverage (NON-NEGOTIABLE)**: Minimum 85% coverage, TDD approach, table-driven tests
+4. **Version Support**: Auto-detect and support GEDCOM 5.5, 5.5.1, and 7.0 with roundtrip fidelity
+5. **Error Transparency**: All errors include line numbers, context, and never panic
+6. **Lossless Representation (NON-NEGOTIABLE)**: Preserve original values, partial data, calendar-specific dates
+
+---
+
+## Strategic Principles
+
+### 1. Nail the Basics First
+Parsing, encoding, and validation must be rock-solid before adding convenience features. No fancy APIs matter if the core is broken.
+
+### 2. Start Small, Ship Often
+One polished feature beats ten half-done ones. Each enhancement should be a complete, testable unit.
+
+### 3. Document as You Go
+Good documentation is a feature. Godoc, examples, ADRs — lack of docs kills adoption.
+
+### 4. Respect the Data
+Genealogy data is irreplaceable. Never lose it, never corrupt it, never silently drop information.
+
+### 5. Honor the Standards
+GEDCOM is a real specification. Support it correctly, including the parts that are awkward or annoying.
+
+---
+
+## Anti-Patterns to Avoid
+
+- **Feature bloat** — Do fewer things well; a library is not an application
+- **Speculative features** — Build what downstream consumers need, not what might be cool
+- **Vendor lock-in** — Data must always be exportable; never add proprietary requirements
+- **Breaking changes** — Follow API stability guarantees; prefer additive changes
+- **Ignoring real-world files** — Support what vendors actually produce, not just the spec
+- **Panicking in library code** — Return errors; let callers decide how to handle them
+
+---
+
+## Inspirations
+
+- **GEDCOM Specification** — The standard itself (5.5, 5.5.1, 7.0)
+- **Go Standard Library** — API design patterns, documentation style, zero-dependency philosophy
+- **Evidence Explained** — Citation standards and genealogical methodology
+- **encoding/json, encoding/xml** — Go's approach to serialization libraries
+
+---
+
+## Related
+
+- [Roadmap](./ROADMAP.md) — Phased feature plan
+- [Architecture Decision Records](./adr/) — Key design decisions
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — How to contribute
+- [API Stability](./API_STABILITY.md) — Compatibility guarantees

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,68 @@
+# Roadmap
+
+The phased feature plan for gedcom-go. For the project vision and guiding principles, see [ETHOS.md](./ETHOS.md).
+
+---
+
+## Phase Guide
+
+Features are organized into phases to focus effort. **Phase 1 is the current priority** — resist the temptation to jump ahead. Features are driven by real downstream usage ([my-family](https://github.com/cacack/my-family)), not speculation.
+
+| Phase | Focus | Principle |
+|-------|-------|-----------|
+| **Phase 1 (Now)** | API polish & stability | Nail the Basics First |
+| **Phase 2 (Near-term)** | Document manipulation | Dogfood Relentlessly |
+| **Phase 3 (Future)** | Advanced features & formats | Start Small, Ship Often |
+
+---
+
+## Phase 1 — API Polish & Stability
+
+Get the existing API right before adding new capabilities.
+
+| Issue | Description | Effort | Value |
+|-------|-------------|--------|-------|
+| [#156](https://github.com/cacack/gedcom-go/issues/156) | Add Options types for Encode and Validate | Medium | Medium |
+| [#135](https://github.com/cacack/gedcom-go/issues/135) | Add place parsing helpers | Low | Low |
+| [#141](https://github.com/cacack/gedcom-go/issues/141) | Add vendor test data (Legacy Family Tree) | Low | — |
+| [#44](https://github.com/cacack/gedcom-go/issues/44) | CLI tool for GEDCOM validation and info | Medium | Medium |
+
+**Exit criteria**: All Phase 1 issues closed, API stability documented, downstream consumer stable.
+
+---
+
+## Phase 2 — Document Manipulation
+
+Enable programmatic modification and comparison of GEDCOM data.
+
+| Issue | Description | Effort | Value |
+|-------|-------------|--------|-------|
+| [#132](https://github.com/cacack/gedcom-go/issues/132) | Merge utilities and XRef remapping | High | Medium |
+| [#36](https://github.com/cacack/gedcom-go/issues/36) | Merge and diff capabilities | High | Low |
+| [#37](https://github.com/cacack/gedcom-go/issues/37) | Export to JSON and XML formats | Medium | Low |
+
+**Exit criteria**: Can merge two GEDCOM files, diff documents, export to JSON/XML.
+
+---
+
+## Phase 3 — Advanced Features
+
+Extend the library for specialized use cases.
+
+| Feature | Description | Source |
+|---------|-------------|--------|
+| GEDZip support | [#127](https://github.com/cacack/gedcom-go/issues/127) — GEDCOM 7.0 archive format | Issue |
+| Fluent builder API | Method-chaining document construction | IDEAS.md |
+| JSON struct tags | `json` tags on types for easy serialization | IDEAS.md |
+| BOM output option | UTF-8 BOM for Windows compatibility | IDEAS.md |
+
+**Exit criteria**: GEDZip implemented, builder API usable for downstream consumers.
+
+---
+
+## Related
+
+- [Project Ethos](./ETHOS.md) — Vision, principles, and differentiators
+- [GitHub Issues](https://github.com/cacack/gedcom-go/issues) — Single source of truth for planned work
+- [IDEAS.md](../IDEAS.md) — Unvetted ideas and rough concepts
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — How to contribute


### PR DESCRIPTION
## Summary

- Add `docs/ETHOS.md` with project vision, core principles (moved from CLAUDE.md), strategic principles, differentiators, and anti-patterns
- Add `docs/ROADMAP.md` with 3-phase plan linked to all 8 open issues and IDEAS.md
- Update `CLAUDE.md`: replace Core Principles section with Strategic Context links, add new docs to documentation structure
- Add 7 Claude Code health check skills for automated project audits:
  - `audit-docs` — Documentation drift detection
  - `check-debt` — Technical debt inventory
  - `check-invariants` — ADR invariant verification
  - `check-patterns` — Code pattern consistency
  - `check-phase` — Roadmap phase alignment
  - `check-tests` — Test quality analysis
  - `health-check` — Orchestrator that runs all 6 in parallel

## Test plan

- [x] `make preflight` passes (all 8 checks, 96.2% coverage)
- [ ] Run `/audit-docs` skill and verify useful output
- [ ] Run `/health-check` skill and verify orchestration
- [ ] Verify internal markdown links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)