### PR TITLE
Pin dependabot/fetch-metadata to commit SHA

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           skip-commit-verification: true


### PR DESCRIPTION
## Summary
- Pin `dependabot/fetch-metadata` to `08eff52` (v2.4.0)
- Aligns with all other workflows, which SHA-pin actions with version comments

## Test plan
- [x] Workflow YAML syntactically valid
- [ ] CI passes