### PR TITLE
Bump minimum Go version to 1.24.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/cacack/gedcom-go
 
-go 1.24.0
+go 1.24.13
 
 require golang.org/x/text v0.28.0


### PR DESCRIPTION
## Summary
- Bumps minimum Go version from 1.24.0 to 1.24.13 in `go.mod`
- Resolves code scanning alert [GO-2026-4337](https://pkg.go.dev/vuln/GO-2026-4337) (CVE-2025-68121) for unexpected session resumption in `crypto/tls`
- govulncheck confirms no vulnerable symbols are called, but bumping clears the alert

## Test plan
- [x] All tests pass
- [x] `govulncheck` reports no vulnerabilities
- [x] `gosec` clean
- [x] `staticcheck` clean
- [x] Coverage: 96.2%

🤖 Generated with [Claude Code](https://claude.com/claude-code)