### PR TITLE
Fix v2 module path so pkg.go.dev resolves the v2 release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,8 +66,8 @@ body:
     id: version
     attributes:
       label: gedcom-go Version
-      description: Output of `go list -m github.com/cacack/gedcom-go`
-      placeholder: v1.0.0
+      description: Output of `go list -m github.com/cacack/gedcom-go/v2`
+      placeholder: v2.0.1
     validations:
       required: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       uses: vladopajic/go-test-coverage@a93b868a4cbcbf18dc3781650fad241f0020e609 # v2
       with:
         profile: coverage.out
-        local-prefix: github.com/cacack/gedcom-go
+        local-prefix: github.com/cacack/gedcom-go/v2
         threshold-file: 0
         threshold-package: 85
         threshold-total: 85
@@ -97,7 +97,7 @@ jobs:
         echo "| Package | Coverage | Status |"
         echo "|---------|----------|--------|"
         for pkg in charset decoder encoder gedcom merge parser validator version; do
-          COV=$(go tool cover -func=coverage.out | grep "github.com/cacack/gedcom-go/$pkg" | tail -1 | awk '{print $3}')
+          COV=$(go tool cover -func=coverage.out | grep "github.com/cacack/gedcom-go/v2/$pkg" | tail -1 | awk '{print $3}')
           PCT=$(echo "$COV" | sed 's/%//')
           if (( $(echo "$PCT >= 85.0" | bc -l) )); then
             echo "| $pkg | $COV | ✅ |"
@@ -161,6 +161,11 @@ jobs:
 
     - name: Run go vet
       run: go vet ./...
+
+    - name: Check module path matches latest tag major
+      run: |
+        git fetch --tags --depth=1 origin
+        ./scripts/check-module-path.sh
 
   # Dependency review - blocks PRs introducing vulnerable dependencies
   dependency-review:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,6 +382,18 @@ jobs:
           git clone --depth 1 --branch "$LATEST_TAG" "https://github.com/${{ github.repository }}.git" "$OLD_DIR" --quiet
           trap "rm -rf '$OLD_DIR'" EXIT
 
+          # Skip apidiff when the module path itself changed (e.g., v1 -> v2 path bump).
+          # Different module paths are different modules per Go's Semantic Import Versioning,
+          # so apidiff would report every type as "changed" — not a meaningful comparison.
+          OLD_MODULE=$(awk '/^module / {print $2}' "$OLD_DIR/go.mod")
+          NEW_MODULE=$(awk '/^module / {print $2}' go.mod)
+          if [ "$OLD_MODULE" != "$NEW_MODULE" ]; then
+            echo "✅ Module path changed ($OLD_MODULE -> $NEW_MODULE); skipping apidiff."
+            echo "   The v$LATEST_TAG module and the current module are distinct under"
+            echo "   Go's Semantic Import Versioning rules and can coexist."
+            exit 0
+          fi
+
           # Export old API to file, then compare against current
           # This is more reliable than comparing directories directly
           API_FILE=$(mktemp)

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -44,12 +44,15 @@ jobs:
         with:
           egress-policy: audit
 
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
       - name: Trigger pkg.go.dev indexing
         env:
           VERSION: ${{ needs.release-please.outputs.tag_name }}
         run: |
-          echo "Triggering pkg.go.dev for version $VERSION..."
-          curl -f "https://proxy.golang.org/github.com/cacack/gedcom-go/@v/$VERSION.info" || true
-          curl -f "https://sum.golang.org/lookup/github.com/cacack/gedcom-go@$VERSION" || true
+          MODULE=$(awk '/^module / {print $2}' go.mod)
+          echo "Triggering pkg.go.dev for $MODULE@$VERSION..."
+          curl -f "https://proxy.golang.org/$MODULE/@v/$VERSION.info" || true
+          curl -f "https://sum.golang.org/lookup/$MODULE@$VERSION" || true
           echo "Indexing request sent to pkg.go.dev"
