### PR TITLE
Add Options types and WithOptions facade variants

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -31,8 +31,21 @@ Re-exported types for single-import convenience:
 - `Document`, `Individual`, `Family` - Core data types
 - `Version`, `Version55`, `Version551`, `Version70` - Version constants
 - `DecodeResult`, `Issue`, `ConversionReport` - Result types
+- `DecodeOptions`, `EncodeOptions`, `ValidateOptions` - Options types
 
 For advanced use cases (custom options, progress callbacks, streaming), import the underlying packages directly. See README.md for examples.
+
+## Configurable Options
+
+Each core operation exposes a dedicated options struct with safe defaults and an explicit `*WithOptions` entry point:
+
+| Operation | Options type | Facade entry point | Common knobs |
+|-----------|--------------|--------------------|--------------|
+| Decode | `decoder.DecodeOptions` | `gedcomgo.DecodeWithOptions` | `Context`, `MaxNestingDepth`, `StrictMode`, `OnProgress`, `TotalSize` |
+| Encode | `encoder.EncodeOptions` | `gedcomgo.EncodeWithOptions` | `LineEnding`, `MaxLineLength`, `DisableLineWrap`, `TargetVersion`, `PreserveUnknownTags` |
+| Validate | `validator.ValidateOptions` | `gedcomgo.ValidateAllWithOptions` | `Strictness`, `MaxErrors`, `SkipRules`, `DateLogic`, `Duplicates`, `TagRegistry`, `ValidateCustomTags`, `SkipEncodingValidation` |
+
+`gedcomgo.DefaultDecodeOptions()`, `DefaultEncodeOptions()`, and `DefaultValidateOptions()` return populated defaults you can tweak. `validator.ValidateOptions` is an alias for the original `validator.ValidatorConfig`; both names work interchangeably.
 
 ## Multi-Version Support
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,16 @@ fmt.Printf("Parsed %d individuals\n", len(doc.Individuals()))
 
 ## Advanced Usage
 
-For advanced use cases requiring custom options, import the underlying packages directly:
+The `gedcomgo` facade also exposes `*WithOptions` variants for the common operations:
+
+```go
+doc, err := gedcomgo.DecodeWithOptions(r, opts)
+err     = gedcomgo.EncodeWithOptions(w, doc, opts)
+errs   := gedcomgo.ValidateWithOptions(doc, opts)
+issues := gedcomgo.ValidateAllWithOptions(doc, opts)
+```
+
+Option types — `DecodeOptions`, `EncodeOptions`, `ValidateOptions` — are re-exported from the facade. For the full surface area (streaming, diagnostics, converter), import the underlying packages directly:
 
 ```go
 import (
@@ -209,40 +218,41 @@ import (
 ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 defer cancel()
 
-opts := &decoder.DecodeOptions{
+opts := &gedcomgo.DecodeOptions{
     Context:   ctx,
     TotalSize: fileInfo.Size(),
     OnProgress: func(bytesRead, totalBytes int64) {
         fmt.Printf("\rProgress: %d%%", bytesRead*100/totalBytes)
     },
 }
-doc, err := decoder.DecodeWithOptions(reader, opts)
+doc, err := gedcomgo.DecodeWithOptions(reader, opts)
 ```
 
-### Custom Validation Configuration
+### Custom Validation Options
 
 ```go
 // Configure validation strictness and duplicate detection
-config := &validator.ValidatorConfig{
+opts := &gedcomgo.ValidateOptions{
     Strictness: validator.StrictnessStrict,
+    MaxErrors:  100,
+    SkipRules:  []string{"W001"},
     Duplicates: &validator.DuplicateConfig{
         RequireExactSurname: true,
         MinNameSimilarity:   0.8,
     },
 }
-v := validator.NewWithConfig(config)
-issues := v.ValidateAll(doc)
+issues := gedcomgo.ValidateAllWithOptions(doc, opts)
 ```
 
 ### Custom Encoder Options
 
 ```go
 // Encode with custom line endings and line length
-opts := &encoder.EncodeOptions{
-    LineEnding:    encoder.LineEndingLF,
-    MaxLineLength: 255,
+opts := &gedcomgo.EncodeOptions{
+    LineEnding:    "\r\n", // CRLF
+    MaxLineLength: 248,
 }
-err := encoder.EncodeWithOptions(writer, doc, opts)
+err := gedcomgo.EncodeWithOptions(writer, doc, opts)
 ```
 
 ### Custom Conversion Options

