### PR TITLE
Add OpenSSF Best Practices badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/cacack/gedcom-go/actions/workflows/ci.yml/badge.svg)](https://github.com/cacack/gedcom-go/actions/workflows/ci.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/cacack/gedcom-go/badge)](https://scorecard.dev/viewer/?uri=github.com/cacack/gedcom-go)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12809/badge)](https://www.bestpractices.dev/projects/12809)
 [![codecov](https://codecov.io/gh/cacack/gedcom-go/graph/badge.svg)](https://codecov.io/gh/cacack/gedcom-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/cacack/gedcom-go)](https://goreportcard.com/report/github.com/cacack/gedcom-go)
 [![GoDoc](https://pkg.go.dev/badge/github.com/cacack/gedcom-go.svg)](https://pkg.go.dev/github.com/cacack/gedcom-go)


### PR DESCRIPTION
## Summary

- Earned the [OpenSSF Best Practices](https://www.bestpractices.dev/projects/12809) passing-tier badge for the project
- Added the badge to the README alongside the existing OpenSSF Scorecard badge

## Test plan

- [x] Badge link resolves to https://www.bestpractices.dev/projects/12809
- [x] Pre-commit hooks pass (gofmt, vet, golangci-lint, tests)
- [x] Coverage unchanged (96.2%)

## Follow-up

Scorecard alert #27 (CIIBestPracticesID) should auto-resolve on the next nightly Scorecard run now that the badge is detectable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
