### PR TITLE
Preserve custom header tags losslessly and complete real-world export test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,13 @@ Support status for common genealogy software:
 
 | Software | Status |
 |----------|--------|
-| RootsMagic | ⚠️ Tested (older version) |
+| Ancestry.com | ✅ Real export tested (2025) |
+| FamilySearch | ✅ Real export tested (2025) |
+| MyHeritage | ✅ Real export tested (2025) |
+| Gramps | ✅ Real export tested (2025) |
+| RootsMagic | ✅ Real export tested (2026) |
 | Legacy Family Tree | ⚠️ Tested (older version) |
 | Family Tree Maker | ⚠️ Tested (older version) |
-| Gramps | 🧪 Synthetic test only |
-| Ancestry | 🧪 Synthetic test only |
 
 Full compatibility matrix: [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md)
 

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -321,6 +321,18 @@ func buildHeader(doc *gedcom.Document, lines []*parser.Line, ver gedcom.Version)
 			continue
 		}
 
+		// Preserve every header sub-tag in raw form (lossless dual storage,
+		// mirroring how buildRecords populates Record.Tags). Typed fields are
+		// still extracted below; this guarantees custom/unmapped header tags
+		// (e.g. _RTLSAVE, _PROJECT_GUID, header NOTEs) are not dropped.
+		doc.Header.Tags = append(doc.Header.Tags, &gedcom.Tag{
+			Level:      line.Level,
+			Tag:        line.Tag,
+			Value:      line.Value,
+			XRef:       line.XRef,
+			LineNumber: line.LineNumber,
+		})
+
 		// Track when we're inside SOUR structure
 		if line.Level == 1 && line.Tag == "SOUR" {
 			inSour = true

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -304,6 +304,66 @@ func TestDecodeHeaderComplete(t *testing.T) {
 	}
 }
 
