### PR TITLE
Add osv-scanner to CI security job for OSV coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,24 @@ jobs:
         sarif_file: trivy-results.sarif
         category: trivy
 
+    # osv-scanner: Full-lockfile OSV vulnerability scan (complements govulncheck's reachability analysis)
+    - name: Run osv-scanner
+      uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+      continue-on-error: true  # Non-blocking initially; promote to blocking after evaluation period
+      with:
+        scan-args: |-
+          --recursive
+          --format=sarif
+          --output=osv-scanner-results.sarif
+          ./
+
+    - name: Upload osv-scanner results to GitHub Security
+      uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4
+      if: success() || failure()
+      with:
+        sarif_file: osv-scanner-results.sarif
+        category: osv-scanner
+
     # Semgrep: Rule-based static analysis
     - name: Semgrep scan
       continue-on-error: true  # Produce SARIF even on findings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,7 +252,7 @@ jobs:
         scan-args: |-
           --recursive
           --format=sarif
-          --output=osv-scanner-results.sarif
+          --output-file=osv-scanner-results.sarif
           ./
 
     - name: Upload osv-scanner results to GitHub Security


### PR DESCRIPTION
## Summary

- Adds `google/osv-scanner-action` v2.3.8 (SHA-pinned) to the `security` job in `ci.yml`
- Scans full `go.sum` against the OSV database; SARIF uploaded to GitHub Security under category `osv-scanner`
- Non-blocking (`continue-on-error: true`) for the initial evaluation period

## Rationale

Closes #254. Complements existing coverage:
- `govulncheck` — Go-vuln-DB only, with reachability analysis (kept)
- `actions/dependency-review-action` — PR-delta only (kept)
- `osv-scanner` — full-lockfile OSV coverage on every run (new)

Out of scope: replacing govulncheck (its reachability analysis is distinct), changing nightly behavior.

## Test plan

- [ ] CI green on this PR — confirms the YAML composes and the action runs
- [ ] After merge: SARIF appears in GitHub Security → Code scanning under category `osv-scanner`
- [ ] Track false-positive rate for 2–3 weeks, then file follow-up to remove `continue-on-error` if signal is good