### PR TITLE
Enable CodeRabbit PR review mode

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# CodeRabbit review configuration.
+# Reference: https://docs.coderabbit.ai/guides/configure-coderabbit
+
+language: en-US
+early_access: false
+tone_instructions: >
+  Focus on correctness, security, GEDCOM spec compliance, and lossless data
+  handling. This is a pre-1.0 Go library; flag breaking API changes.
+
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+
+  # Submit PR reviews (line-level comments + review submissions) on every new
+  # PR targeting main. This is what surfaces in GitHub's Reviews API and what
+  # OSSF Scorecard's Code-Review check reads.
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+
+  # Skip test fixtures, generated fuzz corpora, and go.sum — reviewing these
+  # wastes budget and rarely surfaces useful findings.
+  path_filters:
+    - "!testdata/**"
+    - "!**/testdata/fuzz/**"
+    - "!go.sum"
+
+chat:
+  auto_reply: true


### PR DESCRIPTION
## Summary

Adds `.coderabbit.yaml` to explicitly enable CodeRabbit's PR review mode.

## Why

CodeRabbit is currently installed on the repo and posts walkthrough summary comments, but it's **not submitting actual PR Reviews** (line-level review comments / review submissions). Example: PRs #248, #249, #228, #231 all show `coderabbitai[bot]` in issue comments, but the Reviews API returns an empty list.

OSSF Scorecard's Code-Review check reads the Pull Request Reviews API, not issue comments. That's why we're scoring 0/10 on Code-Review despite having automated review running. This config forces CodeRabbit to submit proper reviews.

## Config choices

- `auto_review.enabled: true` + `base_branches: [main]` — submit reviews on all PRs into main
- `path_filters` skip `testdata/**` and fuzz corpora — avoids wasting review budget on generated/fixture data
- `tone_instructions` — focus CodeRabbit on the things that matter for a pre-1.0 GEDCOM library (correctness, spec compliance, lossless handling, breaking-change flagging)
- `profile: chill` — less aggressive nitpicking; this is a solo project, signal-to-noise matters

## Test plan

- [ ] This PR itself should get a CodeRabbit review visible under "Reviews" on the PR page (not just a comment)
- [ ] After merge, the next substantive PR should also receive a proper review
- [ ] Subsequent Scorecard runs should either credit Code-Review (→ bump) or not (→ we learn scorecard doesn't allowlist CodeRabbit as a reviewer bot, and we know this path is dead)

## Uncertainty

I'm not 100% certain scorecard credits `coderabbitai[bot]` reviews specifically — some bot reviewers are excluded as "self-approval". If the next scorecard run still reports 0/10 after CodeRabbit is clearly submitting reviews, we'll know this avenue is closed and we can drop back.
