### PR TITLE
Add SNOTE handling to parseMediaObject for GEDCOM 7.0

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -191,7 +191,7 @@ snote := doc.GetSharedNote("@N1@")
 | ExternalIDs | External identifiers (EXID) |
 | ChangeDate | Last modification date |
 
-Supported on: Document (as top-level records accessible via `SharedNotes()` and `GetSharedNote()`)
+Supported on: Document (as top-level records accessible via `SharedNotes()` and `GetSharedNote()`), MediaObject (as `SharedNoteXRefs`)
 
 ### Encoding Validation
 

--- a/decoder/entity.go
+++ b/decoder/entity.go
@@ -1206,7 +1206,7 @@ func parseMediaObject(record *gedcom.Record, collector *diagnosticCollector) *ge
 		case "EXID":
 			media.ExternalIDs = append(media.ExternalIDs, parseExternalID(record.Tags, i))
 		case "SNOTE":
-			// Known tags not yet parsed into typed fields
+			media.SharedNoteXRefs = append(media.SharedNoteXRefs, tag.Value)
 		default:
 			if !strings.HasPrefix(tag.Tag, "_") {
 				collector.addUnknownTag(tag.LineNumber, tag.Tag, tag.Value)

--- a/decoder/entity_test.go
+++ b/decoder/entity_test.go
@@ -2967,8 +2967,12 @@ func TestParseMediaObject_FullMetadata(t *testing.T) {
 		t.Errorf("media.UIDs[0] = %s, want '69ebdd0e-c78c-4b81-873f-dc8ac30a48b9'", media.UIDs[0])
 	}
 
-	// Only inline NOTE is captured, SNOTE references are not currently parsed
-	// TODO: Add SNOTE handling to parseMediaObject
+	if len(media.SharedNoteXRefs) != 1 {
+		t.Errorf("len(media.SharedNoteXRefs) = %d, want 1", len(media.SharedNoteXRefs))
+	} else if media.SharedNoteXRefs[0] != "@N1@" {
+		t.Errorf("media.SharedNoteXRefs[0] = %s, want @N1@", media.SharedNoteXRefs[0])
+	}
+
 	if len(media.Notes) != 1 {
 		t.Errorf("len(media.Notes) = %d, want 1", len(media.Notes))
 	}

--- a/gedcom/media.go
+++ b/gedcom/media.go
@@ -66,6 +66,9 @@ type MediaObject struct {
 	// RefNumbers are user reference numbers (REFN tag, can have multiple)
 	RefNumbers []string
 
+	// SharedNoteXRefs are cross-references to shared note records (SNOTE tags, GEDCOM 7.0)
+	SharedNoteXRefs []string
+
 	// Restriction is the access restriction level (RESN tag)
 	Restriction string
 


### PR DESCRIPTION
## Summary

- Add `SharedNoteXRefs []string` field to `MediaObject` struct for GEDCOM 7.0 shared note cross-references
- Parse SNOTE tags in `parseMediaObject` (previously ignored with a TODO comment)
- Add test assertions for shared note XRef parsing in `TestParseMediaObject_FullMetadata`

Closes #184

## Test plan

- [x] `TestParseMediaObject_FullMetadata` asserts `SharedNoteXRefs == ["@N1@"]`
- [x] All tests pass with race detector
- [x] All pre-commit hooks pass (gofmt, vet, golangci-lint, coverage)
- [x] Per-package coverage ≥85% (decoder: 94.4%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)