### PR TITLE
Fix conventional commit validation to reject misplaced bang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,7 +363,7 @@ jobs:
             # since a breaking change may already be merged to main but not yet released.
             COMMITS=$(git log --format="%s%n%b" "$LATEST_TAG..HEAD")
 
-            if echo "$COMMITS" | grep -qE '^(feat|fix|refactor|perf|docs|style|test|build|ci|chore)!:|BREAKING CHANGE:'; then
+            if echo "$COMMITS" | grep -qE '^(feat|fix|refactor|perf|docs|style|test|build|ci|chore)(\(.+\))?!:|BREAKING CHANGE:'; then
               echo "✅ Breaking change properly declared in commit message"
               echo "   Release-please will bump major version"
               exit 0
@@ -440,6 +440,14 @@ jobs:
           FAILED=0
           for SHA in $(git log --format="%H" origin/main..HEAD); do
             SUBJECT=$(git log -1 --format="%s" "$SHA")
+
+            # Reject malformed conventional commits where ! appears before scope
+            if echo "$SUBJECT" | grep -qE '^(feat|fix)!\('; then
+              echo "::error::Commit '$SUBJECT' has malformed format — '!' must come after the scope."
+              echo "  Expected: type(scope)!: description"
+              FAILED=1
+              continue
+            fi
 
             # Only check feat: and fix: commits (including scoped variants)
             if ! echo "$SUBJECT" | grep -qE '^(feat|fix)(\(.+\))?!?:'; then

--- a/scripts/commit-msg
+++ b/scripts/commit-msg
@@ -8,6 +8,18 @@
 COMMIT_MSG_FILE="$1"
 SUBJECT=$(head -1 "$COMMIT_MSG_FILE")
 
+# Reject malformed conventional commits where ! appears before scope
+# e.g., "feat!(api):" should be "feat(api)!:" per the spec
+if echo "$SUBJECT" | grep -qE '^(feat|fix)!\('; then
+  echo ""
+  echo "Error: Malformed conventional commit — '!' must come after the scope, not before."
+  echo ""
+  echo "  Got:      $SUBJECT"
+  echo "  Expected: type(scope)!: description"
+  echo ""
+  exit 1
+fi
+
 # Only check feat: and fix: commits (including scoped and breaking variants)
 if ! echo "$SUBJECT" | grep -qE '^(feat|fix)(\(.+\))?!?:'; then
   exit 0


### PR DESCRIPTION
## Summary

- Reject malformed conventional commits where `!` appears before scope (e.g., `feat!(api):` instead of `feat(api)!:`) in both the commit-msg hook and CI commit-type job
- Fix API compatibility check regex to detect scoped breaking changes like `feat(api)!:` (previously only matched unscoped `feat!:`)

## Context

PR #168 was merged with commit `feat!(api): add TargetVersion...` which has `!` before the scope. This is invalid per the Conventional Commits spec — release-please could not parse it, silently preventing release PR creation since v1.2.0.

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (all packages, 96.2% coverage)
- [x] `make security` passes

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved detection of breaking-change declarations in commit messages with proper scope syntax
  * Added validation to enforce correct commit message formatting and reject malformed entries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->