### PR TITLE
Extend harden-runner audit-mode to every workflow job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+      with:
+        egress-policy: audit
+
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -109,6 +114,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+      with:
+        egress-policy: audit
+
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -127,6 +137,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+      with:
+        egress-policy: audit
+
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -154,6 +169,11 @@ jobs:
     timeout-minutes: 5
     if: github.event_name == 'pull_request'
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+      with:
+        egress-policy: audit
+
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -322,6 +342,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -417,6 +442,11 @@ jobs:
     timeout-minutes: 5
     if: github.event_name == 'pull_request'
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
       - name: Check PR title is not conventional commit format
         env:
           TITLE: ${{ github.event.pull_request.title }}
@@ -449,6 +479,11 @@ jobs:
     timeout-minutes: 5
     if: github.event_name == 'pull_request'
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -502,6 +537,11 @@ jobs:
     needs: [test, coverage, lint, format, dependency-review, security, build-examples, api-compatibility, pr-title, commit-type]
     if: always()
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
       - name: Check all jobs passed
         run: |
           # pr-title is skipped on push events, which is expected

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,11 @@ jobs:
       security-events: write
 
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+      with:
+        egress-policy: audit
+
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -15,6 +15,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
       - name: Fetch Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,6 +31,11 @@ jobs:
             time: 2m
 
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+      with:
+        egress-policy: audit
+
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -144,6 +149,11 @@ jobs:
       contents: read
       issues: write
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+      with:
+        egress-policy: audit
+
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,6 +20,11 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
@@ -34,6 +39,11 @@ jobs:
     if: ${{ needs.release-please.outputs.release_created }}
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
       - name: Trigger pkg.go.dev indexing
         env:
           VERSION: ${{ needs.release-please.outputs.tag_name }}


### PR DESCRIPTION
## Summary

Phase 1 of issue #253: add `step-security/harden-runner` (egress-policy: audit) to every remaining job across all workflows. Hardening is most effective when applied uniformly — a compromised build-time script on any unprotected job can exfiltrate `GITHUB_TOKEN` or publish credentials even if other jobs are locked down.

**14 jobs hardened across 5 files:**

| Workflow | Jobs added |
|---|---|
| `ci.yml` | `coverage`, `lint`, `format`, `dependency-review`, `api-compatibility`, `pr-title`, `commit-type`, `ci-success` |
| `codeql.yml` | `analyze` |
| `release-please.yml` | `release-please`, `publish-docs` |
| `dependabot-automerge.yml` | `automerge` |
| `nightly.yml` | `fuzz`, `notify` (`security` already had it) |

**Notes / drift from issue text:**
- Issue cited SHA-pinned `v2.19.0`. The repo's existing harden-runner steps are pinned to `v2.19.1` (`a5ad31d6a139d249332a2605b85202e8c0b78450`). This PR matches the in-repo pin rather than introducing a second version.
- Issue listed `scorecard.yml` as missing harden-runner. It was already hardened at some point after the issue was filed; left untouched.
- Existing audit-mode steps (`test`, `security`, `build-examples`, scorecard `analysis`, nightly `security`) are unchanged per the issue's "keep them unchanged until phase 2" guidance.

## Phase 2 (separate effort)

After ~1 week of audit-mode observation across at least one run of every workflow, review StepSecurity insights, build per-job allow-lists, and flip to `egress-policy: block` with `allowed-endpoints:`. Will be tracked in a follow-up issue.

## Test plan

- [ ] All workflow YAML still parses (validated locally: `python3 -c yaml.safe_load` for each modified file — all OK)
- [ ] This PR's own CI run passes — every hardened job (`coverage`, `lint`, `format`, `dependency-review`, `api-compatibility`, `pr-title`, `commit-type`, `ci-success`) succeeds with the new step
- [ ] After merge: next scheduled `codeql` and `nightly` runs succeed
- [ ] After merge: next release-please run succeeds

Closes #253

Generated with [Claude Code](https://claude.com/claude-code)