--- a/encoder/doc.go
+++ b/encoder/doc.go
@@ -4,7 +4,7 @@
 // the GEDCOM file format. It supports customizable line endings and ensures
 // proper GEDCOM structure is maintained.
 //
-// Example usage:
+// # Basic Usage
 //
 //	doc := &gedcom.Document{
 //	    Header: &gedcom.Header{Version: "5.5", Encoding: "UTF-8"},
@@ -18,6 +18,25 @@
 //	defer f.Close()
 //
 //	if err := encoder.Encode(f, doc); err != nil {
+//	    log.Fatal(err)
+//	}
+//
+// # Options
+//
+// Use [EncodeWithOptions] together with [EncodeOptions] to customize output.
+// Call [DefaultOptions] for a populated starting point.
+//
+//   - LineEnding          — "\n" (default) or "\r\n" (CRLF for legacy tooling)
+//   - MaxLineLength       — split long values with CONC when writing from typed
+//     entities (default: 248). Pre-built [gedcom.Tag] values are written verbatim.
+//   - DisableLineWrap     — disable CONC splitting entirely
+//   - TargetVersion       — override the document's GEDCOM version in output
+//   - PreserveUnknownTags — true (default) keeps custom _UNDERSCORE tags
+//
+// Example with CRLF line endings:
+//
+//	opts := &encoder.EncodeOptions{LineEnding: "\r\n"}
+//	if err := encoder.EncodeWithOptions(f, doc, opts); err != nil {
 //	    log.Fatal(err)
 //	}
 package encoder

--- a/example_options_test.go
+++ b/example_options_test.go
@@ -57,7 +57,10 @@ func TestValidateWithOptionsFacade(t *testing.T) {
 0 @F1@ FAM
 0 TRLR`
 
-	doc, _ := gedcomgo.Decode(strings.NewReader(data))
+	doc, err := gedcomgo.Decode(strings.NewReader(data))
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
 
 	errs := gedcomgo.ValidateWithOptions(doc, gedcomgo.DefaultValidateOptions())
 	if len(errs) == 0 {
@@ -104,7 +107,11 @@ func ExampleValidateAllWithOptions() {
 2 DATE 1 JAN 1900
 0 TRLR`
 
-	doc, _ := gedcomgo.Decode(strings.NewReader(gedcomData))
+	doc, err := gedcomgo.Decode(strings.NewReader(gedcomData))
+	if err != nil {
+		fmt.Printf("Decode: %v\n", err)
+		return
+	}
 
 	opts := gedcomgo.DefaultValidateOptions()
 	opts.MaxErrors = 5

--- a/example_options_test.go
+++ b/example_options_test.go
@@ -1,0 +1,57 @@
+package gedcomgo_test
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	gedcomgo "github.com/cacack/gedcom-go"
+	"github.com/cacack/gedcom-go/gedcom"
+)
+
+// ExampleEncodeWithOptions shows encoding via the facade with custom options.
+func ExampleEncodeWithOptions() {
+	doc := &gedcom.Document{
+		Header:  &gedcom.Header{Version: gedcom.Version551},
+		Trailer: &gedcom.Trailer{},
+	}
+
+	opts := gedcomgo.DefaultEncodeOptions()
+	opts.LineEnding = "\r\n"
+
+	var buf bytes.Buffer
+	if err := gedcomgo.EncodeWithOptions(&buf, doc, opts); err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+
+	fmt.Printf("CRLF lines: %d\n", strings.Count(buf.String(), "\r\n"))
+
+	// Output:
+	// CRLF lines: 4
+}
+
+// ExampleValidateAllWithOptions shows validating via the facade with custom options.
+func ExampleValidateAllWithOptions() {
+	gedcomData := `0 HEAD
+1 GEDC
+2 VERS 7.0
+0 @I1@ INDI
+1 NAME John /Smith/
+1 BIRT
+2 DATE 1 JAN 2000
+1 DEAT
+2 DATE 1 JAN 1900
+0 TRLR`
+
+	doc, _ := gedcomgo.Decode(strings.NewReader(gedcomData))
+
+	opts := gedcomgo.DefaultValidateOptions()
+	opts.MaxErrors = 5
+
+	issues := gedcomgo.ValidateAllWithOptions(doc, opts)
+	fmt.Printf("Issues: %d\n", len(issues))
+
+	// Output:
+	// Issues: 1
+}