-          echo "Documentation will be available at: https://pkg.go.dev/github.com/cacack/gedcom-go@$VERSION"
+          echo "Documentation will be available at: https://pkg.go.dev/$MODULE@$VERSION"

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -9,7 +9,7 @@ For planned features, see [GitHub Issues](https://github.com/cacack/gedcom-go/is
 Single-import facade for common GEDCOM operations:
 
 ```go
-import gedcomgo "github.com/cacack/gedcom-go"
+import gedcomgo "github.com/cacack/gedcom-go/v2"
 
 doc, err := gedcomgo.Decode(file)           // Parse GEDCOM
 err = gedcomgo.Encode(writer, doc)          // Write GEDCOM
@@ -1481,7 +1481,7 @@ for _, record := range doc.Records {
 The `gedcom/testing` package provides helpers to verify encode/decode cycles preserve data:
 
 ```go
-import gedcomtesting "github.com/cacack/gedcom-go/gedcom/testing"
+import gedcomtesting "github.com/cacack/gedcom-go/v2/gedcom/testing"
 
 func TestMyGEDCOM(t *testing.T) {
     data, _ := os.ReadFile("family.ged")

--- a/Makefile
+++ b/Makefile
@@ -303,7 +303,7 @@ preflight: ## Run all CI checks locally before pushing
 	@echo "  Running preflight checks (mirrors CI)"
 	@echo "═══════════════════════════════════════════════"
 	@echo ""
-	@echo "→ [1/8] Tidying go.mod..."
+	@echo "→ [1/9] Tidying go.mod..."
 	@$(GOMOD) tidy
 	@if [ -n "$$(git status --porcelain go.mod go.sum)" ]; then \
 		echo "✗ go.mod/go.sum changed after tidy"; \
@@ -311,7 +311,10 @@ preflight: ## Run all CI checks locally before pushing
 	fi
 	@echo "✓ go.mod is tidy"
 	@echo ""
-	@echo "→ [2/8] Checking formatting..."
+	@echo "→ [2/9] Checking module path matches latest tag major..."
+	@./scripts/check-module-path.sh
+	@echo ""
+	@echo "→ [3/9] Checking formatting..."
 	@UNFORMATTED=$$(gofmt -l .); \
 	if [ -n "$$UNFORMATTED" ]; then \
 		echo "✗ Files not formatted:"; \
@@ -320,22 +323,22 @@ preflight: ## Run all CI checks locally before pushing
 	fi
 	@echo "✓ Code is formatted"
 	@echo ""
-	@echo "→ [3/8] Running go vet..."
+	@echo "→ [4/9] Running go vet..."
 	@$(GOVET) ./...
 	@echo "✓ No vet issues"
 	@echo ""
-	@echo "→ [4/8] Running golangci-lint..."
+	@echo "→ [5/9] Running golangci-lint..."
 	@GOLANGCI_LINT=$$(command -v golangci-lint || echo "$$HOME/go/bin/golangci-lint"); \
 	if [ ! -x "$$GOLANGCI_LINT" ]; then GOLANGCI_LINT="$$(go env GOPATH)/bin/golangci-lint"; fi; \
 	if [ ! -x "$$GOLANGCI_LINT" ]; then echo "golangci-lint not found. Run 'make install-tools'" && exit 1; fi; \
 	$$GOLANGCI_LINT run --timeout=5m
 	@echo "✓ Lint passed"
 	@echo ""
-	@echo "→ [5/8] Running tests with race detector..."
+	@echo "→ [6/9] Running tests with race detector..."
 	@$(GOTEST) -race ./charset ./decoder ./encoder ./gedcom ./parser ./validator ./version
 	@echo "✓ Tests passed"
 	@echo ""
-	@echo "→ [6/8] Checking coverage thresholds..."
+	@echo "→ [7/9] Checking coverage thresholds..."
 	@$(GOTEST) -coverprofile=$(COVERAGE_FILE) -covermode=atomic ./charset ./decoder ./encoder ./gedcom ./parser ./validator ./version > /dev/null
 	@GO_TEST_COVERAGE=$$(command -v go-test-coverage || echo "$$HOME/go/bin/go-test-coverage"); \
 	if [ ! -x "$$GO_TEST_COVERAGE" ]; then GO_TEST_COVERAGE="$$(go env GOPATH)/bin/go-test-coverage"; fi; \
@@ -343,14 +346,14 @@ preflight: ## Run all CI checks locally before pushing
 	$$GO_TEST_COVERAGE --config=.testcoverage.yml --profile=$(COVERAGE_FILE)
 	@echo "✓ Coverage thresholds met"
 	@echo ""
-	@echo "→ [7/8] Building examples..."
+	@echo "→ [8/9] Building examples..."
 	@$(GOBUILD) -o /dev/null ./examples/parse
 	@$(GOBUILD) -o /dev/null ./examples/encode
 	@$(GOBUILD) -o /dev/null ./examples/query
 	@$(GOBUILD) -o /dev/null ./examples/validate
 	@echo "✓ Examples build"
 	@echo ""
-	@echo "→ [8/8] Running security scans..."
+	@echo "→ [9/9] Running security scans..."
 	@GOSEC=$$(command -v gosec || echo "$$HOME/go/bin/gosec"); \
 	if [ ! -x "$$GOSEC" ]; then GOSEC="$$(go env GOPATH)/bin/gosec"; fi; \
 	if [ ! -x "$$GOSEC" ]; then echo "gosec not found. Run 'make install-tools'" && exit 1; fi; \

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Full compatibility matrix: [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md)
 ## Installation
 
 ```bash
-go get github.com/cacack/gedcom-go
+go get github.com/cacack/gedcom-go/v2
 ```
 
 ## Requirements
@@ -58,7 +58,7 @@ This library tracks Go's [release policy](https://go.dev/doc/devel/release#polic
 The library provides a simple, single-import API for common operations. Import with an alias for cleaner code:
 
 ```go
-import gedcomgo "github.com/cacack/gedcom-go"
+import gedcomgo "github.com/cacack/gedcom-go/v2"
 ```
 
 ### Parse a GEDCOM File
@@ -71,7 +71,7 @@ import (
     "log"
     "os"
 
-    gedcomgo "github.com/cacack/gedcom-go"
+    gedcomgo "github.com/cacack/gedcom-go/v2"
 )
 
 func main() {
@@ -122,10 +122,10 @@ For files too large to materialize in memory (10k+ individuals, exports from maj
 import (
     "os"
 
-    "github.com/cacack/gedcom-go/charset"
-    "github.com/cacack/gedcom-go/encoder"
-    "github.com/cacack/gedcom-go/gedcom"
-    "github.com/cacack/gedcom-go/parser"
+    "github.com/cacack/gedcom-go/v2/charset"
+    "github.com/cacack/gedcom-go/v2/encoder"
+    "github.com/cacack/gedcom-go/v2/gedcom"
+    "github.com/cacack/gedcom-go/v2/parser"
 )
 
 // Streaming parse — iterate level-0 records without building a Document.
@@ -255,7 +255,7 @@ To opt into strict parsing (fail on the first syntax error, no diagnostics colle
   - [`examples/query`](examples/query) - Navigating and querying genealogy data
   - [`examples/validate`](examples/validate) - Validating GEDCOM files
   - [`examples/stream`](examples/stream) - Streaming parse and encode for very large files
-- **API Documentation**: [pkg.go.dev/github.com/cacack/gedcom-go](https://pkg.go.dev/github.com/cacack/gedcom-go)
+- **API Documentation**: [pkg.go.dev/github.com/cacack/gedcom-go/v2](https://pkg.go.dev/github.com/cacack/gedcom-go/v2)
 - **Contributing**: [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## Advanced Usage
@@ -273,10 +273,10 @@ Option types — `DecodeOptions`, `EncodeOptions`, `ValidateOptions` — are re-
 
 ```go
 import (
-    "github.com/cacack/gedcom-go/decoder"
-    "github.com/cacack/gedcom-go/encoder"
-    "github.com/cacack/gedcom-go/validator"
-    "github.com/cacack/gedcom-go/converter"
+    "github.com/cacack/gedcom-go/v2/decoder"
+    "github.com/cacack/gedcom-go/v2/encoder"
+    "github.com/cacack/gedcom-go/v2/validator"
+    "github.com/cacack/gedcom-go/v2/converter"
 )
 ```
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -80,7 +80,7 @@ The main record types you'll encounter:
 Install the library using `go get`:
 
 ```bash
-go get github.com/cacack/gedcom-go
+go get github.com/cacack/gedcom-go/v2
 ```
 
 Requirements:
@@ -99,7 +99,7 @@ import (
     "log"
     "os"
 
-    "github.com/cacack/gedcom-go/decoder"
+    "github.com/cacack/gedcom-go/v2/decoder"
 )
 
 func main() {
@@ -130,7 +130,7 @@ func main() {
 The `decoder` package provides the high-level API for parsing GEDCOM files:
 
 ```go
-import "github.com/cacack/gedcom-go/decoder"
+import "github.com/cacack/gedcom-go/v2/decoder"
 
 // Simple decoding
 f, _ := os.Open("family.ged")
@@ -150,7 +150,7 @@ For more control, use `DecodeWithOptions`:
 import (
     "context"
     "time"
-    "github.com/cacack/gedcom-go/decoder"
+    "github.com/cacack/gedcom-go/v2/decoder"
 )
 
 opts := &decoder.DecodeOptions{
@@ -559,7 +559,7 @@ if person != nil {
 ### Basic Validation
 
 ```go
-import "github.com/cacack/gedcom-go/validator"
+import "github.com/cacack/gedcom-go/v2/validator"
 
 // Create validator
 v := validator.New()
@@ -623,8 +623,8 @@ for code, errs := range errorsByCode {
 
 ```go
 import (
-    "github.com/cacack/gedcom-go/encoder"
-    "github.com/cacack/gedcom-go/gedcom"
+    "github.com/cacack/gedcom-go/v2/encoder"
+    "github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // Create document
@@ -752,7 +752,7 @@ fmt.Println(doc.Header.Encoding)  // Original encoding
 ANSEL is a legacy character encoding used in older GEDCOM files:
 
 ```go
-import "github.com/cacack/gedcom-go/charset"
+import "github.com/cacack/gedcom-go/v2/charset"
 
 // The charset package handles ANSEL decoding automatically
 // when used through the decoder
@@ -766,7 +766,7 @@ fmt.Println(string(utf8Text))  // "À"
 ### Validating UTF-8
 
 ```go
-import "github.com/cacack/gedcom-go/charset"
+import "github.com/cacack/gedcom-go/v2/charset"
 
 text := "Hello, world!"
 if !charset.IsValidUTF8([]byte(text)) {
@@ -798,7 +798,7 @@ if err != nil {
 For more detailed error information, use the parser directly:
 
 ```go
-import "github.com/cacack/gedcom-go/parser"
+import "github.com/cacack/gedcom-go/v2/parser"
 
 p := parser.New(f)
 for {
@@ -861,7 +861,7 @@ case <-time.After(10 * time.Second):
 For very large GEDCOM files, use the lower-level parser to avoid loading everything into memory:
 
 ```go
-import "github.com/cacack/gedcom-go/parser"
+import "github.com/cacack/gedcom-go/v2/parser"
 
 f, _ := os.Open("large.ged")
 defer f.Close()
@@ -1150,6 +1150,6 @@ family := doc.GetFamily("@F1@")
 ## See Also
 
 - [Examples](examples/) - Working code examples
-- [API Documentation](https://pkg.go.dev/github.com/cacack/gedcom-go) - Complete package documentation
+- [API Documentation](https://pkg.go.dev/github.com/cacack/gedcom-go/v2) - Complete package documentation
 - [CONTRIBUTING.md](CONTRIBUTING.md) - How to contribute to the project
 - [README.md](README.md) - Project overview

--- a/charset/example_test.go
+++ b/charset/example_test.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/cacack/gedcom-go/charset"
+	"github.com/cacack/gedcom-go/v2/charset"
 )
 
 // Example demonstrates basic usage of the charset package with UTF-8 data.

--- a/converter/converter.go
+++ b/converter/converter.go
@@ -3,7 +3,7 @@ package converter
 import (
 	"fmt"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // Convert converts a GEDCOM document to the target version using default options.

--- a/converter/converter_test.go
+++ b/converter/converter_test.go
@@ -3,7 +3,7 @@ package converter
 import (
 	"testing"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 func TestConvert(t *testing.T) {

--- a/converter/example_test.go
+++ b/converter/example_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cacack/gedcom-go/converter"
-	"github.com/cacack/gedcom-go/decoder"
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/converter"
+	"github.com/cacack/gedcom-go/v2/decoder"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // Example demonstrates basic GEDCOM version conversion.

--- a/converter/header.go
+++ b/converter/header.go
@@ -1,6 +1,6 @@
 package converter
 
-import "github.com/cacack/gedcom-go/gedcom"
+import "github.com/cacack/gedcom-go/v2/gedcom"
 
 // transformHeader updates the header for the target version.
 func transformHeader(doc *gedcom.Document, targetVersion gedcom.Version, report *gedcom.ConversionReport) {

--- a/converter/header_test.go
+++ b/converter/header_test.go
@@ -3,7 +3,7 @@ package converter
 import (
 	"testing"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 func TestTransformHeader(t *testing.T) {

--- a/converter/media.go
+++ b/converter/media.go
@@ -3,7 +3,7 @@ package converter
 import (
 	"strings"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // legacyToIANA maps legacy GEDCOM 5.5/5.5.1 media types to IANA media types.

--- a/converter/media_test.go
+++ b/converter/media_test.go
@@ -3,7 +3,7 @@ package converter
 import (
 	"testing"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 func TestTransformMediaTypes(t *testing.T) {

--- a/converter/text.go
+++ b/converter/text.go
@@ -3,7 +3,7 @@ package converter
 import (
 	"strings"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // transformTextForVersion handles CONC/CONT transformation based on target version.

--- a/converter/text_test.go
+++ b/converter/text_test.go
@@ -3,7 +3,7 @@ package converter
 import (
 	"testing"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 func TestTransformTextForVersion(t *testing.T) {

--- a/converter/validate.go
+++ b/converter/validate.go
@@ -1,8 +1,8 @@
 package converter
 
 import (
-	"github.com/cacack/gedcom-go/gedcom"
-	"github.com/cacack/gedcom-go/validator"
+	"github.com/cacack/gedcom-go/v2/gedcom"
+	"github.com/cacack/gedcom-go/v2/validator"
 )
 
 // validateConverted runs validation on the converted document.

--- a/converter/validate_test.go
+++ b/converter/validate_test.go
@@ -3,7 +3,7 @@ package converter
 import (
 	"testing"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 func TestValidateConverted(t *testing.T) {

--- a/converter/xref.go
+++ b/converter/xref.go
@@ -3,7 +3,7 @@ package converter
 import (
 	"strings"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // normalizeXRefsToUppercase converts all XRefs to uppercase for GEDCOM 7.0.

--- a/converter/xref_test.go
+++ b/converter/xref_test.go
@@ -3,7 +3,7 @@ package converter
 import (
 	"testing"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 func TestNormalizeXRefsToUppercase(t *testing.T) {

--- a/decoder/benchmark_test.go
+++ b/decoder/benchmark_test.go
@@ -7,8 +7,8 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/cacack/gedcom-go/charset"
-	"github.com/cacack/gedcom-go/parser"
+	"github.com/cacack/gedcom-go/v2/charset"
+	"github.com/cacack/gedcom-go/v2/parser"
 )
 
 // BenchmarkDecodeMinimal benchmarks parsing a minimal GEDCOM file (~170 bytes)

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -5,10 +5,10 @@ import (
 	"io"
 	"strings"
 
-	"github.com/cacack/gedcom-go/charset"
-	"github.com/cacack/gedcom-go/gedcom"
-	"github.com/cacack/gedcom-go/parser"
-	"github.com/cacack/gedcom-go/version"
+	"github.com/cacack/gedcom-go/v2/charset"
+	"github.com/cacack/gedcom-go/v2/gedcom"
+	"github.com/cacack/gedcom-go/v2/parser"
+	"github.com/cacack/gedcom-go/v2/version"
 )
 
 // DecodeResult contains the result of decoding a GEDCOM file with diagnostics.

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // T031: Write integration tests for full document parsing

--- a/decoder/diagnostics_decoder_test.go
+++ b/decoder/diagnostics_decoder_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cacack/gedcom-go/parser"
+	"github.com/cacack/gedcom-go/v2/parser"
 )
 
 // TestDecodeWithDiagnosticsBasic tests basic usage of DecodeWithDiagnostics

--- a/decoder/entity.go
+++ b/decoder/entity.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // diagnosticCollector accumulates diagnostics during entity population.

--- a/decoder/example_test.go
+++ b/decoder/example_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cacack/gedcom-go/decoder"
+	"github.com/cacack/gedcom-go/v2/decoder"
 )
 
 // Example demonstrates basic GEDCOM file decoding.

--- a/decoder/integration_test.go
+++ b/decoder/integration_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // T058: Parse all sample files in testdata/ and verify success

--- a/decoder/lenient_integration_test.go
+++ b/decoder/lenient_integration_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // ============================================================================

--- a/decoder/levelfix.go
+++ b/decoder/levelfix.go
@@ -3,7 +3,7 @@ package decoder
 import (
 	"fmt"
 
-	"github.com/cacack/gedcom-go/parser"
+	"github.com/cacack/gedcom-go/v2/parser"
 )
 
 // normalizeLevelJumps detects malformed indentation in real-world GEDCOM exports

--- a/decoder/levelfix_test.go
+++ b/decoder/levelfix_test.go
@@ -3,7 +3,7 @@ package decoder
 import (
 	"testing"
 
-	"github.com/cacack/gedcom-go/parser"
+	"github.com/cacack/gedcom-go/v2/parser"
 )
 
 func TestNormalizeLevelJumps_NoJumps(t *testing.T) {

--- a/docs/CONVERTER.md
+++ b/docs/CONVERTER.md
@@ -14,9 +14,9 @@ The GEDCOM specification has evolved through multiple versions, each with differ
 
 ```go
 import (
-    "github.com/cacack/gedcom-go/converter"
-    "github.com/cacack/gedcom-go/decoder"
-    "github.com/cacack/gedcom-go/gedcom"
+    "github.com/cacack/gedcom-go/v2/converter"
+    "github.com/cacack/gedcom-go/v2/decoder"
+    "github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // Load a GEDCOM 5.5 file

--- a/encoder/benchmark_test.go
+++ b/encoder/benchmark_test.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // BenchmarkEncodeMinimal benchmarks encoding a minimal GEDCOM document

--- a/encoder/encoder.go
+++ b/encoder/encoder.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // Encode writes a GEDCOM document to a writer.

--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cacack/gedcom-go/decoder"
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/decoder"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 func TestEncodeRoundtrip(t *testing.T) {

--- a/encoder/entity_writer.go
+++ b/encoder/entity_writer.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // textToTags converts a potentially multiline string value to GEDCOM tags.

--- a/encoder/entity_writer_test.go
+++ b/encoder/entity_writer_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cacack/gedcom-go/decoder"
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/decoder"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 func TestEntityToTags_NilEntity(t *testing.T) {

--- a/encoder/example_test.go
+++ b/encoder/example_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cacack/gedcom-go/encoder"
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/encoder"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // Example demonstrates basic GEDCOM document encoding.

--- a/encoder/options.go
+++ b/encoder/options.go
@@ -1,6 +1,6 @@
 package encoder
 
-import "github.com/cacack/gedcom-go/gedcom"
+import "github.com/cacack/gedcom-go/v2/gedcom"
 
 // DefaultMaxLineLength is the recommended maximum line length for GEDCOM files.
 // GEDCOM spec recommends lines not exceed 255 characters total.

--- a/encoder/streaming.go
+++ b/encoder/streaming.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // encodeState represents the current state of the streaming encoder.

--- a/encoder/streaming_test.go
+++ b/encoder/streaming_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cacack/gedcom-go/decoder"
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/decoder"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 func TestStreamEncoder_BasicFlow(t *testing.T) {

--- a/example_options_test.go
+++ b/example_options_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	gedcomgo "github.com/cacack/gedcom-go"
-	"github.com/cacack/gedcom-go/gedcom"
+	gedcomgo "github.com/cacack/gedcom-go/v2"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 func TestDefaultOptionsHelpers(t *testing.T) {

--- a/examples/date-parsing/main.go
+++ b/examples/date-parsing/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 func main() {

--- a/examples/encode/main.go
+++ b/examples/encode/main.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/cacack/gedcom-go/encoder"
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/encoder"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 func main() {

--- a/examples/parse/main.go
+++ b/examples/parse/main.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/cacack/gedcom-go/decoder"
-	"github.com/cacack/gedcom-go/validator"
+	"github.com/cacack/gedcom-go/v2/decoder"
+	"github.com/cacack/gedcom-go/v2/validator"
 )
 
 func main() {

--- a/examples/query/main.go
+++ b/examples/query/main.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/cacack/gedcom-go/decoder"
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/decoder"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 func main() {

--- a/examples/stream/main.go
+++ b/examples/stream/main.go
@@ -26,10 +26,10 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/cacack/gedcom-go/charset"
-	"github.com/cacack/gedcom-go/encoder"
-	"github.com/cacack/gedcom-go/gedcom"
-	"github.com/cacack/gedcom-go/parser"
+	"github.com/cacack/gedcom-go/v2/charset"
+	"github.com/cacack/gedcom-go/v2/encoder"
+	"github.com/cacack/gedcom-go/v2/gedcom"
+	"github.com/cacack/gedcom-go/v2/parser"
 )
 
 const individualCount = 1000

--- a/examples/validate/main.go
+++ b/examples/validate/main.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/cacack/gedcom-go/decoder"
-	"github.com/cacack/gedcom-go/validator"
+	"github.com/cacack/gedcom-go/v2/decoder"
+	"github.com/cacack/gedcom-go/v2/validator"
 )
 
 func main() {

--- a/gedcom/example_test.go
+++ b/gedcom/example_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cacack/gedcom-go/decoder"
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/decoder"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // ExampleDocument demonstrates accessing records in a GEDCOM document.

--- a/gedcom/subset_roundtrip_test.go
+++ b/gedcom/subset_roundtrip_test.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cacack/gedcom-go/decoder"
-	"github.com/cacack/gedcom-go/encoder"
-	"github.com/cacack/gedcom-go/gedcom"
-	"github.com/cacack/gedcom-go/validator"
+	"github.com/cacack/gedcom-go/v2/decoder"
+	"github.com/cacack/gedcom-go/v2/encoder"
+	"github.com/cacack/gedcom-go/v2/gedcom"
+	"github.com/cacack/gedcom-go/v2/validator"
 )
 
 // TestSubset_RoundtripMaximal70 exercises Subset against the most

--- a/gedcom/testing/compare.go
+++ b/gedcom/testing/compare.go
@@ -3,7 +3,7 @@ package testing
 import (
 	"fmt"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // compareDocuments compares two documents and returns differences.

--- a/gedcom/testing/roundtrip.go
+++ b/gedcom/testing/roundtrip.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"testing"
 
-	"github.com/cacack/gedcom-go/decoder"
-	"github.com/cacack/gedcom-go/encoder"
+	"github.com/cacack/gedcom-go/v2/decoder"
+	"github.com/cacack/gedcom-go/v2/encoder"
 )
 
 // AssertRoundTrip decodes input, encodes it, decodes again, and asserts equality.

--- a/gedcom/testing/roundtrip_test.go
+++ b/gedcom/testing/roundtrip_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // validMinimalGEDCOM is a minimal valid GEDCOM 5.5.1 file.

--- a/gedcom_api.go
+++ b/gedcom_api.go
@@ -38,20 +38,20 @@
 //
 // For advanced use cases requiring custom options, import the underlying packages directly:
 //
-//   - github.com/cacack/gedcom-go/decoder - Custom decode options, progress callbacks, diagnostics
-//   - github.com/cacack/gedcom-go/encoder - Custom line endings, encoding options
-//   - github.com/cacack/gedcom-go/validator - Configurable validation rules, quality reports
-//   - github.com/cacack/gedcom-go/converter - Custom conversion options, strict mode
+//   - github.com/cacack/gedcom-go/v2/decoder - Custom decode options, progress callbacks, diagnostics
+//   - github.com/cacack/gedcom-go/v2/encoder - Custom line endings, encoding options
+//   - github.com/cacack/gedcom-go/v2/validator - Configurable validation rules, quality reports
+//   - github.com/cacack/gedcom-go/v2/converter - Custom conversion options, strict mode
 package gedcomgo
 
 import (
 	"io"
 
-	"github.com/cacack/gedcom-go/converter"
-	"github.com/cacack/gedcom-go/decoder"
-	"github.com/cacack/gedcom-go/encoder"
-	"github.com/cacack/gedcom-go/gedcom"
-	"github.com/cacack/gedcom-go/validator"
+	"github.com/cacack/gedcom-go/v2/converter"
+	"github.com/cacack/gedcom-go/v2/decoder"
+	"github.com/cacack/gedcom-go/v2/encoder"
+	"github.com/cacack/gedcom-go/v2/gedcom"
+	"github.com/cacack/gedcom-go/v2/validator"
 )
 
 // Type re-exports for single-import convenience.

--- a/gedcom_api_test.go
+++ b/gedcom_api_test.go
@@ -6,11 +6,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cacack/gedcom-go/converter"
-	"github.com/cacack/gedcom-go/decoder"
-	"github.com/cacack/gedcom-go/encoder"
-	"github.com/cacack/gedcom-go/gedcom"
-	"github.com/cacack/gedcom-go/validator"
+	"github.com/cacack/gedcom-go/v2/converter"
+	"github.com/cacack/gedcom-go/v2/decoder"
+	"github.com/cacack/gedcom-go/v2/encoder"
+	"github.com/cacack/gedcom-go/v2/gedcom"
+	"github.com/cacack/gedcom-go/v2/validator"
 )
 
 // Test GEDCOM content for basic tests.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cacack/gedcom-go
+module github.com/cacack/gedcom-go/v2
 
 go 1.25.8
 

--- a/merge/combine.go
+++ b/merge/combine.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // CollisionStrategy chooses how to handle XRef collisions between

--- a/merge/combine_test.go
+++ b/merge/combine_test.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cacack/gedcom-go/decoder"
-	"github.com/cacack/gedcom-go/gedcom"
-	"github.com/cacack/gedcom-go/merge"
-	"github.com/cacack/gedcom-go/validator"
+	"github.com/cacack/gedcom-go/v2/decoder"
+	"github.com/cacack/gedcom-go/v2/gedcom"
+	"github.com/cacack/gedcom-go/v2/merge"
+	"github.com/cacack/gedcom-go/v2/validator"
 )
 
 // buildDoc constructs a small document with the given prefix on its

--- a/merge/example_test.go
+++ b/merge/example_test.go
@@ -3,8 +3,8 @@ package merge_test
 import (
 	"fmt"
 
-	"github.com/cacack/gedcom-go/gedcom"
-	"github.com/cacack/gedcom-go/merge"
+	"github.com/cacack/gedcom-go/v2/gedcom"
+	"github.com/cacack/gedcom-go/v2/merge"
 )
 
 // Example_remapXRefs demonstrates the recommended transform pattern:

--- a/merge/remap.go
+++ b/merge/remap.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // RemapXRefs returns a new document with every XRef remapped by the

--- a/merge/remap_test.go
+++ b/merge/remap_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cacack/gedcom-go/gedcom"
-	"github.com/cacack/gedcom-go/merge"
+	"github.com/cacack/gedcom-go/v2/gedcom"
+	"github.com/cacack/gedcom-go/v2/merge"
 )
 
 // buildRichFixture creates a small document with cross-references covering

--- a/merge/roundtrip_test.go
+++ b/merge/roundtrip_test.go
@@ -5,11 +5,11 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cacack/gedcom-go/decoder"
-	"github.com/cacack/gedcom-go/encoder"
-	"github.com/cacack/gedcom-go/gedcom"
-	"github.com/cacack/gedcom-go/merge"
-	"github.com/cacack/gedcom-go/validator"
+	"github.com/cacack/gedcom-go/v2/decoder"
+	"github.com/cacack/gedcom-go/v2/encoder"
+	"github.com/cacack/gedcom-go/v2/gedcom"
+	"github.com/cacack/gedcom-go/v2/merge"
+	"github.com/cacack/gedcom-go/v2/validator"
 )
 
 // TestCombine_Roundtrip_PrefixDoc2 exercises the end-to-end pipeline:

--- a/parser/example_test.go
+++ b/parser/example_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cacack/gedcom-go/parser"
+	"github.com/cacack/gedcom-go/v2/parser"
 )
 
 // Example demonstrates basic GEDCOM line parsing.

--- a/scripts/check-module-path.sh
+++ b/scripts/check-module-path.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Verify go.mod's module-path major version matches the latest git tag's major.
+#
+# Background: Go's Semantic Import Versioning requires the module path to include
+# a /vN suffix for v2 and later (e.g., github.com/foo/bar/v2). If we tag v2.0.0
+# without updating go.mod, pkg.go.dev and `go get` will silently keep resolving
+# the latest v1 — exactly what happened with our v2.0.0 release.
+#
+# This guard fails when the majors don't match, before a broken release ships.
+
+set -euo pipefail
+
+MODULE_PATH=$(awk '/^module / {print $2}' go.mod)
+if [ -z "$MODULE_PATH" ]; then
+  echo "✗ could not read module path from go.mod" >&2
+  exit 1
+fi
+
+# Extract major from module path (e.g., .../v2 -> 2). Bare path implies v0/v1.
+MOD_MAJOR=$(echo "$MODULE_PATH" | sed -nE 's|.*/v([0-9]+)$|\1|p')
+MOD_MAJOR=${MOD_MAJOR:-1}
+
+# Latest tag major (excludes pre-release suffixes like v2.0.0-rc1).
+LATEST_TAG=$(git tag --list 'v[0-9]*' --sort=-v:refname | head -n1)
+if [ -z "$LATEST_TAG" ]; then
+  echo "✓ no version tags yet; skipping module-path check"
+  exit 0
+fi
+TAG_MAJOR=$(echo "$LATEST_TAG" | sed -nE 's|^v([0-9]+).*|\1|p')
+
+if [ "$MOD_MAJOR" != "$TAG_MAJOR" ]; then
+  cat >&2 <<EOF
+✗ Module path major version does not match latest tag.
+
+    go.mod module:  $MODULE_PATH    (major v$MOD_MAJOR)
+    latest tag:     $LATEST_TAG    (major v$TAG_MAJOR)
+
+For Go's Semantic Import Versioning, the module path must include /vN for
+v2 and later. To fix before releasing v$TAG_MAJOR:
+
+  1. Update go.mod: 'module <path>/v$TAG_MAJOR'
+  2. Rewrite imports across the tree (find . -name '*.go' -exec sed ...)
+  3. Update README/USAGE/docs to show the new import path
+
+See https://go.dev/ref/mod#major-version-suffixes
+EOF
+  exit 1
+fi
+
+echo "✓ module path ($MODULE_PATH) matches latest tag major ($LATEST_TAG)"

--- a/validator/benchmark_test.go
+++ b/validator/benchmark_test.go
@@ -3,7 +3,7 @@ package validator
 import (
 	"testing"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // BenchmarkValidateMinimal benchmarks validating a minimal document

--- a/validator/date_logic.go
+++ b/validator/date_logic.go
@@ -13,7 +13,7 @@ package validator
 import (
 	"fmt"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // DateLogicConfig contains configurable thresholds for date logic validation.

--- a/validator/date_logic_test.go
+++ b/validator/date_logic_test.go
@@ -3,7 +3,7 @@ package validator
 import (
 	"testing"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // Helper to create a parsed date from a simple year (for testing)

--- a/validator/duplicates.go
+++ b/validator/duplicates.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 	"golang.org/x/text/runes"
 	"golang.org/x/text/transform"
 	"golang.org/x/text/unicode/norm"

--- a/validator/duplicates_test.go
+++ b/validator/duplicates_test.go
@@ -3,7 +3,7 @@ package validator
 import (
 	"testing"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 func TestDefaultDuplicateConfig(t *testing.T) {

--- a/validator/encoding.go
+++ b/validator/encoding.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // EncodingValidator validates GEDCOM 7.0 encoding requirements.

--- a/validator/encoding_test.go
+++ b/validator/encoding_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 func TestNewEncodingValidator(t *testing.T) {

--- a/validator/example_test.go
+++ b/validator/example_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cacack/gedcom-go/decoder"
-	"github.com/cacack/gedcom-go/validator"
+	"github.com/cacack/gedcom-go/v2/decoder"
+	"github.com/cacack/gedcom-go/v2/validator"
 )
 
 // Example demonstrates basic document validation.

--- a/validator/header.go
+++ b/validator/header.go
@@ -9,7 +9,7 @@ package validator
 import (
 	"fmt"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // HeaderValidator validates GEDCOM header requirements.

--- a/validator/header_test.go
+++ b/validator/header_test.go
@@ -3,7 +3,7 @@ package validator
 import (
 	"testing"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 func TestNewHeaderValidator(t *testing.T) {

--- a/validator/quality.go
+++ b/validator/quality.go
@@ -12,7 +12,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // QualityReport contains aggregated validation results and data completeness statistics.

--- a/validator/quality_test.go
+++ b/validator/quality_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // Helper to create an individual with optional birth date, sources, and places

--- a/validator/references.go
+++ b/validator/references.go
@@ -10,7 +10,7 @@ package validator
 import (
 	"fmt"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // ReferenceType represents the type of cross-reference being validated.

--- a/validator/references_test.go
+++ b/validator/references_test.go
@@ -3,7 +3,7 @@ package validator
 import (
 	"testing"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // Helper to create a minimal document with XRefMap

--- a/validator/streaming.go
+++ b/validator/streaming.go
@@ -26,7 +26,7 @@ package validator
 import (
 	"fmt"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // StreamingOptions configures the StreamingValidator behavior.

--- a/validator/streaming_test.go
+++ b/validator/streaming_test.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 func TestNewStreamingValidator(t *testing.T) {

--- a/validator/tag_validator.go
+++ b/validator/tag_validator.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // TagValidator validates custom (underscore-prefixed) tags against a registry.

--- a/validator/tag_validator_test.go
+++ b/validator/tag_validator_test.go
@@ -4,7 +4,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 func TestNewTagValidator(t *testing.T) {

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -3,7 +3,7 @@ package validator
 import (
 	"fmt"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // ValidationError represents a validation error with error code, message, line number, and optional cross-reference.

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cacack/gedcom-go/decoder"
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/decoder"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 func TestValidateBrokenXRef(t *testing.T) {

--- a/validator/vendor_tags.go
+++ b/validator/vendor_tags.go
@@ -24,7 +24,7 @@
 
 package validator
 
-import "github.com/cacack/gedcom-go/gedcom"
+import "github.com/cacack/gedcom-go/v2/gedcom"
 
 // AncestryRegistry returns a TagRegistry containing common Ancestry.com custom tags.
 //

--- a/validator/vendor_tags_test.go
+++ b/validator/vendor_tags_test.go
@@ -3,7 +3,7 @@ package validator
 import (
 	"testing"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 func TestAncestryRegistry(t *testing.T) {

--- a/validator/xref.go
+++ b/validator/xref.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // MaxXRefLength is the maximum XRef content length (excluding @ delimiters)

--- a/validator/xref_test.go
+++ b/validator/xref_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cacack/gedcom-go/gedcom"
+	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
 // Helper to create a document with specific version and XRefs

--- a/version/detect.go
+++ b/version/detect.go
@@ -3,8 +3,8 @@ package version
 import (
 	"strings"
 
-	"github.com/cacack/gedcom-go/gedcom"
-	"github.com/cacack/gedcom-go/parser"
+	"github.com/cacack/gedcom-go/v2/gedcom"
+	"github.com/cacack/gedcom-go/v2/parser"
 )
 
 // DetectVersion detects the GEDCOM version from parsed lines.

--- a/version/example_test.go
+++ b/version/example_test.go
@@ -3,9 +3,9 @@ package version_test
 import (
 	"fmt"
 
-	"github.com/cacack/gedcom-go/gedcom"
-	"github.com/cacack/gedcom-go/parser"
-	"github.com/cacack/gedcom-go/version"
+	"github.com/cacack/gedcom-go/v2/gedcom"
+	"github.com/cacack/gedcom-go/v2/parser"
+	"github.com/cacack/gedcom-go/v2/version"
 )
 
 // Example demonstrates basic GEDCOM version detection.

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -3,8 +3,8 @@ package version
 import (
 	"testing"
 
-	"github.com/cacack/gedcom-go/gedcom"
-	"github.com/cacack/gedcom-go/parser"
+	"github.com/cacack/gedcom-go/v2/gedcom"
+	"github.com/cacack/gedcom-go/v2/parser"
 )
 
 // T030: Write tests for version detection (header-based and tag-based fallback)


### PR DESCRIPTION
## Summary

- v2.0.0 shipped with the wrong module path (`github.com/cacack/gedcom-go` instead of `.../v2`), so Go's resolver silently falls back to v1.2.0 — which is why pkg.go.dev still shows 1.2.0.
- This PR updates `go.mod`, rewrites all 81 Go imports, fixes docs/README/examples/workflows, and adds a CI guard so this can't happen again on a future major bump.
- On merge, release-please will cut **v2.0.1** — the first actually-installable v2 release.

## Changes

- `go.mod` → `module github.com/cacack/gedcom-go/v2`
- 81 Go files: import paths rewritten to `/v2`
- Docs: `README.md`, `USAGE.md`, `FEATURES.md`, `docs/CONVERTER.md` (imports + `go get` + pkg.go.dev link)
- Workflows: `ci.yml` (goimports `local-prefix` and coverage grep), `release-please.yml` (now reads module path from `go.mod` so it's future-proof through v3+; added a checkout step to make `go.mod` available)
- Bug-report template: updated `go list -m` example
- **New**: `scripts/check-module-path.sh` — compares `go.mod` major against the highest `v*` tag and fails with an actionable message on mismatch. Wired into `make preflight` (step 2/9) and the CI **Format Check** job.

## Why not delete the v2.0.0 tag?

Deleting published tags is generally a bad idea (proxies and mirrors may have already cached metadata, and anyone who pinned v2.0.0 would get errors instead of an obvious "upgrade to v2.0.1"). The broken v2.0.0 will simply remain unresolvable; v2.0.1 will be the first v2 anyone can actually `go get`.

## Downstream impact

`cacack/my-family` consumes this via a `replace` directive locally, which masked the broken module path. It will need its imports updated from `github.com/cacack/gedcom-go/...` → `github.com/cacack/gedcom-go/v2/...` after v2.0.1 is published. That update is intentionally out of scope here.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./...` — all packages pass (charset, decoder, encoder, gedcom, parser, validator, version, merge, converter)
- [x] All five `examples/*` binaries build
- [x] `go mod tidy` produces no further changes
- [x] Pre-commit + pre-push hooks pass locally (coverage 96.2% total, all packages ≥85%)
- [x] Guard script: passes on current state, fails correctly when go.mod path is reverted to bare
- [ ] CI Format Check job runs the new module-path guard
- [ ] After merge: confirm release-please opens a v2.0.1 release PR
- [ ] After v2.0.1 tag: pkg.go.dev/github.com/cacack/gedcom-go/v2 indexes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)