+// TestDecodeHeaderPreservesRawTags verifies that all header sub-tags are kept
+// in Header.Tags (lossless dual storage), including custom/unmapped tags that
+// have no dedicated typed field. Regression test: buildHeader previously
+// extracted only a handful of known fields and silently dropped everything
+// else (e.g. _RTLSAVE, _PROJECT_GUID, header NOTEs).
+func TestDecodeHeaderPreservesRawTags(t *testing.T) {
+	input := `0 HEAD
+1 GEDC
+2 VERS 5.5.1
+2 FORM LINEAGE-LINKED
+1 CHAR UTF-8
+1 SOUR MYHERITAGE
+2 NAME MyHeritage Family Tree Builder
+2 _RTLSAVE RTL
+1 DEST MYHERITAGE
+1 _PROJECT_GUID ABC123
+1 _EXPORTED_FROM_SITE_ID 1729941170
+1 NOTE Unified System GEDCOM Standardizer 1.0
+0 TRLR`
+
+	doc, err := Decode(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+
+	// Typed fields still extracted (dual storage, not replaced).
+	if doc.Header.SourceSystem != "MYHERITAGE" {
+		t.Errorf("Header.SourceSystem = %q, want %q", doc.Header.SourceSystem, "MYHERITAGE")
+	}
+
+	findTag := func(name string) *gedcom.Tag {
+		for _, tg := range doc.Header.Tags {
+			if tg.Tag == name {
+				return tg
+			}
+		}
+		return nil
+	}
+
+	// Custom/unmapped header tags that have no typed field must survive.
+	for _, want := range []struct {
+		tag, value string
+	}{
+		{"_RTLSAVE", "RTL"},
+		{"DEST", "MYHERITAGE"},
+		{"_PROJECT_GUID", "ABC123"},
+		{"_EXPORTED_FROM_SITE_ID", "1729941170"},
+		{"NOTE", "Unified System GEDCOM Standardizer 1.0"},
+	} {
+		got := findTag(want.tag)
+		if got == nil {
+			t.Errorf("Header.Tags missing %q (header tag was dropped)", want.tag)
+			continue
+		}
+		if got.Value != want.value {
+			t.Errorf("Header.Tags[%q].Value = %q, want %q", want.tag, got.Value, want.value)
+		}
+	}
+}
+
 // Test context cancellation at different stages
 func TestDecodeContextCancellationStages(t *testing.T) {
 	t.Run("context cancelled after parsing", func(t *testing.T) {

--- a/decoder/integration_test.go
+++ b/decoder/integration_test.go
@@ -1043,6 +1043,213 @@ func TestRootsMagicRealExport(t *testing.T) {
 		individuals, families, sources, repos)
 }
 
+// headerTag returns the first header tag with the given name, or nil.
+func headerTag(doc *gedcom.Document, name string) *gedcom.Tag {
+	for _, tg := range doc.Header.Tags {
+		if tg.Tag == name {
+			return tg
+		}
+	}
+	return nil
+}
+
+// individualHasTag reports whether the individual carries a raw tag by name.
+func individualHasTag(ind *gedcom.Individual, name string) bool {
+	for _, tg := range ind.Tags {
+		if tg.Tag == name {
+			return true
+		}
+	}
+	return false
+}
+
+// TestFamilySearchRealExport tests a real FamilySearch 2025 export (5.5.1).
+// FamilySearch is identified not by HEAD.SOUR (it preserves the original
+// authoring system) but by per-record _HASH/_LHASH change-detection checksums
+// and a header standardizer NOTE. See docs/COMPATIBILITY.md.
+func TestFamilySearchRealExport(t *testing.T) {
+	f, err := os.Open("../testdata/edge-cases/familysearch-2025-export.ged")
+	if err != nil {
+		t.Skipf("Test file not found: %s", "../testdata/edge-cases/familysearch-2025-export.ged")
+		return
+	}
+	defer f.Close()
+
+	doc, err := Decode(f)
+	if err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+
+	if doc.Header.Version != gedcom.Version551 {
+		t.Errorf("Expected GEDCOM 5.5.1, got %v", doc.Header.Version)
+	}
+	if doc.Header.Encoding != gedcom.EncodingUTF8 {
+		t.Errorf("Expected UTF-8 encoding, got %v", doc.Header.Encoding)
+	}
+
+	// FamilySearch preserves the original authoring system rather than claiming
+	// authorship, so the file is NOT vendor-detectable from HEAD.SOUR.
+	if doc.Header.SourceSystem != "GEDCOM-GO" {
+		t.Errorf("Header.SourceSystem = %q, want %q (FamilySearch preserves original SOUR)", doc.Header.SourceSystem, "GEDCOM-GO")
+	}
+
+	if got := len(doc.Individuals()); got != 14 {
+		t.Errorf("Expected 14 individuals, got %d", got)
+	}
+	if got := len(doc.Families()); got != 5 {
+		t.Errorf("Expected 5 families, got %d", got)
+	}
+
+	// Per-record _HASH and _LHASH checksums must be preserved.
+	ind := doc.GetIndividual("@I1@")
+	if ind == nil {
+		t.Fatal("GetIndividual(@I1@) returned nil")
+	}
+	if !individualHasTag(ind, "_HASH") {
+		t.Error("Individual @I1@ missing _HASH tag (FamilySearch checksum dropped)")
+	}
+	if !individualHasTag(ind, "_LHASH") {
+		t.Error("Individual @I1@ missing _LHASH tag (FamilySearch checksum dropped)")
+	}
+
+	// The header standardizer NOTE identifies the export pipeline and must
+	// survive (regression guard for header-tag preservation).
+	foundStandardizer := false
+	for _, tg := range doc.Header.Tags {
+		if tg.Tag == "NOTE" && strings.Contains(tg.Value, "Standardizer") {
+			foundStandardizer = true
+			break
+		}
+	}
+	if !foundStandardizer {
+		t.Error("Header standardizer NOTE not preserved in Header.Tags")
+	}
+
+	t.Logf("Successfully verified FamilySearch 2025 real export: %d individuals, %d families",
+		len(doc.Individuals()), len(doc.Families()))
+}
+
+// TestMyHeritageRealExport tests a real MyHeritage 2025 export (5.5.1),
+// verifying _UID/RIN identifiers, header extensions, and the documented
+// behavior of stripping REPO records. See docs/COMPATIBILITY.md.
+func TestMyHeritageRealExport(t *testing.T) {
+	f, err := os.Open("../testdata/edge-cases/myheritage-2025-export.ged")
+	if err != nil {
+		t.Skipf("Test file not found: %s", "../testdata/edge-cases/myheritage-2025-export.ged")
+		return
+	}
+	defer f.Close()
+
+	doc, err := Decode(f)
+	if err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+
+	if doc.Vendor != gedcom.VendorMyHeritage {
+		t.Errorf("Expected VendorMyHeritage, got %v", doc.Vendor)
+	}
+	if doc.Header.Version != gedcom.Version551 {
+		t.Errorf("Expected GEDCOM 5.5.1, got %v", doc.Header.Version)
+	}
+
+	if got := len(doc.Individuals()); got != 14 {
+		t.Errorf("Expected 14 individuals, got %d", got)
+	}
+	if got := len(doc.Families()); got != 5 {
+		t.Errorf("Expected 5 families, got %d", got)
+	}
+	// MyHeritage strips REPO records from its exports.
+	if got := len(doc.Repositories()); got != 0 {
+		t.Errorf("Expected 0 repositories (MyHeritage drops REPO), got %d", got)
+	}
+
+	// _UID and RIN identifiers must be preserved per record.
+	ind := doc.GetIndividual("@I1@")
+	if ind == nil {
+		t.Fatal("GetIndividual(@I1@) returned nil")
+	}
+	if !individualHasTag(ind, "_UID") {
+		t.Error("Individual @I1@ missing _UID tag")
+	}
+	if !individualHasTag(ind, "RIN") {
+		t.Error("Individual @I1@ missing RIN tag")
+	}
+
+	// Header extensions must survive (regression guard for header-tag loss).
+	for _, want := range []string{"_RTLSAVE", "_PROJECT_GUID", "_EXPORTED_FROM_SITE_ID"} {
+		if headerTag(doc, want) == nil {
+			t.Errorf("Header.Tags missing MyHeritage extension %q", want)
+		}
+	}
+
+	t.Logf("Successfully verified MyHeritage 2025 real export: %d individuals, %d families, %d repositories",
+		len(doc.Individuals()), len(doc.Families()), len(doc.Repositories()))
+}
+
+// TestGrampsRealExport tests a real Gramps 6.0.6 export (5.5.1), verifying
+// CHAN change-tracking records, NAME TYPE birth subrecords, note references,
+// and header copyright preservation. See docs/COMPATIBILITY.md.
+func TestGrampsRealExport(t *testing.T) {
+	f, err := os.Open("../testdata/edge-cases/gramps-2025-export.ged")
+	if err != nil {
+		t.Skipf("Test file not found: %s", "../testdata/edge-cases/gramps-2025-export.ged")
+		return
+	}
+	defer f.Close()
+
+	doc, err := Decode(f)
+	if err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+
+	if doc.Vendor != gedcom.VendorGramps {
+		t.Errorf("Expected VendorGramps, got %v", doc.Vendor)
+	}
+	if doc.Header.SourceSystem != "Gramps" {
+		t.Errorf("Header.SourceSystem = %q, want %q", doc.Header.SourceSystem, "Gramps")
+	}
+
+	if got := len(doc.Individuals()); got != 14 {
+		t.Errorf("Expected 14 individuals, got %d", got)
+	}
+	if got := len(doc.Families()); got != 5 {
+		t.Errorf("Expected 5 families, got %d", got)
+	}
+
+	ind := doc.GetIndividual("@I0001@")
+	if ind == nil {
+		t.Fatal("GetIndividual(@I0001@) returned nil")
+	}
+
+	// CHAN change-date is captured into the typed ChangeDate field.
+	if ind.ChangeDate == nil {
+		t.Error("Individual @I0001@ missing ChangeDate (CHAN record)")
+	} else if ind.ChangeDate.Date != "27 JAN 2026" {
+		t.Errorf("ChangeDate.Date = %q, want %q", ind.ChangeDate.Date, "27 JAN 2026")
+	}
+
+	// Gramps tags the primary NAME with TYPE birth.
+	if len(ind.Names) == 0 {
+		t.Fatal("Individual @I0001@ has no names")
+	}
+	if ind.Names[0].Type != "birth" {
+		t.Errorf("Name.Type = %q, want %q", ind.Names[0].Type, "birth")
+	}
+
+	// Notes are stored as references to root-level NOTE records.
+	if len(ind.Notes) == 0 || !strings.HasPrefix(ind.Notes[0], "@N") {
+		t.Errorf("Individual @I0001@ Notes = %v, want a reference to a root-level NOTE record", ind.Notes)
+	}
+
+	// Gramps emits a header COPR copyright tag.
+	if doc.Header.Copyright == "" {
+		t.Error("Header.Copyright empty, want Gramps COPR value")
+	}
+
+	t.Logf("Successfully verified Gramps 6.0.6 real export: %d individuals, %d families",
+		len(doc.Individuals()), len(doc.Families()))
+}
+
 // TestVendorSpecificFiles tests GEDCOM files from various genealogy software vendors.
 // These files were sourced from the gedcom4j project (MIT License) and test vendor-specific
 // custom tags and extensions.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -185,7 +185,9 @@ Tested with real export from FamilySearch.org (2025).
 - Removes SUBM (submitter) records
 - Nicknames preserved as NICK subrecord (standard-compliant)
 
-**Note**: FamilySearch exports GEDCOM 5.5.1, not GEDCOM 7.0, despite being the GEDCOM 7.0 spec maintainer. The GEDCOM 7.0 spec examples in our test suite are from gedcom.io documentation, not real FamilySearch exports.
+**Note**: Our FamilySearch fixture is GEDCOM 5.5.1, and the GEDCOM 7.0 spec examples in our test suite are from gedcom.io documentation, not real FamilySearch exports.
+
+**Note (2025+)**: FamilySearch's website family-tree download now produces **GEDCOM 7**. The 5.5.1 fixture above represents an earlier export style; obtaining and testing a real FamilySearch GEDCOM 7 export is tracked in [#301](https://github.com/cacack/gedcom-go/issues/301).
 
 ## How We Test Compatibility
 

--- a/gedcom/header.go
+++ b/gedcom/header.go
@@ -30,6 +30,8 @@ type Header struct {
 	// this GEDCOM was exported from.
 	AncestryTreeID string
 
-	// Raw tags from the header for preserving unknown/custom tags
+	// Tags contains all raw header sub-tags in document order, providing a
+	// lossless record of the header (including custom/unmapped tags such as
+	// _RTLSAVE or header NOTEs) alongside the typed fields above.
 	Tags []*Tag
 }


### PR DESCRIPTION
## Summary

Completes #217 (real-world fixtures) and fixes a lossless-representation bug discovered while doing it.

Writing real assertions against the platform export fixtures surfaced that `buildHeader` was silently dropping every header sub-tag it didn't explicitly map — a violation of the Lossless Representation principle. This PR fixes that, then adds the assertions and doc sync that close out #217.

## Changes

**`fix(decoder): preserve custom header tags losslessly`**
- `buildHeader` now populates `Header.Tags` with all header sub-tags in document order (dual storage, mirroring `buildRecords` per ADR 003). Previously only `CHAR`/`LANG`/`COPR`/`SOUR`/`_TREE` were kept; everything else (vendor extensions like `_RTLSAVE`/`_PROJECT_GUID`, header `NOTE`s) was dropped.
- The encoder reconstructs the header from typed fields and does not read `Header.Tags`, so encoded round-trip output is unchanged.
- Regression test: `TestDecodeHeaderPreservesRawTags`.

**`test: add real-export assertions for FamilySearch/MyHeritage/Gramps`**
- These three fixtures previously had only parse-and-count coverage, so the ✅ "real export tested" claims in `docs/COMPATIBILITY.md` weren't backed by assertions. Added dedicated tests matching the existing Ancestry/RootsMagic depth, verifying documented per-platform quirks (`_HASH`/`_LHASH`, `_UID`/`RIN`, REPO stripping, `CHAN`, `NAME TYPE birth`, header-extension preservation, etc.).

**`docs: sync compatibility matrix with tested real exports`**
- README compatibility table was stale and contradicted `COMPATIBILITY.md` — synced it (5 platforms now marked real-export tested).
- Added a dated note that FamilySearch's current website export produces GEDCOM 7 (our fixture is the earlier 5.5.1 style), tracked in #301.

## Testing

- `make preflight` — all checks pass, total coverage 96.2%
- Downstream consumer `cacack/my-family` test suite passes against this change

## Related

- Closes #217
- Follow-up deep-research effort tracked in #301 (real GEDCOM 7 FamilySearch fixture, broader corpus/quirk survey)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