--- a/example_options_test.go
+++ b/example_options_test.go
@@ -4,10 +4,70 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+	"testing"
 
 	gedcomgo "github.com/cacack/gedcom-go"
 	"github.com/cacack/gedcom-go/gedcom"
 )
+
+func TestDefaultOptionsHelpers(t *testing.T) {
+	t.Parallel()
+
+	if opts := gedcomgo.DefaultDecodeOptions(); opts == nil || opts.MaxNestingDepth == 0 {
+		t.Errorf("DefaultDecodeOptions returned unexpected value: %+v", opts)
+	}
+	if opts := gedcomgo.DefaultEncodeOptions(); opts == nil || opts.LineEnding == "" {
+		t.Errorf("DefaultEncodeOptions returned unexpected value: %+v", opts)
+	}
+	if opts := gedcomgo.DefaultValidateOptions(); opts == nil {
+		t.Error("DefaultValidateOptions returned nil")
+	}
+}
+
+func TestDecodeWithOptionsFacade(t *testing.T) {
+	t.Parallel()
+
+	data := `0 HEAD
+1 GEDC
+2 VERS 5.5
+0 @I1@ INDI
+1 NAME Test /User/
+0 TRLR`
+
+	doc, err := gedcomgo.DecodeWithOptions(strings.NewReader(data), gedcomgo.DefaultDecodeOptions())
+	if err != nil {
+		t.Fatalf("DecodeWithOptions: %v", err)
+	}
+	if doc == nil || len(doc.Records) != 1 {
+		t.Errorf("expected 1 record, got %+v", doc)
+	}
+
+	doc, err = gedcomgo.DecodeWithOptions(strings.NewReader(data), nil)
+	if err != nil || doc == nil {
+		t.Errorf("DecodeWithOptions(nil opts) failed: %v", err)
+	}
+}
+
+func TestValidateWithOptionsFacade(t *testing.T) {
+	t.Parallel()
+
+	data := `0 HEAD
+1 GEDC
+2 VERS 5.5
+0 @F1@ FAM
+0 TRLR`
+
+	doc, _ := gedcomgo.Decode(strings.NewReader(data))
+
+	errs := gedcomgo.ValidateWithOptions(doc, gedcomgo.DefaultValidateOptions())
+	if len(errs) == 0 {
+		t.Error("ValidateWithOptions: expected at least one error for empty family")
+	}
+
+	if errs := gedcomgo.ValidateWithOptions(doc, nil); len(errs) == 0 {
+		t.Error("ValidateWithOptions(nil opts): expected at least one error")
+	}
+}
 
 // ExampleEncodeWithOptions shows encoding via the facade with custom options.
 func ExampleEncodeWithOptions() {

--- a/gedcom_api.go
+++ b/gedcom_api.go
@@ -79,7 +79,31 @@ type (
 
 	// ConversionReport contains the results of a GEDCOM version conversion.
 	ConversionReport = gedcom.ConversionReport
+
+	// DecodeOptions configures GEDCOM decoding. See [decoder.DecodeOptions].
+	DecodeOptions = decoder.DecodeOptions
+
+	// EncodeOptions configures GEDCOM encoding. See [encoder.EncodeOptions].
+	EncodeOptions = encoder.EncodeOptions
+
+	// ValidateOptions configures GEDCOM validation. See [validator.ValidateOptions].
+	ValidateOptions = validator.ValidateOptions
 )
+
+// DefaultDecodeOptions returns the default decoding options.
+func DefaultDecodeOptions() *DecodeOptions {
+	return decoder.DefaultOptions()
+}
+
+// DefaultEncodeOptions returns the default encoding options.
+func DefaultEncodeOptions() *EncodeOptions {
+	return encoder.DefaultOptions()
+}
+
+// DefaultValidateOptions returns the default validation options.
+func DefaultValidateOptions() *ValidateOptions {
+	return validator.DefaultOptions()
+}
 
 // Version constants for convenience.
 const (
@@ -96,10 +120,16 @@ const (
 // Decode parses a GEDCOM file from an io.Reader and returns a Document.
 // This is the simplest way to parse a GEDCOM file using default options.
 //
-// For custom options (progress callbacks, context cancellation), use the
-// decoder package directly: decoder.DecodeWithOptions().
+// For custom options (progress callbacks, context cancellation), use
+// [DecodeWithOptions].
 func Decode(r io.Reader) (*Document, error) {
 	return decoder.Decode(r)
+}
+
+// DecodeWithOptions parses a GEDCOM file with the given options.
+// If opts is nil, default options are used.
+func DecodeWithOptions(r io.Reader, opts *DecodeOptions) (*Document, error) {
+	return decoder.DecodeWithOptions(r, opts)
 }
 
 // DecodeWithDiagnostics parses a GEDCOM file and returns both the document and any diagnostics.
@@ -113,33 +143,56 @@ func DecodeWithDiagnostics(r io.Reader) (*DecodeResult, error) {
 }
 
 // Encode writes a GEDCOM document to a writer using default options.
-// The output uses CRLF line endings as per the GEDCOM specification.
+// The output uses LF line endings; pass [EncodeOptions.LineEnding] = "\r\n"
+// to write CRLF.
 //
-// For custom options (line endings, encoding), use the
-// encoder package directly: encoder.EncodeWithOptions().
+// For custom options (line endings, target version, line wrapping, custom-tag
+// preservation), use [EncodeWithOptions].
 func Encode(w io.Writer, doc *Document) error {
 	return encoder.Encode(w, doc)
+}
+
+// EncodeWithOptions writes a GEDCOM document with the given options.
+// If opts is nil, default options are used.
+func EncodeWithOptions(w io.Writer, doc *Document, opts *EncodeOptions) error {
+	return encoder.EncodeWithOptions(w, doc, opts)
 }
 
 // Validate validates a GEDCOM document and returns any validation errors.
 // This performs basic structural validation including cross-reference checks
 // and required field validation.
 //
-// For comprehensive validation with severity levels, use ValidateAll().
-// For custom validation configuration, use the validator package directly.
+// For comprehensive validation with severity levels, use [ValidateAll].
+// For custom validation configuration (strictness, MaxErrors, SkipRules),
+// use [ValidateWithOptions] or [ValidateAllWithOptions].
 func Validate(doc *Document) []error {
 	return validator.New().Validate(doc)
 }
 
+// ValidateWithOptions validates a GEDCOM document with the given options
+// and returns any validation errors. If opts is nil, default options are used.
+//
+// Note: [ValidateOptions.MaxErrors] and [ValidateOptions.SkipRules] only
+// affect [ValidateAllWithOptions]; the legacy []error API ignores them.
+func ValidateWithOptions(doc *Document, opts *ValidateOptions) []error {
+	return validator.NewWithOptions(opts).Validate(doc)
+}
+
 // ValidateAll returns comprehensive validation as Issues with severity levels.
-// This is the enhanced API that provides more detail than Validate(), including
+// This is the enhanced API that provides more detail than [Validate], including
 // date logic validation, reference checking, and quality analysis.
 //
 // Issues are categorized by severity: Error, Warning, and Info.
-// For custom validation configuration (strictness, thresholds), use the
-// validator package directly: validator.NewWithConfig().
+// For custom validation configuration (strictness, thresholds, skip rules),
+// use [ValidateAllWithOptions].
 func ValidateAll(doc *Document) []Issue {
 	return validator.New().ValidateAll(doc)
+}
+
+// ValidateAllWithOptions runs comprehensive validation with the given options.
+// If opts is nil, default options are used.
+func ValidateAllWithOptions(doc *Document, opts *ValidateOptions) []Issue {
+	return validator.NewWithOptions(opts).ValidateAll(doc)
 }
 
 // Convert converts a GEDCOM document to the target version.

--- a/validator/doc.go
+++ b/validator/doc.go
@@ -50,15 +50,28 @@
 //	fmt.Printf("Errors: %d, Warnings: %d\n", report.ErrorCount, report.WarningCount)
 //	fmt.Printf("Birth date coverage: %.0f%%\n", report.BirthDateCoverage*100)
 //
-// # Configuration
+// # Options
 //
-// Customize validation behavior:
+// Use [NewWithOptions] together with [ValidateOptions] to customize validation
+// behavior. [ValidatorConfig] is retained as a backward-compatible alias.
+// Call [DefaultOptions] for a populated starting point.
 //
-//	config := &validator.ValidatorConfig{
+//   - Strictness             — StrictnessRelaxed | StrictnessNormal (default) | StrictnessStrict
+//   - MaxErrors              — cap collected issues (0 = unlimited)
+//   - SkipRules              — issue codes to exclude (e.g. []string{"W001"})
+//   - DateLogic              — date-logic thresholds (e.g. MaxReasonableAge)
+//   - Duplicates             — duplicate-detection thresholds
+//   - TagRegistry            — definitions for custom (underscore) tags
+//   - ValidateCustomTags     — enable custom-tag validation against registry
+//   - SkipEncodingValidation — disable GEDCOM 7.0 encoding checks
+//
+// Example combining strictness with skip rules:
+//
+//	opts := &validator.ValidateOptions{
 //	    Strictness: validator.StrictnessStrict,
-//	    DateLogic: &validator.DateLogicConfig{
-//	        MaxReasonableAge: 110,
-//	    },
+//	    MaxErrors:  100,
+//	    SkipRules:  []string{"W001"},
+//	    DateLogic:  &validator.DateLogicConfig{MaxReasonableAge: 110},
 //	}
-//	v := validator.NewWithConfig(config)
+//	issues := validator.NewWithOptions(opts).ValidateAll(doc)
 package validator

--- a/validator/example_test.go
+++ b/validator/example_test.go
@@ -113,6 +113,40 @@ func ExampleNewWithConfig() {
 	// Issues found: 0
 }
 
+// ExampleNewWithOptions demonstrates combining Strictness, SkipRules, and MaxErrors.
+func ExampleNewWithOptions() {
+	opts := &validator.ValidateOptions{
+		Strictness: validator.StrictnessStrict,
+		MaxErrors:  10,
+		SkipRules:  []string{"ENCODING_BANNED_C0"},
+	}
+
+	v := validator.NewWithOptions(opts)
+
+	gedcomData := `0 HEAD
+1 GEDC
+2 VERS 7.0
+0 @I1@ INDI
+1 NAME John /Smith/
+1 BIRT
+2 DATE 1 JAN 2000
+1 DEAT
+2 DATE 1 JAN 1900
+0 TRLR`
+
+	doc, _ := decoder.Decode(strings.NewReader(gedcomData))
+
+	issues := v.ValidateAll(doc)
+	fmt.Printf("Issues found: %d\n", len(issues))
+	if len(issues) > 0 {
+		fmt.Printf("First: [%s] %s\n", issues[0].Severity, issues[0].Code)
+	}
+
+	// Output:
+	// Issues found: 1
+	// First: [ERROR] DEATH_BEFORE_BIRTH
+}
+
 // ExampleValidator_QualityReport shows generating a data quality report.
 func ExampleValidator_QualityReport() {
 	gedcomData := `0 HEAD

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -38,6 +38,10 @@ const (
 
 // ValidatorConfig contains configuration options for the Validator.
 //
+// Deprecated: use [ValidateOptions] for consistency with the other option
+// types ([decoder.DecodeOptions], [encoder.EncodeOptions]). ValidatorConfig
+// remains a working alias and will not be removed.
+//
 //nolint:revive // Name kept for API clarity despite repetition
 type ValidatorConfig struct {
 	// DateLogic configures date logic validation thresholds.
@@ -77,6 +81,29 @@ type ValidatorConfig struct {
 	// Example: []string{"W001", "I002"} to skip warning W001 and info I002.
 	// Default: nil (no rules skipped).
 	SkipRules []string
+}
+
+// ValidateOptions configures validator behavior. It is the canonical options
+// type, aligned with [decoder.DecodeOptions] and [encoder.EncodeOptions].
+//
+// ValidateOptions is a type alias for [ValidatorConfig]; both names refer to
+// the same type and may be used interchangeably.
+type ValidateOptions = ValidatorConfig
+
+// DefaultOptions returns the default validator options.
+func DefaultOptions() *ValidateOptions {
+	return &ValidateOptions{
+		Strictness: StrictnessNormal,
+	}
+}
+
+// NewWithOptions creates a new Validator with the given options.
+// If opts is nil, default options are used.
+//
+// NewWithOptions is the canonical constructor; [NewWithConfig] is retained
+// as a backward-compatible alias.
+func NewWithOptions(opts *ValidateOptions) *Validator {
+	return NewWithConfig(opts)
 }
 
 // Validator validates GEDCOM documents against specification rules.

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -370,6 +370,8 @@ func TestNewWithOptions(t *testing.T) {
 
 	if v := NewWithOptions(nil); v == nil {
 		t.Error("NewWithOptions(nil) returned nil")
+	} else if v.config == nil || v.config.Strictness != StrictnessNormal {
+		t.Errorf("NewWithOptions(nil) strictness = %v, want %v", v.config.Strictness, StrictnessNormal)
 	}
 }
 

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -348,6 +348,31 @@ func TestNewWithConfig(t *testing.T) {
 	}
 }
 
+func TestDefaultOptions(t *testing.T) {
+	opts := DefaultOptions()
+	if opts == nil {
+		t.Fatal("DefaultOptions() returned nil")
+	}
+	if opts.Strictness != StrictnessNormal {
+		t.Errorf("Strictness = %v, want StrictnessNormal", opts.Strictness)
+	}
+}
+
+func TestNewWithOptions(t *testing.T) {
+	opts := &ValidateOptions{Strictness: StrictnessStrict}
+	v := NewWithOptions(opts)
+	if v == nil {
+		t.Fatal("NewWithOptions() returned nil")
+	}
+	if v.config.Strictness != StrictnessStrict {
+		t.Errorf("Strictness = %v, want StrictnessStrict", v.config.Strictness)
+	}
+
+	if v := NewWithOptions(nil); v == nil {
+		t.Error("NewWithOptions(nil) returned nil")
+	}
+}
+
 // Test ValidateAll returns Issues
 func TestValidateAllReturnsIssues(t *testing.T) {
 	// Create document with date logic issue (death before birth)


### PR DESCRIPTION
## Summary

- Surfaces `EncodeOptions` and `ValidateOptions` (alias of `ValidatorConfig`) as prominent public API alongside the existing `DecodeOptions`.
- Adds `gedcomgo.{Decode,Encode,Validate,ValidateAll}WithOptions` facade wrappers and `Default{Decode,Encode,Validate}Options` helpers, so callers no longer need to drop down to underlying packages for customization.
- Updates encoder/validator godoc and the README/FEATURES tables to advertise the options surface explicitly.

Backward-compatible: `ValidatorConfig`, `NewWithConfig`, and all existing entry points keep working. The deprecation notice on `ValidatorConfig` is documentation-only.

## Test plan

- [x] `make preflight` — lint, vet, race tests, coverage 96.2% (≥85% gate), security all pass
- [x] `make api-check` — only pre-existing breakage (commit `98b3680!`) flagged; this PR is purely additive
- [x] New godoc examples (`ExampleNewWithOptions`, `ExampleEncodeWithOptions`, `ExampleValidateAllWithOptions`) compile and pass
- [ ] CI workflow green on push

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Re-exported option types for single-import use and added option-aware facade calls for decoding, encoding, and validation.
  * Added default option helpers for easy defaults.

* **Documentation**
  * Expanded docs and README with configurable options, usage examples, API clarifications, and deprecation note for legacy validator config.

* **Examples & Tests**
  * Added examples and tests demonstrating option helpers, facade usage, and option-aware calls.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cacack/gedcom-go/pull/270)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->