### PR TITLE
Harden workflows for OSSF Scorecard quick wins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,7 +315,7 @@ jobs:
           go-version: '1.26'
 
       - name: Install apidiff
-        run: go install golang.org/x/exp/cmd/apidiff@latest
+        run: go install golang.org/x/exp/cmd/apidiff@v0.0.0-20260410095643-746e56fc9e2f
 
       - name: Check API compatibility
         run: |
@@ -400,9 +400,10 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Check PR title is not conventional commit format
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+          PR_USER: ${{ github.event.pull_request.user.login }}
         run: |
-          TITLE="${{ github.event.pull_request.title }}"
-
           # Exempt release-please PRs (they use chore(main): release X.Y.Z)
           if echo "$TITLE" | grep -qE "^chore\(main\): release [0-9]"; then
             echo "✅ Release-please PR exempt from title check"
@@ -410,7 +411,7 @@ jobs:
           fi
 
           # Exempt Dependabot PRs (they use conventional commit format by default)
-          if [[ "${{ github.event.pull_request.user.login }}" == "dependabot[bot]" ]]; then
+          if [[ "$PR_USER" == "dependabot[bot]" ]]; then
             echo "✅ Dependabot PR exempt from title check"
             exit 0
           fi

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,10 @@ on:
     # Run weekly on Sundays at 00:00 UTC
     - cron: '0 0 * * 0'
 
+# Restrict default GITHUB_TOKEN permissions (principle of least privilege)
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -2,14 +2,18 @@ name: Dependabot Auto-Merge
 
 on: pull_request_target
 
+# Restrict default GITHUB_TOKEN permissions (principle of least privilege).
+# The automerge job requires write access to merge and approve PRs.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   automerge:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Fetch Dependabot metadata
         id: metadata

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,10 +6,10 @@ on:
     - cron: '0 3 * * *'
   workflow_dispatch: # Allow manual trigger
 
+# Restrict default GITHUB_TOKEN permissions (principle of least privilege).
+# Per-job permissions scope additional writes where they're needed.
 permissions:
   contents: read
-  issues: write
-  security-events: write
 
 jobs:
   fuzz:
@@ -55,6 +55,9 @@ jobs:
     name: Security Scan (Nightly)
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
@@ -120,6 +123,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [fuzz, security]
     if: failure() && github.event_name == 'schedule'
+    permissions:
+      contents: read
+      issues: write
     steps:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,13 +5,17 @@ on:
     branches:
       - main
 
+# Restrict default GITHUB_TOKEN permissions (principle of least privilege).
+# Release-please needs write access to create release PRs and tags.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -31,8 +35,9 @@ jobs:
 
     steps:
       - name: Trigger pkg.go.dev indexing
+        env:
+          VERSION: ${{ needs.release-please.outputs.tag_name }}
         run: |
-          VERSION=${{ needs.release-please.outputs.tag_name }}
           echo "Triggering pkg.go.dev for version $VERSION..."
           curl -f "https://proxy.golang.org/github.com/cacack/gedcom-go/@v/$VERSION.info" || true
           curl -f "https://sum.golang.org/lookup/github.com/cacack/gedcom-go@$VERSION" || true

--- a/scripts/perf-regression-test.sh
+++ b/scripts/perf-regression-test.sh
@@ -33,7 +33,7 @@ echo
 # Check if benchstat is installed
 if ! command -v benchstat &> /dev/null; then
     echo -e "${YELLOW}⚠${NC}  benchstat not found. Installing..."
-    go install golang.org/x/perf/cmd/benchstat@latest
+    go install golang.org/x/perf/cmd/benchstat@v0.0.0-20260409210113-8e83ce0f7b1c
 fi
 
 # Check if baseline exists


### PR DESCRIPTION
## Summary

Three quick wins from the OSSF Scorecard run (current score: 5.7/10). Together these should push the score to ~8.

### 1. Dangerous-Workflow: 0 → 10
`ci.yml:403` interpolated `${{ github.event.pull_request.title }}` and `${{ github.event.pull_request.user.login }}` directly into a shell script — a classic script-injection vector (a PR author could craft a title containing shell metacharacters). Moved both to `env:` vars so the runner exports them safely.

### 2. Token-Permissions: 0 → 10
Several workflows declared `write` permissions at the top level, granting them to every job regardless of need. Fixed:
- `codeql.yml` — added top-level `contents: read`
- `nightly.yml` — top-level is now `contents: read`; `security-events: write` scoped to the `security` job, `issues: write` scoped to the `notify` job
- `dependabot-automerge.yml` — `contents: write` / `pull-requests: write` scoped to the `automerge` job
- `release-please.yml` — `contents: write` / `pull-requests: write` scoped to the `release-please` job; also wrapped the `publish-docs` inline tag_name context in an `env:` var for consistency

### 3. Pinned-Dependencies: 9 → 10
Two `go install` commands used `@latest`:
- `.github/workflows/ci.yml:318` — `apidiff` pinned to `v0.0.0-20260410095643-746e56fc9e2f`
- `scripts/perf-regression-test.sh:36` — `benchstat` pinned to `v0.0.0-20260409210113-8e83ce0f7b1c`

## Test plan

- [ ] CI green (all existing checks)
- [ ] After merge, next Scorecard run (on-push trigger) reports scores of 10 for Dangerous-Workflow, Token-Permissions, and Pinned-Dependencies
- [ ] Release-please, dependabot-automerge, and nightly workflows still function normally on their next trigger

## Deferred

- **Code-Review / Branch-Protection**: require human reviewers — impractical for a solo project.
- **CII-Best-Practices**: earnable but requires a ~80-item questionnaire at [bestpractices.dev](https://www.bestpractices.dev/).
