### PR TITLE
Fix nightly workflow fuzz regex, gosec version, and SARIF categories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
 
     - name: Run gosec
       run: |
-        go install github.com/securego/gosec/v2/cmd/gosec@latest
+        go install github.com/securego/gosec/v2/cmd/gosec@424fc4cd9c82ea0fd6bee9cd49c2db2c3cc0c93f # v2.22.11
         gosec -fmt sarif -out gosec-results.sarif ./...
 
     - name: Upload gosec results to GitHub Security

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,13 +21,13 @@ jobs:
       matrix:
         include:
           - package: ./parser
-            fuzz: FuzzParse
+            fuzz: ^FuzzParse$
             time: 2m
           - package: ./parser
-            fuzz: FuzzParseLine
+            fuzz: ^FuzzParseLine$
             time: 2m
           - package: ./gedcom
-            fuzz: FuzzParseDate
+            fuzz: ^FuzzParseDate$
             time: 2m
 
     steps:
@@ -82,11 +82,11 @@ jobs:
       if: success() || failure()
       with:
         sarif_file: govulncheck-results.sarif
-        category: govulncheck-nightly
+        category: govulncheck
 
     - name: Run gosec
       run: |
-        go install github.com/securego/gosec/v2/cmd/gosec@latest
+        go install github.com/securego/gosec/v2/cmd/gosec@424fc4cd9c82ea0fd6bee9cd49c2db2c3cc0c93f # v2.22.11
         gosec -fmt sarif -out gosec-results.sarif ./...
 
     - name: Upload gosec results
@@ -94,7 +94,7 @@ jobs:
       if: success() || failure()
       with:
         sarif_file: gosec-results.sarif
-        category: gosec-nightly
+        category: gosec
 
     - name: Trivy filesystem scan
       uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
@@ -111,7 +111,7 @@ jobs:
       if: success() || failure()
       with:
         sarif_file: trivy-results.sarif
-        category: trivy-nightly
+        category: trivy
 
   notify:
     name: Notify on Failure


### PR DESCRIPTION
## Summary
- Anchor fuzz test patterns with `^...$` to prevent `-fuzz=FuzzParse` from matching both `FuzzParse` and `FuzzParseLine`
- Pin gosec to v2.22.11 by commit hash to fix `tool_version` reporting as `dev` on GitHub code scanning status page
- Unify SARIF upload categories between CI and nightly workflows to prevent duplicate security alerts

Closes #190

## Test plan
- [ ] Verify nightly workflow passes (fuzz jobs no longer fail with "matches more than one fuzz test")
- [ ] Verify gosec reports proper version on GitHub Security > Code scanning > Tools
- [ ] Verify govulncheck alerts are no longer duplicated between CI and nightly runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)