### PR TITLE
Add missing testdata directories to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,8 @@ husband := doc.GetIndividual(family.Husband)  // family.Husband is "@I1@"
 
 ```
 testdata/
+├── edge-cases/      # Boundary condition and unusual structure samples
+├── encoding/        # Character encoding test files (ANSEL, UTF-16, BOM)
 ├── gedcom-5.5/      # GEDCOM 5.5 samples
 ├── gedcom-5.5.1/    # GEDCOM 5.5.1 samples
 ├── gedcom-7.0/      # GEDCOM 7.0 samples


### PR DESCRIPTION
## Summary
- Add `edge-cases/` and `encoding/` subdirectories to the testdata tree in CLAUDE.md
- Discovered during project health check documentation audit

## Test plan
- [x] Verified directories exist in `testdata/`
- [x] All pre-commit checks pass
- [x] Documentation-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)