### PR TITLE
Add coordinate decimal-degree helpers

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -506,6 +506,26 @@ mutated.
 - MAP coordinates (LATI, LONG)
 - Place notes
 
+### Coordinate Conversion
+
+Convert GEDCOM-format coordinates (direction-prefixed, e.g. `N42.3601`) to signed decimal degrees:
+
+```go
+// place.Coordinates is *Coordinates and is nil when the place has no MAP tag.
+// AsDecimal is nil-safe (a nil receiver yields 0, 0, nil), but guarding makes
+// the intent explicit:
+if !place.Coordinates.IsEmpty() {
+    // Whole pair, with axis + range validation
+    // (lat must use N/S ∈ [-90,90]; long must use E/W ∈ [-180,180]).
+    lat, long, err := place.Coordinates.AsDecimal()
+}
+
+// Single component (pure format conversion, no range/axis check).
+lat, err := gedcom.ParseCoordinate("N42.3601")  // 42.3601
+```
+
+`AsDecimal` returns `(0, 0, nil)` when the pair is empty (nil receiver or both components blank) and an error when only one is present. Valid coordinates at the origin (`N0`/`E0`) also return `(0, 0, nil)` — use `IsEmpty` to distinguish the absent case.
+
 ## Address Structure
 
 - ADR1, ADR2, ADR3 - Address lines

--- a/gedcom/coordinate.go
+++ b/gedcom/coordinate.go
@@ -1,0 +1,117 @@
+package gedcom
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ParseCoordinate parses a GEDCOM coordinate string ("N42.3601", "W71.0589")
+// to signed decimal degrees. N/E are positive; S/W are negative. Direction
+// letters are case-insensitive and surrounding whitespace is ignored.
+//
+// The value following the direction letter must be unsigned: the sign is
+// carried by the direction, so an explicitly signed value such as "N-42.3601"
+// is rejected rather than silently inverted.
+//
+// It performs format conversion only and does not range-check the result, nor
+// does it verify that the direction matches a particular axis, because a single
+// component carries no information about whether it is a latitude or a
+// longitude. Callers are responsible for using N/S for latitudes and E/W for
+// longitudes; Coordinates.AsDecimal enforces this. Returns an error for empty
+// or malformed input.
+func ParseCoordinate(s string) (float64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("empty coordinate")
+	}
+
+	direction := s[0]
+	num := s[1:]
+	if strings.HasPrefix(num, "+") || strings.HasPrefix(num, "-") {
+		return 0, fmt.Errorf("coordinate value must be unsigned, got %q", s)
+	}
+
+	value, err := strconv.ParseFloat(num, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid coordinate %q: %w", s, err)
+	}
+
+	switch direction {
+	case 'N', 'n', 'E', 'e':
+		return value, nil
+	case 'S', 's', 'W', 'w':
+		return -value, nil
+	default:
+		return 0, fmt.Errorf("invalid direction %q in coordinate %q", string(direction), s)
+	}
+}
+
+// IsEmpty reports whether the coordinate pair carries no data. A nil receiver
+// and a pair whose latitude and longitude are both empty (ignoring whitespace)
+// are both empty. Use this to distinguish absent coordinates from valid
+// coordinates at the origin (0°, 0°), which AsDecimal also reports as
+// (0, 0, nil).
+func (c *Coordinates) IsEmpty() bool {
+	if c == nil {
+		return true
+	}
+	return strings.TrimSpace(c.Latitude) == "" && strings.TrimSpace(c.Longitude) == ""
+}
+
+// AsDecimal returns latitude and longitude as signed decimal degrees.
+// N/E are positive; S/W are negative.
+//
+// It returns (0, 0, nil) when the pair is empty — that is, when the receiver is
+// nil or both components are blank. Note that valid coordinates at the origin
+// (latitude "N0", longitude "E0") also yield (0, 0, nil); callers that must
+// distinguish the absent case should consult IsEmpty first.
+//
+// If exactly one component is present the pair is incomplete and an error is
+// returned. An error is also returned when a component is malformed, uses the
+// wrong axis direction (latitude must use N/S, longitude E/W), or is out of
+// range (latitude within [-90, 90], longitude within [-180, 180]).
+func (c *Coordinates) AsDecimal() (lat, long float64, err error) {
+	if c == nil {
+		return 0, 0, nil
+	}
+
+	latStr := strings.TrimSpace(c.Latitude)
+	longStr := strings.TrimSpace(c.Longitude)
+
+	if latStr == "" && longStr == "" {
+		return 0, 0, nil
+	}
+	if latStr == "" || longStr == "" {
+		return 0, 0, fmt.Errorf("incomplete coordinates: latitude %q, longitude %q", c.Latitude, c.Longitude)
+	}
+
+	switch latStr[0] {
+	case 'N', 'n', 'S', 's':
+	default:
+		return 0, 0, fmt.Errorf("latitude must use N/S direction, got %q", c.Latitude)
+	}
+	switch longStr[0] {
+	case 'E', 'e', 'W', 'w':
+	default:
+		return 0, 0, fmt.Errorf("longitude must use E/W direction, got %q", c.Longitude)
+	}
+
+	lat, err = ParseCoordinate(latStr)
+	if err != nil {
+		return 0, 0, fmt.Errorf("latitude: %w", err)
+	}
+	if lat < -90 || lat > 90 {
+		return 0, 0, fmt.Errorf("latitude %g out of range [-90, 90]", lat)
+	}
+
+	long, err = ParseCoordinate(longStr)
+	if err != nil {
+		return 0, 0, fmt.Errorf("longitude: %w", err)
+	}
+	if long < -180 || long > 180 {
+		return 0, 0, fmt.Errorf("longitude %g out of range [-180, 180]", long)
+	}
+
+	return lat, long, nil
+}

