### PR TITLE
Retry nightly fuzz step once on fuzztime-deadline race

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,7 +41,24 @@ jobs:
         cache: true
 
     - name: Run ${{ matrix.fuzz }}
-      run: go test ${{ matrix.package }} -fuzz=${{ matrix.fuzz }} -fuzztime=${{ matrix.time }} -timeout=0
+      # Retry once on the "context deadline exceeded" race, where Go's fuzz
+      # coordinator cancels an in-flight iteration right at the -fuzztime
+      # boundary on slow/contended runners. A real failing input (which writes
+      # to testdata/fuzz/...) still fails immediately on the first attempt.
+      run: |
+        set -o pipefail
+        run_fuzz() {
+          go test ${{ matrix.package }} -fuzz=${{ matrix.fuzz }} \
+            -fuzztime=${{ matrix.time }} -timeout=0 2>&1 | tee fuzz.out
+        }
+        if run_fuzz; then exit 0; fi
+        if grep -q "context deadline exceeded" fuzz.out \
+           && ! grep -q "Failing input written" fuzz.out; then
+          echo "::warning::Fuzztime-deadline race detected; retrying once."
+          run_fuzz
+        else
+          exit 1
+        fi
 
     - name: Upload crash artifacts
       if: failure()


### PR DESCRIPTION
## Summary

- Wraps the nightly fuzz step in a single-retry guard that only re-runs on the Go fuzz framework's "context deadline exceeded" race (the in-flight iteration getting cancelled at the `-fuzztime` boundary).
- Real failing inputs (which write a corpus file with "Failing input written") still fail immediately on the first attempt — no retry, no hiding bugs.
- Diagnoses #272: nightly failed at elapsed 120.07s ≈ `-fuzztime=2m`, no new corpus entry was uploaded, and a local 2-minute repro (23M executions, 180–205K execs/sec) ran cleanly. `ParseDate` takes no `context.Context`, so cancellation cannot propagate into the function — confirming the framework race, not a slow path.

## Test plan

- [x] YAML validates (`yaml.safe_load`)
- [x] `make preflight` (gofmt, vet, golangci-lint, tests, coverage) — all green pre-commit and pre-push
- [ ] Trigger nightly manually post-merge via `gh workflow run nightly.yml` to confirm green
- [ ] Close #272 once nightly passes once

Refs #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced nightly fuzz testing with improved retry logic for better test reliability during timeout scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cacack/gedcom-go/pull/273)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->