### PR TITLE
Stabilize streaming APIs and harden iterator contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,11 @@ For files too large to materialize in memory (10k+ individuals, exports from maj
 
 ```go
 import (
+    "os"
+
     "github.com/cacack/gedcom-go/charset"
     "github.com/cacack/gedcom-go/encoder"
+    "github.com/cacack/gedcom-go/gedcom"
     "github.com/cacack/gedcom-go/parser"
 )
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,69 @@ defer f.Close()
 err := gedcomgo.Encode(f, doc)
 ```
 
+### Streaming for Large Files
+
+For files too large to materialize in memory (10k+ individuals, exports from major platforms), use the streaming APIs. The parser yields records one at a time; the encoder writes them one at a time. The full `Document` is never constructed, so the heap retained after the operation completes is a small constant rather than proportional to file size.
+
+```go
+import (
+    "github.com/cacack/gedcom-go/charset"
+    "github.com/cacack/gedcom-go/encoder"
+    "github.com/cacack/gedcom-go/parser"
+)
+
+// Streaming parse — iterate level-0 records without building a Document.
+func countRecords(path string) (map[string]int, error) {
+    f, err := os.Open(path)
+    if err != nil {
+        return nil, err
+    }
+    defer f.Close()
+
+    counts := make(map[string]int)
+    for rec, err := range parser.Records(charset.NewReader(f)) {
+        if err != nil {
+            return nil, err   // rec is nil here; always check err first
+        }
+        counts[rec.Type]++
+    }
+    return counts, nil
+}
+
+// Streaming encode — call sequence is WriteHeader → WriteRecord* → WriteTrailer → Close.
+// Capture Close's error so ErrTrailerNotWritten and flush failures aren't dropped.
+func writeStreamed(path string, records []*gedcom.Record) (err error) {
+    out, err := os.Create(path)
+    if err != nil {
+        return err
+    }
+    defer func() {
+        if cerr := out.Close(); cerr != nil && err == nil {
+            err = cerr
+        }
+    }()
+
+    enc := encoder.NewStreamEncoder(out)
+    defer func() {
+        if cerr := enc.Close(); cerr != nil && err == nil {
+            err = cerr
+        }
+    }()
+
+    if err := enc.WriteHeader(&gedcom.Header{Version: "5.5", Encoding: "UTF-8"}); err != nil {
+        return err
+    }
+    for _, rec := range records {
+        if err := enc.WriteRecord(rec); err != nil {
+            return err
+        }
+    }
+    return enc.WriteTrailer()
+}
+```
+
+On a 1.1MB / 2,322-individual file, streaming parse holds **~17%** of the heap that batch decode retains after the call returns (and ~54% of the cumulative allocations). See [`examples/stream`](examples/stream/main.go) for the full pattern and [docs/PERFORMANCE.md](docs/PERFORMANCE.md#streaming-apis-performance) for benchmark details.
+
 ### Convert Between Versions
 
 ```go
@@ -188,6 +251,7 @@ To opt into strict parsing (fail on the first syntax error, no diagnostics colle
   - [`examples/encode`](examples/encode) - Creating GEDCOM files programmatically
   - [`examples/query`](examples/query) - Navigating and querying genealogy data
   - [`examples/validate`](examples/validate) - Validating GEDCOM files
+  - [`examples/stream`](examples/stream) - Streaming parse and encode for very large files
 - **API Documentation**: [pkg.go.dev/github.com/cacack/gedcom-go](https://pkg.go.dev/github.com/cacack/gedcom-go)
 - **Contributing**: [CONTRIBUTING.md](CONTRIBUTING.md)
 
@@ -291,16 +355,16 @@ This library follows [Semantic Versioning](https://semver.org/). We do not break
 |---------|----------|
 | `gedcom` | Document, Individual, Family, Event, Date |
 | `decoder` | Decode(), DecodeWithOptions() |
-| `encoder` | Encode(), EncodeWithOptions() |
+| `encoder` | Encode(), EncodeWithOptions(), NewStreamEncoder(), NewStreamEncoderWithOptions(), EncodeStreaming(), EncodeStreamingWithOptions() |
 | `converter` | Convert(), ConvertWithOptions() |
-| `parser` | Parse(), ParseLine() |
-| `validator` | Validate(), ValidateAll() |
+| `parser` | Parse(), ParseLine(), NewRecordIterator(), NewRecordIteratorWithOffset(), Records(), RecordsWithOffset(), NewLazyParser() |
+| `validator` | Validate(), ValidateAll(), NewStreamingValidator() |
 | `charset` | NewReader() |
 | `version` | Detect() |
 
 ### What May Change
 
-- **Experimental features** (streaming APIs, duplicate detection) may evolve in minor versions
+- **Experimental features** (duplicate detection algorithms, quality report format) may evolve in minor versions
 
 ### GEDCOM Spec Evolution
 

--- a/decoder/benchmark_test.go
+++ b/decoder/benchmark_test.go
@@ -4,7 +4,11 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"runtime"
 	"testing"
+
+	"github.com/cacack/gedcom-go/charset"
+	"github.com/cacack/gedcom-go/parser"
 )
 
 // BenchmarkDecodeMinimal benchmarks parsing a minimal GEDCOM file (~170 bytes)
@@ -89,4 +93,116 @@ func BenchmarkDecodeLarge(b *testing.B) {
 // Helper to create a fresh bytes.Reader for each iteration
 func newBytesReader(data []byte) io.Reader {
 	return bytes.NewReader(data)
+}
+
+// BenchmarkStreamingParseLarge benchmarks streaming parse of the same large
+// file used by BenchmarkDecodeLarge. Each iteration touches rec.Type so the
+// benchmark models a real consumer that at least inspects each record,
+// matching the example pattern.
+//
+//	go test -bench='DecodeLarge|StreamingParseLarge' -benchmem ./decoder/
+func BenchmarkStreamingParseLarge(b *testing.B) {
+	data, err := os.ReadFile("../testdata/gedcom-5.5/pres2020.ged")
+	if err != nil {
+		b.Skip("Test file not found:", err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		r := charset.NewReader(bytes.NewReader(data))
+		var iterErr error
+		for rec, perr := range parser.Records(r) {
+			if perr != nil {
+				iterErr = perr
+				break
+			}
+			_ = rec.Type
+		}
+		if iterErr != nil {
+			b.Fatal(iterErr)
+		}
+	}
+}
+
+// TestMemoryBatchVsStreaming reports two complementary memory metrics for
+// batch-decode vs streaming-parse over the large fixture:
+//
+//  1. Cumulative allocated bytes (TotalAlloc delta) — total work done.
+//     Stable, GC-immune. Tells you "how many bytes did the operation churn
+//     through in aggregate".
+//  2. Retained heap after return (HeapAlloc delta with KeepAlive) — what's
+//     still resident when the call completes. Tells you "if I do this in
+//     the middle of a long-running process, what's the steady-state cost?"
+//
+// The streaming win shows up in (2): batch holds the full Document; streaming
+// holds essentially nothing. Cumulative work in (1) is similar because both
+// paths parse the same bytes and allocate similar per-record buffers.
+//
+//	go test -v -run TestMemory ./decoder/
+func TestMemoryBatchVsStreaming(t *testing.T) {
+	data, err := os.ReadFile("../testdata/gedcom-5.5/pres2020.ged")
+	if err != nil {
+		t.Skip("Test file not found:", err)
+	}
+
+	batchAllocs, batchRetained := measureMemory(t, func() {
+		doc, err := Decode(bytes.NewReader(data))
+		if err != nil {
+			t.Fatal(err)
+		}
+		runtime.KeepAlive(doc)
+	})
+
+	streamAllocs, streamRetained := measureMemory(t, func() {
+		r := charset.NewReader(bytes.NewReader(data))
+		var iterErr error
+		for rec, perr := range parser.Records(r) {
+			if perr != nil {
+				iterErr = perr
+				break
+			}
+			_ = rec.Type
+		}
+		if iterErr != nil {
+			t.Fatal(iterErr)
+		}
+	})
+
+	t.Logf("Large fixture: %d bytes", len(data))
+	t.Logf("Batch decode:    cumulative=%d KB retained=%d KB", batchAllocs/1024, batchRetained/1024)
+	t.Logf("Streaming parse: cumulative=%d KB retained=%d KB", streamAllocs/1024, streamRetained/1024)
+	if batchRetained > 0 {
+		t.Logf("Streaming retains ~%.1f%% of batch retained heap", 100*float64(streamRetained)/float64(batchRetained))
+	}
+}
+
+// measureMemory runs fn and returns two values:
+//   - cumulative: bytes allocated during fn (TotalAlloc delta — monotonic,
+//     GC-immune; "total work done")
+//   - retained: heap-resident bytes after fn returns (HeapAlloc delta;
+//     "what's still in memory afterwards")
+//
+// Together they capture two distinct aspects of memory cost. Call sites
+// that want the post-call heap to include something specific must use
+// runtime.KeepAlive on it inside fn so the GC can't reclaim it before
+// the second ReadMemStats.
+//
+// This helper is intentionally duplicated in encoder/benchmark_test.go
+// (Go test helpers can't be shared across packages without an internal
+// package, and the duplication is small enough that adding one isn't
+// worth it). Keep the two copies in sync.
+func measureMemory(t *testing.T, fn func()) (cumulative, retained uint64) {
+	t.Helper()
+	runtime.GC()
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	fn()
+	runtime.ReadMemStats(&after)
+	cumulative = after.TotalAlloc - before.TotalAlloc
+	if after.HeapAlloc > before.HeapAlloc {
+		retained = after.HeapAlloc - before.HeapAlloc
+	}
+	return cumulative, retained
 }

--- a/docs/API_STABILITY.md
+++ b/docs/API_STABILITY.md
@@ -52,7 +52,7 @@ These packages/APIs are stable and follow semver strictly:
 | `decoder` | Stable | `Decode()`, `DecodeWithOptions()` |
 | `encoder` | Stable | `Encode()`, `EncodeWithOptions()`, `NewStreamEncoder()`, `NewStreamEncoderWithOptions()`, `EncodeStreaming()`, `EncodeStreamingWithOptions()` |
 | `converter` | Stable | `Convert()`, `ConvertWithOptions()` |
-| `parser` | Stable | `Parse()`, `ParseLine()`, `NewRecordIterator()`, `Records()`, `RecordsWithOffset()`, `NewLazyParser()` |
+| `parser` | Stable | `Parse()`, `ParseLine()`, `NewRecordIterator()`, `NewRecordIteratorWithOffset()`, `Records()`, `RecordsWithOffset()`, `NewLazyParser()` |
 | `validator` | Stable | `Validate()`, `ValidateAll()`, `NewStreamingValidator()` |
 | `charset` | Stable | `NewReader()` |
 | `version` | Stable | `Detect()`, version constants |

--- a/docs/API_STABILITY.md
+++ b/docs/API_STABILITY.md
@@ -50,10 +50,10 @@ These packages/APIs are stable and follow semver strictly:
 |---------|--------|-------|
 | `gedcom` | Stable | Core types: Document, Individual, Family, etc. |
 | `decoder` | Stable | `Decode()`, `DecodeWithOptions()` |
-| `encoder` | Stable | `Encode()`, `EncodeWithOptions()` |
+| `encoder` | Stable | `Encode()`, `EncodeWithOptions()`, `NewStreamEncoder()`, `NewStreamEncoderWithOptions()`, `EncodeStreaming()`, `EncodeStreamingWithOptions()` |
 | `converter` | Stable | `Convert()`, `ConvertWithOptions()` |
-| `parser` | Stable | `Parse()`, `ParseLine()` |
-| `validator` | Stable | `Validate()`, `ValidateAll()` |
+| `parser` | Stable | `Parse()`, `ParseLine()`, `NewRecordIterator()`, `Records()`, `RecordsWithOffset()`, `NewLazyParser()` |
+| `validator` | Stable | `Validate()`, `ValidateAll()`, `NewStreamingValidator()` |
 | `charset` | Stable | `NewReader()` |
 | `version` | Stable | `Detect()`, version constants |
 
@@ -61,7 +61,6 @@ These packages/APIs are stable and follow semver strictly:
 
 Features marked experimental may change in minor versions:
 
-- Streaming encoder/decoder APIs
 - Duplicate detection algorithms
 - Quality report format
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -92,17 +92,52 @@ Line ending format has negligible impact (<1% overhead for CRLF vs LF).
 
 ## Streaming APIs Performance
 
-The streaming APIs provide memory-efficient alternatives for very large files.
+The streaming APIs provide memory-efficient alternatives for very large files. Two memory metrics matter:
+
+- **Cumulative allocated bytes** (`TotalAlloc` delta): total bytes ever allocated during the operation. Both streaming and batch do similar parsing/encoding work, so cumulative allocations are roughly similar.
+- **Retained heap after return** (`HeapAlloc` delta with `KeepAlive`): bytes still resident when the call completes. **This is the streaming win.** Batch holds the full `Document` afterwards; streaming holds essentially nothing.
+
+The retained-heap metric is what matters when the operation runs inside a longer-lived process and you care about steady-state memory.
+
+### Decoder (Batch) vs Streaming Parse — `pres2020.ged` (1.1MB, 2,322 individuals)
+
+| Metric | `decoder.Decode` (batch) | `parser.Records` (streaming) | Ratio |
+|---|---|---|---|
+| Time/op | 14.2 ms | 7.9 ms | 0.56x |
+| Cumulative bytes/op | 22 MB | 12 MB | 0.55x |
+| Allocs/op | 261,258 | 170,263 | 0.65x |
+| **Retained heap after** | **9,545 KB** | **1,611 KB** | **0.17x** |
+
+Streaming parse retains ~17% of batch decode's heap after the call returns. Reproduce with:
+
+```bash
+go test -bench='DecodeLarge|StreamingParseLarge' -benchmem ./decoder/
+go test -v -run TestMemory ./decoder/
+```
 
 ### Streaming Encoder
 
-| Document Size | Batch Encoder | Stream Encoder | Memory Difference |
-|---------------|---------------|----------------|-------------------|
-| 1K individuals | 1.7 ms / 400 KB | 1.8 ms / ~1 KB | 400x less memory |
-| 10K individuals | 17 ms / 4 MB | 18 ms / ~1 KB | 4000x less memory |
-| 100K individuals | 170 ms / 40 MB | 180 ms / ~1 KB | 40000x less memory |
+The throughput benchmarks below construct records inside the loop for the streaming path (matching how real streaming consumers produce records on the fly) and use a pre-built `Document` for the batch path (because batch *requires* the full Document to exist before it can run):
 
-**Key Insight**: Stream encoder maintains O(1) memory regardless of record count.
+| Metric (1,000 individuals) | `encoder.Encode` (batch, pre-built doc) | `encoder.StreamEncoder` (records produced in loop) |
+|---|---|---|
+| Time/op | 1.27 ms | 1.77 ms |
+| Bytes/op | 400 KB | 1.67 MB |
+| Allocs/op | 25,009 | 41,505 |
+
+Streaming throughput appears worse because the streaming benchmark includes record-construction cost while the batch benchmark excludes it (the cost is paid up front, before `b.ResetTimer`). For a memory comparison where both paths do the same total work, see the retained-heap test:
+
+| Metric (10,000 individuals) | Batch | Streaming | Ratio |
+|---|---|---|---|
+| Cumulative bytes | 16 MB | 16 MB | 0.99x |
+| **Retained heap after** | **14,813 KB** | **2,492 KB** | **0.17x** |
+
+Streaming encode retains ~17% of batch encode's heap because batch keeps the entire `Document` (all 10K records) live throughout, while streaming generates and discards each record as it writes.
+
+```bash
+go test -bench='EncodeLarge|StreamEncodeLarge' -benchmem ./encoder/
+go test -v -run TestMemory ./encoder/
+```
 
 ### Streaming Validator
 
@@ -112,7 +147,7 @@ The streaming APIs provide memory-efficient alternatives for very large files.
 | 10K individuals | 66 µs / 0 B | 72 µs | O(unique XRefs) |
 | 100K individuals | 660 µs / 0 B | 720 µs | O(unique XRefs) |
 
-**Key Insight**: Stream validator memory scales with unique cross-references, not record count.
+Stream validator memory scales with unique cross-references (needed for orphan-reference detection at `Finalize()`), not total record count. Note that streaming validation currently covers Individual and Family records fully and collects cross-references from Source records; Repository, Note, Multimedia Object, and Submitter records are not validated in streaming mode — use batch `validator.Validate()` if you need coverage for those types.
 
 ### Incremental Parser
 

--- a/encoder/benchmark_test.go
+++ b/encoder/benchmark_test.go
@@ -127,12 +127,20 @@ func BenchmarkStreamEncodeLarge(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		enc := NewStreamEncoder(io.Discard)
-		_ = enc.WriteHeader(header)
-		for j := 0; j < n; j++ {
-			_ = enc.WriteRecord(newIndividual(j))
+		if err := enc.WriteHeader(header); err != nil {
+			b.Fatal(err)
 		}
-		_ = enc.WriteTrailer()
-		_ = enc.Close()
+		for j := 0; j < n; j++ {
+			if err := enc.WriteRecord(newIndividual(j)); err != nil {
+				b.Fatal(err)
+			}
+		}
+		if err := enc.WriteTrailer(); err != nil {
+			b.Fatal(err)
+		}
+		if err := enc.Close(); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 
@@ -155,19 +163,29 @@ func TestMemoryBatchVsStreamingEncode(t *testing.T) {
 
 	batchAllocs, batchRetained := measureMemory(t, func() {
 		doc := generateDocument(n)
-		_ = Encode(io.Discard, doc)
+		if err := Encode(io.Discard, doc); err != nil {
+			t.Fatal(err)
+		}
 		runtime.KeepAlive(doc)
 	})
 
 	streamAllocs, streamRetained := measureMemory(t, func() {
 		header := &gedcom.Header{Version: "5.5", Encoding: "UTF-8", SourceSystem: "benchmark"}
 		enc := NewStreamEncoder(io.Discard)
-		_ = enc.WriteHeader(header)
-		for i := 0; i < n; i++ {
-			_ = enc.WriteRecord(newIndividual(i))
+		if err := enc.WriteHeader(header); err != nil {
+			t.Fatal(err)
 		}
-		_ = enc.WriteTrailer()
-		_ = enc.Close()
+		for i := 0; i < n; i++ {
+			if err := enc.WriteRecord(newIndividual(i)); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := enc.WriteTrailer(); err != nil {
+			t.Fatal(err)
+		}
+		if err := enc.Close(); err != nil {
+			t.Fatal(err)
+		}
 	})
 
 	t.Logf("Individuals: %d", n)

--- a/encoder/benchmark_test.go
+++ b/encoder/benchmark_test.go
@@ -2,7 +2,9 @@ package encoder
 
 import (
 	"bytes"
+	"fmt"
 	"io"
+	"runtime"
 	"testing"
 
 	"github.com/cacack/gedcom-go/gedcom"
@@ -105,33 +107,141 @@ func BenchmarkEncodeLineEndings(b *testing.B) {
 	}
 }
 
+// BenchmarkStreamEncodeLarge benchmarks streaming encode of 1000 individuals
+// where records are generated *inside* the loop, mirroring how a real
+// streaming consumer produces records on the fly without materializing the
+// full document.
+//
+// The comparison with BenchmarkEncodeLarge is intentionally asymmetric:
+// batch encoding requires the full Document to exist before it can run, so
+// that allocation cost is part of the batch workload. Use
+// TestAllocDeltaBatchVsStreamingEncode for a more direct memory comparison.
+//
+//	go test -bench='EncodeLarge|StreamEncodeLarge' -benchmem ./encoder/
+func BenchmarkStreamEncodeLarge(b *testing.B) {
+	const n = 1000
+	header := &gedcom.Header{Version: "5.5", Encoding: "UTF-8", SourceSystem: "benchmark"}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		enc := NewStreamEncoder(io.Discard)
+		_ = enc.WriteHeader(header)
+		for j := 0; j < n; j++ {
+			_ = enc.WriteRecord(newIndividual(j))
+		}
+		_ = enc.WriteTrailer()
+		_ = enc.Close()
+	}
+}
+
+// TestMemoryBatchVsStreamingEncode reports two complementary memory metrics
+// for batch encode vs streaming encode of 10,000 generated individuals:
+//
+//  1. Cumulative allocated bytes (TotalAlloc delta) — total work done.
+//  2. Retained heap after return (HeapAlloc delta with KeepAlive) — what's
+//     still resident when the call completes.
+//
+// The streaming win is in (2): the batch path constructs a full Document
+// (held alive during Encode and after, via KeepAlive), while streaming
+// generates records on the fly and discards them. Cumulative work in (1)
+// is similar because both paths construct the same records — they just
+// retain them differently.
+//
+//	go test -v -run TestMemory ./encoder/
+func TestMemoryBatchVsStreamingEncode(t *testing.T) {
+	const n = 10000
+
+	batchAllocs, batchRetained := measureMemory(t, func() {
+		doc := generateDocument(n)
+		_ = Encode(io.Discard, doc)
+		runtime.KeepAlive(doc)
+	})
+
+	streamAllocs, streamRetained := measureMemory(t, func() {
+		header := &gedcom.Header{Version: "5.5", Encoding: "UTF-8", SourceSystem: "benchmark"}
+		enc := NewStreamEncoder(io.Discard)
+		_ = enc.WriteHeader(header)
+		for i := 0; i < n; i++ {
+			_ = enc.WriteRecord(newIndividual(i))
+		}
+		_ = enc.WriteTrailer()
+		_ = enc.Close()
+	})
+
+	t.Logf("Individuals: %d", n)
+	t.Logf("Batch encode:    cumulative=%d KB retained=%d KB", batchAllocs/1024, batchRetained/1024)
+	t.Logf("Streaming encode: cumulative=%d KB retained=%d KB", streamAllocs/1024, streamRetained/1024)
+	if batchRetained > 0 {
+		t.Logf("Streaming retains ~%.1f%% of batch retained heap", 100*float64(streamRetained)/float64(batchRetained))
+	}
+}
+
+// newIndividual produces a representative individual record at index i with
+// a unique XRef. The shape mirrors generateDocument so a per-record streaming
+// loop produces semantically equivalent output to the batch path.
+func newIndividual(i int) *gedcom.Record {
+	xref := fmt.Sprintf("@I%d@", i)
+	name := fmt.Sprintf("Person %d /Surname/", i)
+	return &gedcom.Record{
+		XRef: xref,
+		Type: gedcom.RecordTypeIndividual,
+		Tags: []*gedcom.Tag{
+			{Level: 1, Tag: "NAME", Value: name},
+			{Level: 1, Tag: "SEX", Value: "M"},
+			{Level: 1, Tag: "BIRT"},
+			{Level: 2, Tag: "DATE", Value: "1 JAN 1980"},
+			{Level: 2, Tag: "PLAC", Value: "New York, NY"},
+			{Level: 1, Tag: "DEAT"},
+			{Level: 2, Tag: "DATE", Value: "1 JAN 2050"},
+			{Level: 2, Tag: "PLAC", Value: "Boston, MA"},
+		},
+		Entity: &gedcom.Individual{
+			XRef: xref,
+			Names: []*gedcom.PersonalName{
+				{Full: name},
+			},
+			Sex: "M",
+		},
+	}
+}
+
+// measureMemory runs fn and returns two values:
+//   - cumulative: bytes allocated during fn (TotalAlloc delta — monotonic,
+//     GC-immune; "total work done")
+//   - retained: heap-resident bytes after fn returns (HeapAlloc delta;
+//     "what's still in memory afterwards")
+//
+// Together they capture two distinct aspects of memory cost. Call sites
+// that want the post-call heap to include something specific must use
+// runtime.KeepAlive on it inside fn so the GC can't reclaim it before
+// the second ReadMemStats.
+//
+// This helper is intentionally duplicated in decoder/benchmark_test.go
+// (Go test helpers can't be shared across packages without an internal
+// package, and the duplication is small enough that adding one isn't
+// worth it). Keep the two copies in sync.
+func measureMemory(t *testing.T, fn func()) (cumulative, retained uint64) {
+	t.Helper()
+	runtime.GC()
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	fn()
+	runtime.ReadMemStats(&after)
+	cumulative = after.TotalAlloc - before.TotalAlloc
+	if after.HeapAlloc > before.HeapAlloc {
+		retained = after.HeapAlloc - before.HeapAlloc
+	}
+	return cumulative, retained
+}
+
 // Helper function to generate a document with N individuals
 func generateDocument(numIndividuals int) *gedcom.Document {
 	records := make([]*gedcom.Record, 0, numIndividuals)
 
 	for i := 0; i < numIndividuals; i++ {
-		xref := "@I" + string(rune('0'+i%10)) + "@"
-		records = append(records, &gedcom.Record{
-			XRef: xref,
-			Type: gedcom.RecordTypeIndividual,
-			Tags: []*gedcom.Tag{
-				{Level: 1, Tag: "NAME", Value: "Person " + string(rune('0'+i%10)) + " /Surname/"},
-				{Level: 1, Tag: "SEX", Value: "M"},
-				{Level: 1, Tag: "BIRT"},
-				{Level: 2, Tag: "DATE", Value: "1 JAN 1980"},
-				{Level: 2, Tag: "PLAC", Value: "New York, NY"},
-				{Level: 1, Tag: "DEAT"},
-				{Level: 2, Tag: "DATE", Value: "1 JAN 2050"},
-				{Level: 2, Tag: "PLAC", Value: "Boston, MA"},
-			},
-			Entity: &gedcom.Individual{
-				XRef: xref,
-				Names: []*gedcom.PersonalName{
-					{Full: "Person " + string(rune('0'+i%10)) + " /Surname/"},
-				},
-				Sex: "M",
-			},
-		})
+		records = append(records, newIndividual(i))
 	}
 
 	return &gedcom.Document{

--- a/encoder/streaming.go
+++ b/encoder/streaming.go
@@ -40,24 +40,41 @@ func (s encodeState) String() string {
 // enabling generation of very large GEDCOM files without loading the entire
 // document into memory first.
 //
-// The encoder enforces valid GEDCOM structure through a state machine:
-//   - WriteHeader must be called first (and only once)
-//   - WriteRecord can be called zero or more times
-//   - WriteTrailer must be called to complete the document
-//   - Close should be called to flush any buffered data
+// The encoder enforces valid GEDCOM structure through a state machine.
+// The canonical call sequence is:
 //
-// Example usage:
+//	WriteHeader → WriteRecord (zero or more times) → WriteTrailer → Close
 //
-//	f, _ := os.Create("output.ged")
-//	defer f.Close()
+// Each step is required (except WriteRecord, which may be skipped). Close
+// flushes any buffered data and verifies that WriteTrailer was called; if
+// the trailer is missing, Close returns [ErrTrailerNotWritten] and the
+// output file will be structurally invalid.
 //
-//	enc := encoder.NewStreamEncoder(f)
-//	enc.WriteHeader(header)
-//	for _, record := range records {
-//	    enc.WriteRecord(record)
+// Flush is optional and only useful for intermediate checkpointing (e.g.,
+// forcing partial output visible to a downstream consumer). Close calls
+// Flush internally, so an explicit Flush before Close is redundant.
+//
+// IMPORTANT: capture Close's error. Using `defer enc.Close()` silently
+// discards [ErrTrailerNotWritten] and any flush failure — both of which
+// indicate the output file is incomplete or corrupt. Prefer:
+//
+//	func writeStreamed(w io.Writer, records []*gedcom.Record) (err error) {
+//	    enc := encoder.NewStreamEncoder(w)
+//	    defer func() {
+//	        if cerr := enc.Close(); cerr != nil && err == nil {
+//	            err = cerr
+//	        }
+//	    }()
+//	    if err := enc.WriteHeader(header); err != nil {
+//	        return err
+//	    }
+//	    for _, rec := range records {
+//	        if err := enc.WriteRecord(rec); err != nil {
+//	            return err
+//	        }
+//	    }
+//	    return enc.WriteTrailer()
 //	}
-//	enc.WriteTrailer()
-//	enc.Close()
 type StreamEncoder struct {
 	writer  *bufio.Writer
 	options *EncodeOptions
@@ -192,8 +209,10 @@ func (e *StreamEncoder) Flush() error {
 }
 
 // Close flushes any buffered data and marks the encoder as complete.
-// If the trailer has not been written, it returns ErrTrailerNotWritten
-// but still flushes any buffered data.
+// If the trailer has not been written, it returns [ErrTrailerNotWritten]
+// but still flushes any buffered data (yielding a structurally invalid
+// file). Always check Close's return value rather than using a bare
+// `defer enc.Close()`, which silently drops the error.
 //
 // After Close is called, no further writes are allowed.
 func (e *StreamEncoder) Close() error {

--- a/examples/README.md
+++ b/examples/README.md
@@ -154,7 +154,56 @@ Error Types: 4
 
 ---
 
-### 4. Encode - Creating GEDCOM Files
+### 4. Stream - Memory-Efficient Streaming Parse and Encode
+
+**Location**: [`stream/main.go`](stream/main.go)
+
+**What it does**: Demonstrates the streaming APIs for handling very large GEDCOM files with constant memory usage. Shows two streaming halves:
+
+- **Streaming parse** with `parser.Records` — iterate level-0 records from any `io.Reader` without building a full `Document`
+- **Streaming encode** with `encoder.NewStreamEncoder` — write records one at a time without holding the document in memory
+
+**How to run**:
+```bash
+# Streaming parse only (skips encode demo)
+cd examples/stream
+go run main.go ../../testdata/gedcom-5.5/pres2020.ged
+
+# Streaming parse + streaming encode to file
+go run main.go ../../testdata/gedcom-5.5/pres2020.ged /tmp/out.ged
+```
+
+**Example output**:
+```
+=== Streaming Parse ===
+Input: ../../testdata/gedcom-5.5/pres2020.ged
+Total lines processed: 49431
+Record counts by type:
+  HEAD: 1
+  INDI: 2322
+  FAM: 1115
+  SOUR: 91
+  NOTE: 141
+  OBJE: 171
+  REPO: 1
+  SUBM: 1
+  TRLR: 1
+[heap after streaming parse] HeapAlloc=3053KB Sys=12978KB
+
+=== Streaming Encode ===
+Wrote 1000 individuals to /tmp/out.ged using StreamEncoder.
+[heap after streaming encode] HeapAlloc=3382KB Sys=12978KB
+```
+
+**Use cases**:
+- Files larger than available RAM (10k+ individuals)
+- Extracting subsets without a full Document build
+- Generating GEDCOM exports from streaming data sources
+- Memory-constrained environments
+
+---
+
+### 5. Encode - Creating GEDCOM Files
 
 **Location**: [`encode/main.go`](encode/main.go)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -174,7 +174,7 @@ go run main.go ../../testdata/gedcom-5.5/pres2020.ged /tmp/out.ged
 ```
 
 **Example output**:
-```
+```text
 === Streaming Parse ===
 Input: ../../testdata/gedcom-5.5/pres2020.ged
 Total lines processed: 49431

--- a/examples/README.md
+++ b/examples/README.md
@@ -281,6 +281,9 @@ cd query && go run main.go ../../testdata/gedcom-5.5/royal92.ged && cd ..
 # Run validate example
 cd validate && go run main.go ../../testdata/gedcom-5.5/minimal.ged && cd ..
 
+# Run stream example (streaming parse + streaming encode)
+cd stream && go run main.go ../../testdata/gedcom-5.5/pres2020.ged /tmp/streamed.ged && cd ..
+
 # Run encode example
 cd encode && go run main.go /tmp/output.ged && cd ..
 ```

--- a/examples/stream/main.go
+++ b/examples/stream/main.go
@@ -1,0 +1,176 @@
+// Package main demonstrates streaming GEDCOM processing for memory-efficient
+// handling of very large files.
+//
+// Two streaming halves are shown:
+//
+//  1. Streaming parse via parser.Records — iterate level-0 records one at a
+//     time from any io.Reader. The current record is the only one held in
+//     memory; previous records are eligible for GC.
+//  2. Streaming encode via encoder.NewStreamEncoder — write a document
+//     record-by-record to any io.Writer. No full Document is constructed.
+//
+// Use streaming whenever the document is too large to materialize in memory,
+// or when you only need a subset of records and want to skip the cost of a
+// full Document build.
+//
+// Note: this example uses os.Args paths directly with filepath.Clean. For
+// production use that takes user-supplied paths (e.g., a web handler),
+// also validate the path is under an allowed root before opening or
+// creating files — filepath.Clean alone does not prevent path traversal.
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/cacack/gedcom-go/charset"
+	"github.com/cacack/gedcom-go/encoder"
+	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/parser"
+)
+
+const individualCount = 1000
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run main.go <gedcom_file> [output.ged]")
+		fmt.Println("Example: go run main.go ../../testdata/gedcom-5.5/pres2020.ged /tmp/out.ged")
+		os.Exit(1)
+	}
+
+	inputPath := filepath.Clean(os.Args[1])
+
+	// Part 1: Streaming parse — iterate records without building a Document.
+	fmt.Println("=== Streaming Parse ===")
+	counts, totalLines, err := streamingParse(inputPath)
+	if err != nil {
+		log.Fatalf("Streaming parse failed: %v", err)
+	}
+	fmt.Printf("Input: %s\n", inputPath)
+	fmt.Printf("Total lines processed: %d\n", totalLines)
+	fmt.Println("Record counts by type:")
+	for typ, n := range counts {
+		fmt.Printf("  %s: %d\n", typ, n)
+	}
+	reportHeap("after streaming parse")
+
+	// Part 2: Streaming encode — write a generated document record-by-record.
+	if len(os.Args) < 3 {
+		fmt.Println("\nNo output path provided — skipping streaming encode demo.")
+		fmt.Println("Pass a second argument to write a streamed output file:")
+		fmt.Println("  go run main.go", os.Args[1], "/tmp/out.ged")
+		return
+	}
+
+	outputPath := filepath.Clean(os.Args[2])
+	fmt.Println("\n=== Streaming Encode ===")
+	if err := streamingEncode(outputPath, individualCount); err != nil {
+		log.Fatalf("Streaming encode failed: %v", err)
+	}
+	fmt.Printf("Wrote %d individuals to %s using StreamEncoder.\n", individualCount, outputPath)
+	reportHeap("after streaming encode")
+}
+
+// streamingParse iterates records from a GEDCOM file without building a
+// Document. parser.Records yields one *parser.RawRecord at a time; previous
+// records fall out of scope and become eligible for GC immediately.
+func streamingParse(path string) (map[string]int, int, error) {
+	f, err := os.Open(filepath.Clean(path))
+	if err != nil {
+		return nil, 0, fmt.Errorf("open input: %w", err)
+	}
+	defer f.Close()
+
+	// Wrap with charset.NewReader so BOM and non-UTF-8 encodings are handled
+	// transparently before the parser sees the bytes.
+	r := charset.NewReader(f)
+
+	counts := make(map[string]int)
+	totalLines := 0
+
+	for rec, err := range parser.Records(r) {
+		if err != nil {
+			return nil, totalLines, fmt.Errorf("parse: %w", err)
+		}
+		counts[rec.Type]++
+		totalLines += len(rec.Lines)
+	}
+
+	return counts, totalLines, nil
+}
+
+// streamingEncode writes records one at a time with encoder.StreamEncoder.
+// No full Document is constructed; each record is emitted and becomes
+// eligible for GC.
+//
+// The named return value `err` is captured by the deferred Close calls so
+// any error from finalising the stream (or closing the file) is surfaced
+// to the caller — a plain `defer enc.Close()` would silently drop those
+// errors, including ErrTrailerNotWritten if an earlier write returned
+// early before WriteTrailer ran.
+func streamingEncode(path string, count int) (err error) {
+	f, err := os.Create(filepath.Clean(path))
+	if err != nil {
+		return fmt.Errorf("create output: %w", err)
+	}
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close output: %w", cerr)
+		}
+	}()
+
+	enc := encoder.NewStreamEncoder(f)
+	defer func() {
+		// Close flushes any buffered data and verifies the trailer was
+		// written. Surface its error if no earlier error already preempted.
+		if cerr := enc.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close encoder: %w", cerr)
+		}
+	}()
+
+	header := &gedcom.Header{
+		Version:      "5.5",
+		Encoding:     "UTF-8",
+		SourceSystem: "gedcom-go streaming example",
+		Language:     "English",
+	}
+	if err := enc.WriteHeader(header); err != nil {
+		return fmt.Errorf("write header: %w", err)
+	}
+
+	for i := 1; i <= count; i++ {
+		xref := fmt.Sprintf("@I%d@", i)
+		rec := &gedcom.Record{
+			XRef: xref,
+			Type: gedcom.RecordTypeIndividual,
+			Tags: []*gedcom.Tag{
+				{Level: 1, Tag: "NAME", Value: fmt.Sprintf("Person%d /Streamed/", i)},
+				{Level: 1, Tag: "SEX", Value: "U"},
+			},
+		}
+		if err := enc.WriteRecord(rec); err != nil {
+			return fmt.Errorf("write record %s: %w", xref, err)
+		}
+		// rec is no longer referenced; the GC can reclaim it on the next iteration.
+	}
+
+	if err := enc.WriteTrailer(); err != nil {
+		return fmt.Errorf("write trailer: %w", err)
+	}
+	// Deferred enc.Close() flushes — no explicit Flush needed.
+	return nil
+}
+
+// reportHeap prints current heap allocation as a rough indicator of memory
+// behavior. For rigorous measurement, use the TestMemory* tests in
+// decoder/ and encoder/ that report both cumulative allocations and
+// retained heap after the operation returns.
+func reportHeap(label string) {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	fmt.Printf("[heap %s] HeapAlloc=%dKB Sys=%dKB\n",
+		label, m.HeapAlloc/1024, m.Sys/1024)
+}

--- a/parser/index.go
+++ b/parser/index.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 )
 
 // IndexEntry represents a single record's location in a GEDCOM file.
@@ -99,21 +100,27 @@ func (idx *RecordIndex) LookupByType(recordType string) (IndexEntry, bool) {
 	return entry, ok
 }
 
-// XRefs returns all XRefs in the index.
+// XRefs returns all XRefs in the index, in sorted lexicographic order for
+// reproducibility. Each returned XRef is guaranteed resolvable via
+// [RecordIndex.Lookup] as long as the underlying file has not been modified
+// since the index was built (or loaded via [LazyParser.LoadIndex]).
 func (idx *RecordIndex) XRefs() []string {
 	xrefs := make([]string, 0, len(idx.entries))
 	for xref := range idx.entries {
 		xrefs = append(xrefs, xref)
 	}
+	sort.Strings(xrefs)
 	return xrefs
 }
 
-// Types returns all record types without XRefs in the index.
+// Types returns all record types without XRefs in the index, in sorted
+// lexicographic order.
 func (idx *RecordIndex) Types() []string {
 	types := make([]string, 0, len(idx.typeEntries))
 	for t := range idx.typeEntries {
 		types = append(types, t)
 	}
+	sort.Strings(types)
 	return types
 }
 

--- a/parser/iterator.go
+++ b/parser/iterator.go
@@ -2,9 +2,28 @@ package parser
 
 import (
 	"bufio"
+	"errors"
 	"io"
 	"iter"
 )
+
+// ErrLineTooLong is returned by [RecordIteratorWithOffset] / [RecordsWithOffset]
+// when a single line exceeds [MaxLineBytes]. The streaming [RecordIterator] /
+// [Records] surface the same condition via [bufio.ErrTooLong].
+var ErrLineTooLong = errors.New("gedcom-go/parser: line exceeds MaxLineBytes")
+
+// MaxLineBytes is the maximum length of a single GEDCOM line accepted by the
+// streaming iterators. The GEDCOM 5.5.1 spec recommends a 255-byte limit;
+// real-world files routinely exceed it (CONC/CONT chains, embedded BLOB
+// data), so we use a generous 1 MiB ceiling. A line longer than this aborts
+// the iterator with an error rather than allocating unboundedly — preventing
+// hostile or corrupt input from exhausting memory.
+const MaxLineBytes = 1 << 20 // 1 MiB
+
+// recordLinesInitialCap is a hint for the initial capacity of RawRecord.Lines.
+// Typical INDI records have 10-30 subordinate lines; this avoids 3-4 slice
+// reallocations per record without over-allocating for simple ones.
+const recordLinesInitialCap = 16
 
 // RawRecord represents a complete GEDCOM record with all its subordinate lines.
 // A record starts at level 0 and includes all following lines until the next level 0.
@@ -40,9 +59,16 @@ type RecordIterator struct {
 
 // NewRecordIterator creates a new RecordIterator that reads from the given reader.
 // The reader should already be wrapped with charset.NewReader() for encoding normalization.
+//
+// Lines longer than [MaxLineBytes] cause iteration to abort with an error
+// rather than allocating unboundedly. Spec-compliant GEDCOM lines never
+// approach this limit.
 func NewRecordIterator(r io.Reader) *RecordIterator {
 	scanner := bufio.NewScanner(r)
 	scanner.Split(scanGEDCOMLines)
+	// Explicit buffer with documented ceiling; default bufio.Scanner cap is
+	// 64 KiB which can be too small for files containing embedded BLOBs.
+	scanner.Buffer(make([]byte, 0, 4096), MaxLineBytes)
 
 	return &RecordIterator{
 		scanner:    scanner,
@@ -60,6 +86,7 @@ func (it *RecordIterator) Next() bool {
 
 	record := &RawRecord{
 		ByteOffset: it.byteOffset,
+		Lines:      make([]*Line, 0, recordLinesInitialCap),
 	}
 
 	// Use pending line from previous iteration if available
@@ -220,9 +247,12 @@ func trimLineEnding(b []byte) []byte {
 }
 
 // readGEDCOMLine reads bytes until a line terminator (CR, LF, or CRLF).
-// Returns the line including the terminator(s).
+// Returns the line including the terminator(s). Aborts with ErrLineTooLong
+// if the line exceeds [MaxLineBytes] before a terminator is reached.
 func readGEDCOMLine(r *bufio.Reader) ([]byte, error) {
-	var line []byte
+	// Pre-size to cover typical GEDCOM lines (255-byte spec recommendation)
+	// without intermediate reallocations.
+	line := make([]byte, 0, 256)
 
 	for {
 		b, err := r.ReadByte()
@@ -234,6 +264,9 @@ func readGEDCOMLine(r *bufio.Reader) ([]byte, error) {
 		}
 
 		line = append(line, b)
+		if len(line) > MaxLineBytes {
+			return nil, ErrLineTooLong
+		}
 
 		if b == '\n' {
 			return line, nil
@@ -256,7 +289,9 @@ func (it *RecordIteratorWithOffset) Next() bool {
 		return false
 	}
 
-	record := &RawRecord{}
+	record := &RawRecord{
+		Lines: make([]*Line, 0, recordLinesInitialCap),
+	}
 
 	// Use pending line from previous iteration
 	if it.pending != nil {
@@ -328,22 +363,24 @@ func (it *RecordIteratorWithOffset) Err() error {
 
 // Records returns an iterator over GEDCOM records using Go 1.23 range-over-func.
 // It yields (*RawRecord, nil) for each successfully parsed record.
-// On parse error, it yields (nil, error) and stops iteration.
+// On parse error, it yields (nil, error) — exactly once — and stops iteration.
 //
-// This function provides a modern, idiomatic alternative to [RecordIterator]
-// for streaming GEDCOM record processing. The reader should already be wrapped
-// with charset.NewReader() for encoding normalization.
-//
-// Usage:
+// IMPORTANT: when err is non-nil, record is nil. Always check err before
+// dereferencing record:
 //
 //	for record, err := range parser.Records(reader) {
 //	    if err != nil {
-//	        return err
+//	        return err  // record is nil here
 //	    }
-//	    // process record
+//	    // safe to use record
 //	}
 //
-// Early termination is supported - breaking from the loop will stop iteration:
+// This function provides a modern, idiomatic alternative to [RecordIterator]
+// for streaming GEDCOM record processing. The reader should already be wrapped
+// with charset.NewReader() for encoding normalization. Lines longer than
+// [MaxLineBytes] cause iteration to abort with [bufio.ErrTooLong].
+//
+// Early termination is supported — breaking from the loop will stop iteration:
 //
 //	for record, err := range parser.Records(reader) {
 //	    if err != nil {
@@ -369,11 +406,13 @@ func Records(r io.Reader) iter.Seq2[*RawRecord, error] {
 
 // RecordsWithOffset returns an iterator over GEDCOM records with accurate byte offset tracking.
 // It yields (*RawRecord, nil) for each successfully parsed record.
-// On parse error, it yields (nil, error) and stops iteration.
+// On parse error, it yields (nil, error) — exactly once — and stops iteration.
+// When err is non-nil, record is nil; always check err before dereferencing record.
 //
 // This is the range-over-func equivalent of [RecordIteratorWithOffset], providing
 // precise ByteOffset and ByteLength values suitable for building file indexes.
 // The reader should already be wrapped with charset.NewReader() for encoding normalization.
+// Lines longer than [MaxLineBytes] cause iteration to abort with [ErrLineTooLong].
 //
 // Usage:
 //

--- a/parser/lazy.go
+++ b/parser/lazy.go
@@ -245,7 +245,10 @@ func (p *LazyParser) AllRecords() iter.Seq2[*RawRecord, error] {
 	return p.RecordsFrom(0)
 }
 
-// XRefs returns all XRefs in the index.
+// XRefs returns all XRefs in the index, in sorted lexicographic order for
+// reproducibility. Each returned XRef is guaranteed resolvable via
+// [LazyParser.FindRecord] as long as the underlying file has not been
+// modified since the index was built (or loaded via [LazyParser.LoadIndex]).
 // Returns nil if no index is available.
 func (p *LazyParser) XRefs() []string {
 	if p.index == nil {

--- a/validator/streaming.go
+++ b/validator/streaming.go
@@ -94,6 +94,23 @@ func NewStreamingValidator(opts StreamingOptions) *StreamingValidator {
 //   - Validates record structure and entity-specific rules
 //   - Collects XRef references for deferred validation
 //   - Returns immediate issues (malformed dates, invalid structure, etc.)
+//
+// Per-record-type coverage:
+//
+//   - RecordTypeIndividual: full validation (date logic, structure)
+//   - RecordTypeFamily: full validation (date logic, structure)
+//   - RecordTypeSource: reference collection only (for orphan detection in
+//     Finalize); no source-content validation
+//   - RecordTypeRepository, RecordTypeNote, RecordTypeSubmitter,
+//     RecordTypeObject, others: not validated (the record is still
+//     registered for XRef tracking, but no rules are evaluated)
+//
+// Callers who need full validation coverage for all record types should use
+// the batch [Validator.Validate] / [Validator.ValidateAll] instead — they
+// trade memory for completeness.
+//
+// Parent-child date logic checks (child born before parent) require a
+// complete document and are not supported in streaming mode.
 func (sv *StreamingValidator) ValidateRecord(record *gedcom.Record) []Issue {
 	if record == nil {
 		return nil


### PR DESCRIPTION
## Summary

Stabilizes the streaming APIs (encoder, validator, parser iterator/lazy) and adds the supporting work to make that contract defensible long-term. Closes #220.

- **API stability**: streaming entries promoted from Experimental to Stable in `docs/API_STABILITY.md`; README stability table refreshed
- **New example**: `examples/stream/main.go` demonstrates streaming parse + streaming encode end-to-end on the 1.1MB `pres2020.ged` fixture
- **Honest performance numbers**: `docs/PERFORMANCE.md` now distinguishes cumulative allocations from retained heap. The streaming win is in retained heap (~17% of batch), not throughput
- **Parser hardening** driven by the stable contract: explicit `MaxLineBytes` ceiling, `ErrLineTooLong` sentinel, pre-sized buffers, sorted `XRefs()` output
- **Footgun documentation**: encoder godoc spells out the canonical `WriteHeader → WriteRecord* → WriteTrailer → Close` sequence and warns against `defer enc.Close()` (which silently drops `ErrTrailerNotWritten`)
- **Streaming validator coverage** documented: Individual/Family validated, Source reference-collected, Repository/Note/Submitter/Object not validated (use batch validator for those)
- Pre-existing `newIndividual` / `generateDocument` cyclic-XRef bug in benchmark helpers fixed — they now produce valid GEDCOM

## Measured Results

| Metric (pres2020.ged, 2,322 individuals) | Batch decode | Streaming parse | Ratio |
|---|---|---|---|
| Cumulative allocated | 22 MB | 12 MB | 0.55x |
| Retained heap after | 9.5 MB | 1.6 MB | **0.17x** |

| Metric (10,000 individuals) | Batch encode | Streaming encode | Ratio |
|---|---|---|---|
| Cumulative allocated | 16 MB | 16 MB | 0.99x |
| Retained heap after | 14.8 MB | 2.5 MB | **0.17x** |

## Test plan

- [x] `make preflight` clean (lint, vet, race tests, 96.2% coverage, security)
- [x] `go test -v -run TestMemory ./decoder/ ./encoder/` reports the figures above
- [x] `go run ./examples/stream ./testdata/gedcom-5.5/pres2020.ged /tmp/out.ged` succeeds
- [x] `make api-check` shows no new breaking changes (the pre-existing `validator.ValidatorConfig` change against v1.2.0 is unrelated — present on `main`)
- [ ] Downstream consumer (`my-family`) still builds with this branch via `replace` directive

## Pre-existing concern surfaced

`make api-check` flags `validator.ValidatorConfig: old is comparable, new is not` against v1.2.0. This is present on `main` without these changes — likely a prior unflagged breaking change that needs `feat!:` annotation on the next release. Not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming APIs promoted to stable.
  * Bounded line-length handling (1 MiB) to avoid oversized-line parsing issues.
  * New memory-efficient streaming example for parse+encode workflows.

* **Documentation**
  * README, examples, API stability, and performance docs updated with streaming usage, examples, and metrics.
  * Clarified streaming encoder close/error guidance and validator streaming coverage.

* **Bug Fixes**
  * Deterministic ordering for record-index lookups.

* **Tests**
  * Added streaming performance and memory-comparison benchmarks/tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cacack/gedcom-go/pull/283?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->