### PR TITLE
Update test coverage claim to reflect actual numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A pure Go library for parsing and validating GEDCOM (GEnealogical Data COMmunica
 - **Comprehensive Validation**: Date logic, orphaned references, duplicates, and quality reports
 - **Vendor Extensions**: Parse Ancestry.com and FamilySearch custom tags
 - **Zero Dependencies**: Uses only the Go standard library
-- **Well-tested**: 93% test coverage with multi-platform CI
+- **Well-tested**: 93-100% per-package test coverage with multi-platform CI
 
 See [FEATURES.md](FEATURES.md) for the complete feature list including all supported record types, events, attributes, and encoding details.
 
@@ -315,7 +315,7 @@ make all
 # Run tests
 make test
 
-# Run tests with coverage (93% coverage)
+# Run tests with coverage (93-100% per-package coverage)
 make test-coverage
 
 # Generate HTML coverage report


### PR DESCRIPTION
## Summary
- Updated README.md coverage claim from flat "93%" to "93-100% per-package" to match actual test coverage numbers (93.8% - 100% across packages, 96.2% total)

## Test plan
- [x] Verified actual coverage numbers via `go test ./... -cover`
- [x] Pre-commit and pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated test coverage metrics in the README to reflect per-package coverage breakdown instead of a single overall coverage percentage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->