### PR TITLE
Add OSSF Scorecard workflow and badge

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,57 @@
+name: OSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    # Run weekly on Sundays at 01:30 UTC (offset from CodeQL)
+    - cron: '30 1 * * 0'
+  push:
+    branches: [ main ]
+
+# Declare default permissions as read-only
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload results to GitHub's code scanning dashboard
+      security-events: write
+      # Needed to publish results and get a badge (via publish_results)
+      id-token: write
+      # Read-only access to repo contents
+      contents: read
+      actions: read
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish results to the OpenSSF REST API so the badge reflects the latest score.
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          sarif_file: results.sarif
+          category: scorecard

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # gedcom-go
 
 [![CI](https://github.com/cacack/gedcom-go/actions/workflows/ci.yml/badge.svg)](https://github.com/cacack/gedcom-go/actions/workflows/ci.yml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/cacack/gedcom-go/badge)](https://scorecard.dev/viewer/?uri=github.com/cacack/gedcom-go)
 [![codecov](https://codecov.io/gh/cacack/gedcom-go/graph/badge.svg)](https://codecov.io/gh/cacack/gedcom-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/cacack/gedcom-go)](https://goreportcard.com/report/github.com/cacack/gedcom-go)
 [![GoDoc](https://pkg.go.dev/badge/github.com/cacack/gedcom-go.svg)](https://pkg.go.dev/github.com/cacack/gedcom-go)


### PR DESCRIPTION
## Summary

- Adds an OSSF Scorecard workflow (`.github/workflows/scorecard.yml`) running weekly and on pushes to `main`.
- Uploads SARIF to GitHub code scanning and publishes results to the OpenSSF REST API so the badge auto-updates.
- Adds an OpenSSF Scorecard badge to `README.md` alongside the existing badges.

All actions are SHA-pinned and the job uses `step-security/harden-runner` with audit egress, matching the rest of the CI suite.

## Test plan

- [ ] Workflow appears under Actions after merge
- [ ] First scheduled run (or push to `main`) completes without errors
- [ ] SARIF results show up under Security → Code scanning (category `scorecard`)
- [ ] Badge resolves on `scorecard.dev` once the first analysis publishes

## Notes

- Initial score will surface things like branch protection, signed releases, and token permissions. We already pin actions and harden runners, so the baseline should be reasonable.
- If any score component proves noisy, we can tune via policy files later.
