### PR TITLE
Fix Go version resolution in CI and CodeQL workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: ['1.24', '1.25']
+        go: ['min', '1.25']
 
     steps:
     - name: Harden Runner
@@ -38,7 +38,8 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
       with:
-        go-version: ${{ matrix.go }}
+        go-version: ${{ matrix.go != 'min' && matrix.go || '' }}
+        go-version-file: 'go.mod'
         cache: true
 
     - name: Verify dependencies

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
       with:
-        go-version: '1.24'
+        go-version-file: 'go.mod'
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@9e907b5e64f6b83e7804b09294d44122997950d6 # v4


### PR DESCRIPTION
## Summary
- Use `go-version-file: go.mod` in CodeQL workflow instead of hardcoded `go-version: '1.24'`
- CI test matrix `min` entry now falls back to `go-version-file: go.mod` instead of hardcoding `1.24`

This prevents failures when `go.mod` requires a newer patch version (e.g., 1.24.13) than what `setup-go` resolves for `'1.24'`. CodeQL's `GOTOOLCHAIN=local` made this a hard failure.

Unblocks Dependabot PRs #202, #203, #204.

## Test plan
- [ ] CI passes with the new `min` matrix entry (installs Go version from go.mod)
- [ ] CI passes with the `1.25` matrix entry (explicit go-version still works)
- [ ] CodeQL Analyze job passes with go-version-file

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows to use Go version from go.mod file instead of hard-coded versions, enabling consistency between local development and CI environments.
  * Modified test matrix to support minimum and latest Go versions for broader compatibility testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->