### PR TITLE
Add Dependabot 5-day cooldown to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
       day: "monday"
     open-pull-requests-limit: 5
     rebase-strategy: "auto"
+    cooldown:
+      default-days: 5
+      include:
+        - "*"
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -26,6 +30,10 @@ updates:
       day: "monday"
     open-pull-requests-limit: 5
     rebase-strategy: "auto"
+    cooldown:
+      default-days: 5
+      include:
+        - "*"
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
## Summary
- Adds `cooldown: default-days: 5` to both `gomod` and `github-actions` ecosystem blocks in `.github/dependabot.yml`
- Dependabot will now wait 5 days after a version is published before opening a PR, narrowing the window where compromised/typosquatted releases reach our repo before being detected and yanked
- Mirrors the same change in the consumer project: cacack/my-family#444

## Test plan
- [ ] Visual review of YAML structure
- [ ] Next Monday's Dependabot run opens fewer PRs (only versions >=5 days old)

Closes #252

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update configuration to include a 5-day cooldown period for automatic updates across all dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cacack/gedcom-go/pull/281?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->