### PR TITLE
Bump minimum Go from 1.24 to 1.25, CI to 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: ['min', '1.25']
+        go: ['min', '1.26']
 
     steps:
     - name: Harden Runner
@@ -50,7 +50,7 @@ jobs:
       shell: bash
 
     - name: Upload coverage to Codecov
-      if: matrix.os == 'ubuntu-latest' && matrix.go == '1.25'
+      if: matrix.os == 'ubuntu-latest' && matrix.go == '1.26'
       uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -70,7 +70,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
       with:
-        go-version: '1.25'
+        go-version: '1.26'
         cache: true
 
     - name: Generate coverage
@@ -115,7 +115,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
       with:
-        go-version: '1.25'
+        go-version: '1.26'
 
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
@@ -133,7 +133,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
       with:
-        go-version: '1.25'
+        go-version: '1.26'
 
     - name: Check formatting
       run: |
@@ -186,7 +186,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
       with:
-        go-version: '1.25'
+        go-version: '1.26'
 
     - name: Verify dependencies
       run: go mod verify
@@ -276,7 +276,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
       with:
-        go-version: '1.25'
+        go-version: '1.26'
 
     - name: Build parse example
       run: go build -o /tmp/example-parse ./examples/parse
@@ -309,7 +309,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - name: Install apidiff
         run: go install golang.org/x/exp/cmd/apidiff@latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
       with:
-        go-version: '1.25'
+        go-version: '1.26'
         cache: true
 
     - name: Run ${{ matrix.fuzz }}
@@ -69,7 +69,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
       with:
-        go-version: '1.25'
+        go-version: '1.26'
 
     - name: Run govulncheck
       run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Quick Start
 
-**Required**: Go 1.24+
+**Required**: Go 1.25+
 
 ```bash
 make setup            # Downloads deps, installs tools, sets up hooks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ This project adheres to a simple code of conduct:
 
 ### Prerequisites
 
-- Go 1.24 or later
+- Go 1.25 or later
 - Git
 - Familiarity with the GEDCOM specification (helpful but not required)
 
@@ -434,7 +434,7 @@ Include the following information:
    What actually happened
 
    **Environment**
-   - Go version: 1.24.0
+   - Go version: 1.25.0
    - OS: macOS 14.0
    - go-gedcom version: v0.1.0
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1353,7 +1353,7 @@ for _, record := range doc.Records {
 
 - 93% test coverage across core packages
 - Multi-platform CI (Linux, macOS, Windows)
-- Multi-version Go testing (1.24, 1.25)
+- Multi-version Go testing (1.25, 1.26)
 - Benchmark regression testing
 - Real-world GEDCOM file testing
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ go get github.com/cacack/gedcom-go
 
 ## Requirements
 
-- Go 1.24 or later
+- Go 1.25 or later
 
 This library tracks Go's [release policy](https://go.dev/doc/devel/release#policy), supporting the two most recent major versions. When a Go version reaches end-of-life and no longer receives security patches, we bump our minimum accordingly.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -84,7 +84,7 @@ go get github.com/cacack/gedcom-go
 ```
 
 Requirements:
-- Go 1.24 or later
+- Go 1.25 or later
 - No external dependencies (uses only the Go standard library)
 
 ## Quick Start

--- a/examples/README.md
+++ b/examples/README.md
@@ -325,10 +325,10 @@ go run main.go ../../testdata/gedcom-5.5/minimal.ged
 
 ### Import errors
 
-Ensure you're using Go 1.24 or later:
+Ensure you're using Go 1.25 or later:
 
 ```bash
-go version  # Should show 1.24 or higher
+go version  # Should show 1.25 or higher
 ```
 
 ### Module issues

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/cacack/gedcom-go
 
-go 1.24.13
+go 1.25.8
 
 require golang.org/x/text v0.28.0


### PR DESCRIPTION
## Summary

- Bump `go.mod` from Go 1.24.13 to 1.25.8 (Go 1.24 is EOL)
- Update CI/nightly workflows from Go 1.25 to 1.26 (latest stable)
- Update all documentation references to reflect new minimum

Resolves 3 open govulncheck code scanning alerts:
- [GO-2026-4601](https://pkg.go.dev/vuln/GO-2026-4601) - Incorrect IPv6 parsing in net/url
- [GO-2026-4602](https://pkg.go.dev/vuln/GO-2026-4602) - FileInfo escape from Root in os
- [GO-2026-4603](https://pkg.go.dev/vuln/GO-2026-4603) - Unescaped URLs in html/template meta content

None of the vulnerable symbols are called by this library, but bumping ensures CI runs against patched stdlib.

## Test plan

- [x] All tests pass locally (`make test`)
- [x] Lint passes (`make lint`)
- [x] Security scan passes (`make security`)
- [x] `govulncheck ./...` reports 0 symbol-level vulnerabilities
- [ ] CI passes on all platforms (Linux, macOS, Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)