--- a/gedcom/coordinate_test.go
+++ b/gedcom/coordinate_test.go
@@ -1,0 +1,185 @@
+package gedcom
+
+import (
+	"math"
+	"testing"
+)
+
+func TestParseCoordinate(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    float64
+		wantErr bool
+	}{
+		{name: "north positive", input: "N42.3601", want: 42.3601},
+		{name: "south negative", input: "S33.8688", want: -33.8688},
+		{name: "east positive", input: "E151.2093", want: 151.2093},
+		{name: "west negative", input: "W71.0589", want: -71.0589},
+		{name: "lowercase direction", input: "n42.3601", want: 42.3601},
+		{name: "lowercase west", input: "w71.0589", want: -71.0589},
+		{name: "surrounding whitespace", input: "  N42.3601  ", want: 42.3601},
+		{name: "zero value", input: "N0", want: 0},
+		{name: "integer value", input: "S5", want: -5},
+		{name: "empty string", input: "", wantErr: true},
+		{name: "whitespace only", input: "   ", wantErr: true},
+		{name: "invalid direction", input: "X42.3601", wantErr: true},
+		{name: "no direction prefix", input: "42.3601", wantErr: true},
+		{name: "non-numeric value", input: "Nabc", wantErr: true},
+		{name: "direction only", input: "N", wantErr: true},
+		{name: "signed value rejected (negative)", input: "N-42.3601", wantErr: true},
+		{name: "signed value rejected (positive)", input: "N+42.3601", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseCoordinate(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParseCoordinate(%q) = %v, want error", tt.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseCoordinate(%q) unexpected error: %v", tt.input, err)
+			}
+			if math.Abs(got-tt.want) > 1e-9 {
+				t.Errorf("ParseCoordinate(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCoordinates_AsDecimal(t *testing.T) {
+	tests := []struct {
+		name     string
+		coords   *Coordinates
+		wantLat  float64
+		wantLong float64
+		wantErr  bool
+	}{
+		{
+			name:    "nil receiver returns zero no error",
+			coords:  nil,
+			wantLat: 0, wantLong: 0,
+		},
+		{
+			name:    "origin (Null Island) returns zero no error",
+			coords:  &Coordinates{Latitude: "N0", Longitude: "E0"},
+			wantLat: 0, wantLong: 0,
+		},
+		{
+			name:    "latitude wrong axis direction",
+			coords:  &Coordinates{Latitude: "E42.3601", Longitude: "W71.0589"},
+			wantErr: true,
+		},
+		{
+			name:    "longitude wrong axis direction",
+			coords:  &Coordinates{Latitude: "N42.3601", Longitude: "N71.0589"},
+			wantErr: true,
+		},
+		{
+			name:    "signed latitude value rejected",
+			coords:  &Coordinates{Latitude: "N-42.3601", Longitude: "W71.0589"},
+			wantErr: true,
+		},
+		{
+			name:     "valid pair",
+			coords:   &Coordinates{Latitude: "N42.3601", Longitude: "W71.0589"},
+			wantLat:  42.3601,
+			wantLong: -71.0589,
+		},
+		{
+			name:     "southern eastern hemisphere",
+			coords:   &Coordinates{Latitude: "S33.8688", Longitude: "E151.2093"},
+			wantLat:  -33.8688,
+			wantLong: 151.2093,
+		},
+		{
+			name:     "both empty returns zero no error",
+			coords:   &Coordinates{},
+			wantLat:  0,
+			wantLong: 0,
+		},
+		{
+			name:    "missing longitude",
+			coords:  &Coordinates{Latitude: "N42.3601"},
+			wantErr: true,
+		},
+		{
+			name:    "missing latitude",
+			coords:  &Coordinates{Longitude: "W71.0589"},
+			wantErr: true,
+		},
+		{
+			name:    "malformed latitude",
+			coords:  &Coordinates{Latitude: "Nxyz", Longitude: "W71.0589"},
+			wantErr: true,
+		},
+		{
+			name:    "malformed longitude",
+			coords:  &Coordinates{Latitude: "N42.3601", Longitude: "Wxyz"},
+			wantErr: true,
+		},
+		{
+			name:    "latitude out of range",
+			coords:  &Coordinates{Latitude: "N91.0", Longitude: "W71.0589"},
+			wantErr: true,
+		},
+		{
+			name:    "longitude out of range",
+			coords:  &Coordinates{Latitude: "N42.3601", Longitude: "W181.0"},
+			wantErr: true,
+		},
+		{
+			name:     "boundary values",
+			coords:   &Coordinates{Latitude: "N90.0", Longitude: "W180.0"},
+			wantLat:  90,
+			wantLong: -180,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lat, long, err := tt.coords.AsDecimal()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("AsDecimal() = (%v, %v), want error", lat, long)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("AsDecimal() unexpected error: %v", err)
+			}
+			if math.Abs(lat-tt.wantLat) > 1e-9 {
+				t.Errorf("AsDecimal() lat = %v, want %v", lat, tt.wantLat)
+			}
+			if math.Abs(long-tt.wantLong) > 1e-9 {
+				t.Errorf("AsDecimal() long = %v, want %v", long, tt.wantLong)
+			}
+		})
+	}
+}
+
+func TestCoordinates_IsEmpty(t *testing.T) {
+	tests := []struct {
+		name   string
+		coords *Coordinates
+		want   bool
+	}{
+		{name: "nil receiver", coords: nil, want: true},
+		{name: "both empty", coords: &Coordinates{}, want: true},
+		{name: "whitespace only", coords: &Coordinates{Latitude: "  ", Longitude: "\t"}, want: true},
+		{name: "origin coordinates not empty", coords: &Coordinates{Latitude: "N0", Longitude: "E0"}, want: false},
+		{name: "populated", coords: &Coordinates{Latitude: "N42.3601", Longitude: "W71.0589"}, want: false},
+		{name: "only latitude", coords: &Coordinates{Latitude: "N42.3601"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.coords.IsEmpty(); got != tt.want {
+				t.Errorf("IsEmpty() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/gedcom/example_test.go
+++ b/gedcom/example_test.go
@@ -413,3 +413,29 @@ func ExampleDate_Validate() {
 	// Feb 28, 2020 is valid
 	// Feb 30 is invalid
 }
+
+// ExampleParseCoordinate shows parsing a single GEDCOM coordinate component
+// to signed decimal degrees.
+func ExampleParseCoordinate() {
+	lat, _ := gedcom.ParseCoordinate("N42.3601")
+	long, _ := gedcom.ParseCoordinate("W71.0589")
+	fmt.Printf("lat=%.4f long=%.4f\n", lat, long)
+
+	// Output:
+	// lat=42.3601 long=-71.0589
+}
+
+// ExampleCoordinates_AsDecimal shows converting a place's Coordinates to
+// signed decimal degrees with range validation.
+func ExampleCoordinates_AsDecimal() {
+	coords := &gedcom.Coordinates{Latitude: "S33.8688", Longitude: "E151.2093"}
+	lat, long, err := coords.AsDecimal()
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+	fmt.Printf("lat=%.4f long=%.4f\n", lat, long)
+
+	// Output:
+	// lat=-33.8688 long=151.2093
+}


### PR DESCRIPTION
## Summary

Adds helpers to convert GEDCOM direction-prefixed coordinate strings (e.g. `N42.3601`, `W71.0589`) to signed decimal degrees, so consumers stop re-implementing this conversion. Driven by `cacack/my-family`, which had a private `ParseGEDCOMCoordinate`.

## API

- `gedcom.ParseCoordinate(s string) (float64, error)` — pure format→decimal for a single component. Case-insensitive direction, trims whitespace, rejects explicitly-signed values (the sign belongs to the direction letter). No range/axis check — a lone component cannot know which axis it is.
- `(*Coordinates) AsDecimal() (lat, long float64, err error)` — parses both components, validates axis (N/S for latitude, E/W for longitude) and range (lat ∈ [-90,90], long ∈ [-180,180]). Nil-safe; returns `(0,0,nil)` for an empty pair, errors on an incomplete pair.
- `(*Coordinates) IsEmpty() bool` — nil-safe; distinguishes absent coordinates from valid origin (`N0`/`E0`) coordinates, which `AsDecimal` also reports as `(0,0,nil)`.

## Review notes

The implementation incorporates fixes from a panel review pass: nil-receiver safety, rejection of sign-prefixed values that would invert the hemisphere, and axis-direction validation.

## Testing

- `make preflight` green (lint, race tests, security scans).
- 100% coverage on `ParseCoordinate`, `AsDecimal`, and `IsEmpty`.
- Runnable examples added; `FEATURES.md` documents the canonical usage with a nil guard.

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)
