### PR TITLE
Expose structured Source-to-Repository link (CALN, MEDI, NOTE)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -420,7 +420,9 @@ mutated.
 
 - Cross-reference ID (`@S1@`)
 - Title, author, publication info
-- Repository references
+- Structured repository link (`RepositoryLink`) carrying call numbers (CALN),
+  media type (MEDI), and per-link notes (NOTE) — by XRef or inline by name
+  (the flat `RepositoryRef`/`Repository` fields remain for compatibility)
 - Notes and multimedia
 
 ### Repositories (REPO)

--- a/decoder/entity.go
+++ b/decoder/entity.go
@@ -836,12 +836,10 @@ func parseSource(record *gedcom.Record, collector *diagnosticCollector) *gedcom.
 		case "TEXT":
 			src.Text = tag.Value
 		case "REPO":
-			if tag.Value != "" {
-				src.RepositoryRef = tag.Value
-			} else {
-				// Look for inline repository with NAME subordinate
-				src.Repository = parseInlineRepository(record.Tags, i, collector)
-			}
+			src.RepositoryLink = parseSourceRepositoryLink(record.Tags, i, collector)
+			// Populate deprecated fields for backward compatibility.
+			src.RepositoryRef = src.RepositoryLink.XRef
+			src.Repository = src.RepositoryLink.Inline
 		case "NOTE":
 			src.Notes = append(src.Notes, tag.Value)
 		case "OBJE":
@@ -869,34 +867,75 @@ func parseSource(record *gedcom.Record, collector *diagnosticCollector) *gedcom.
 	return src
 }
 
-// parseInlineRepository extracts an inline repository from tags starting at repoIdx.
-// An inline repository has no XRef value and contains subordinate tags like NAME.
-func parseInlineRepository(tags []*gedcom.Tag, repoIdx int, collector *diagnosticCollector) *gedcom.InlineRepository {
-	repo := &gedcom.InlineRepository{}
+// parseSourceRepositoryLink extracts the structured REPO link of a source from
+// tags starting at repoIdx. The REPO substructure may carry a repository XRef
+// (or an inline repository by NAME), CALN call numbers (each with an optional
+// MEDI media type), and NOTE subordinates.
+func parseSourceRepositoryLink(tags []*gedcom.Tag, repoIdx int, collector *diagnosticCollector) *gedcom.SourceRepositoryLink {
+	link := &gedcom.SourceRepositoryLink{}
 
-	baseLevel := tags[repoIdx].Level
+	repoTag := tags[repoIdx]
+	baseLevel := repoTag.Level
 
-	// Look for subordinate tags at baseLevel+1
+	if repoTag.Value != "" {
+		link.XRef = repoTag.Value
+	} else {
+		// No XRef value: this is an inline repository referenced by name.
+		link.Inline = &gedcom.InlineRepository{}
+	}
+
 	for i := repoIdx + 1; i < len(tags); i++ {
 		tag := tags[i]
 		if tag.Level <= baseLevel {
 			break
 		}
-		if tag.Level == baseLevel+1 {
-			switch tag.Tag {
-			case "NAME":
-				repo.Name = tag.Value
-			case "CALN", "NOTE":
-				// Known tags not yet parsed into typed fields
-			default:
-				if !strings.HasPrefix(tag.Tag, "_") {
-					collector.addUnknownTag(tag.LineNumber, tag.Tag, tag.Value)
+		if tag.Level != baseLevel+1 {
+			continue
+		}
+		switch tag.Tag {
+		case "NAME":
+			if link.Inline == nil {
+				link.Inline = &gedcom.InlineRepository{}
+			}
+			link.Inline.Name = tag.Value
+		case "CALN":
+			link.CallNumbers = append(link.CallNumbers, tag.Value)
+			// MEDI is a subordinate of CALN at baseLevel+2.
+			if medi := findSubordinate(tags, i, "MEDI"); medi != "" {
+				if link.MediaType == "" {
+					link.MediaType = medi
 				}
+				if link.CallNumberMedia == nil {
+					link.CallNumberMedia = make(map[string]string)
+				}
+				link.CallNumberMedia[tag.Value] = medi
+			}
+		case "NOTE":
+			link.Notes = append(link.Notes, tag.Value)
+		default:
+			if !strings.HasPrefix(tag.Tag, "_") {
+				collector.addUnknownTag(tag.LineNumber, tag.Tag, tag.Value)
 			}
 		}
 	}
 
-	return repo
+	return link
+}
+
+// findSubordinate returns the value of the first direct child tag of the tag at
+// parentIdx that matches name, or "" if none exists.
+func findSubordinate(tags []*gedcom.Tag, parentIdx int, name string) string {
+	parentLevel := tags[parentIdx].Level
+	for i := parentIdx + 1; i < len(tags); i++ {
+		tag := tags[i]
+		if tag.Level <= parentLevel {
+			break
+		}
+		if tag.Level == parentLevel+1 && tag.Tag == name {
+			return tag.Value
+		}
+	}
+	return ""
 }
 
 // parseChangeDate extracts a change date structure from tags starting at chanIdx.

--- a/decoder/entity.go
+++ b/decoder/entity.go
@@ -894,10 +894,16 @@ func parseSourceRepositoryLink(tags []*gedcom.Tag, repoIdx int, collector *diagn
 		}
 		switch tag.Tag {
 		case "NAME":
-			if link.Inline == nil {
-				link.Inline = &gedcom.InlineRepository{}
+			// A NAME subordinate denotes an inline repository. If the REPO tag
+			// already carried an XRef value, the record is malformed (XRef and
+			// inline name are mutually exclusive); keep the XRef as canonical
+			// and ignore the stray NAME rather than populate both fields.
+			if link.XRef == "" {
+				if link.Inline == nil {
+					link.Inline = &gedcom.InlineRepository{}
+				}
+				link.Inline.Name = tag.Value
 			}
-			link.Inline.Name = tag.Value
 		case "CALN":
 			link.CallNumbers = append(link.CallNumbers, tag.Value)
 			// MEDI is a subordinate of CALN at baseLevel+2.
@@ -908,6 +914,9 @@ func parseSourceRepositoryLink(tags []*gedcom.Tag, repoIdx int, collector *diagn
 				if link.CallNumberMedia == nil {
 					link.CallNumberMedia = make(map[string]string)
 				}
+				// Duplicate CALN strings collapse to last-writer-wins here; the
+				// CallNumbers slice retains every entry. See the CallNumberMedia
+				// doc comment in gedcom/repository.go.
 				link.CallNumberMedia[tag.Value] = medi
 			}
 		case "NOTE":

--- a/decoder/entity_test.go
+++ b/decoder/entity_test.go
@@ -2,6 +2,7 @@ package decoder
 
 import (
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -3321,6 +3322,107 @@ func TestSourceInlineRepositoryRoundtrip(t *testing.T) {
 	}
 	if src.Repository.Name != "County Archives" {
 		t.Errorf("Repository.Name = %s, want 'County Archives'", src.Repository.Name)
+	}
+}
+
+// TestSourceRepositoryLinkDecoding tests decoding of the structured REPO link
+// carrying CALN (with MEDI) and NOTE subordinates (Issue #289).
+func TestSourceRepositoryLinkDecoding(t *testing.T) {
+	input := `0 HEAD
+1 GEDC
+2 VERS 5.5.1
+0 @S1@ SOUR
+1 TITL Census Record
+1 REPO @R1@
+2 CALN MS-1234
+3 MEDI Manuscript
+2 CALN Roll 42
+2 NOTE Held in archives, advance booking required
+0 TRLR
+`
+	doc, err := Decode(strings.NewReader(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	src := doc.GetSource("@S1@")
+	if src == nil {
+		t.Fatal("Source @S1@ not found")
+	}
+
+	link := src.RepositoryLink
+	if link == nil {
+		t.Fatal("src.RepositoryLink is nil, want non-nil")
+	}
+	if link.XRef != "@R1@" {
+		t.Errorf("link.XRef = %q, want %q", link.XRef, "@R1@")
+	}
+	if link.Inline != nil {
+		t.Errorf("link.Inline = %+v, want nil for XRef link", link.Inline)
+	}
+	wantCALN := []string{"MS-1234", "Roll 42"}
+	if !reflect.DeepEqual(link.CallNumbers, wantCALN) {
+		t.Errorf("link.CallNumbers = %v, want %v", link.CallNumbers, wantCALN)
+	}
+	if link.MediaType != "Manuscript" {
+		t.Errorf("link.MediaType = %q, want %q", link.MediaType, "Manuscript")
+	}
+	if got := link.CallNumberMedia["MS-1234"]; got != "Manuscript" {
+		t.Errorf("link.CallNumberMedia[MS-1234] = %q, want %q", got, "Manuscript")
+	}
+	if _, ok := link.CallNumberMedia["Roll 42"]; ok {
+		t.Errorf("link.CallNumberMedia should not contain 'Roll 42' (no MEDI)")
+	}
+	wantNotes := []string{"Held in archives, advance booking required"}
+	if !reflect.DeepEqual(link.Notes, wantNotes) {
+		t.Errorf("link.Notes = %v, want %v", link.Notes, wantNotes)
+	}
+
+	// Deprecated fields stay populated for backward compatibility.
+	if src.RepositoryRef != "@R1@" {
+		t.Errorf("src.RepositoryRef = %q, want %q", src.RepositoryRef, "@R1@")
+	}
+}
+
+// TestSourceRepositoryLinkInlineDecoding tests the structured REPO link for an
+// inline (by-name) repository with call-number metadata (Issue #289).
+func TestSourceRepositoryLinkInlineDecoding(t *testing.T) {
+	input := `0 HEAD
+1 GEDC
+2 VERS 5.5.1
+0 @S1@ SOUR
+1 TITL Parish Register
+1 REPO
+2 NAME State Archives
+2 CALN PR-99
+0 TRLR
+`
+	doc, err := Decode(strings.NewReader(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	src := doc.GetSource("@S1@")
+	if src == nil {
+		t.Fatal("Source @S1@ not found")
+	}
+	link := src.RepositoryLink
+	if link == nil {
+		t.Fatal("src.RepositoryLink is nil, want non-nil")
+	}
+	if link.XRef != "" {
+		t.Errorf("link.XRef = %q, want empty", link.XRef)
+	}
+	if link.Inline == nil || link.Inline.Name != "State Archives" {
+		t.Errorf("link.Inline = %+v, want Name 'State Archives'", link.Inline)
+	}
+	if !reflect.DeepEqual(link.CallNumbers, []string{"PR-99"}) {
+		t.Errorf("link.CallNumbers = %v, want [PR-99]", link.CallNumbers)
+	}
+
+	// Deprecated Repository field stays populated.
+	if src.Repository == nil || src.Repository.Name != "State Archives" {
+		t.Errorf("src.Repository = %+v, want Name 'State Archives'", src.Repository)
 	}
 }
 

--- a/decoder/entity_test.go
+++ b/decoder/entity_test.go
@@ -3424,6 +3424,77 @@ func TestSourceRepositoryLinkInlineDecoding(t *testing.T) {
 	if src.Repository == nil || src.Repository.Name != "State Archives" {
 		t.Errorf("src.Repository = %+v, want Name 'State Archives'", src.Repository)
 	}
+	// An inline link has no XRef, so the deprecated RepositoryRef alias must
+	// stay empty (it mirrors RepositoryLink.XRef, not the inline name).
+	if src.RepositoryRef != "" {
+		t.Errorf("src.RepositoryRef = %q, want empty for an inline link", src.RepositoryRef)
+	}
+}
+
+// TestSourceRepositoryLinkMalformedXRefAndName verifies that a REPO carrying
+// both an XRef value and a stray NAME subordinate keeps the XRef canonical and
+// does not populate the inline form, preserving the XRef/Inline mutual
+// exclusion invariant.
+func TestSourceRepositoryLinkMalformedXRefAndName(t *testing.T) {
+	input := `0 HEAD
+1 GEDC
+2 VERS 5.5.1
+0 @S1@ SOUR
+1 TITL Parish Register
+1 REPO @R1@
+2 NAME Stray Name
+0 TRLR
+`
+	doc, err := Decode(strings.NewReader(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := doc.GetSource("@S1@")
+	if src == nil {
+		t.Fatal("Source @S1@ not found")
+	}
+	link := src.RepositoryLink
+	if link == nil {
+		t.Fatal("src.RepositoryLink is nil, want non-nil")
+	}
+	if link.XRef != "@R1@" {
+		t.Errorf("link.XRef = %q, want %q", link.XRef, "@R1@")
+	}
+	if link.Inline != nil {
+		t.Errorf("link.Inline = %+v, want nil (XRef is canonical)", link.Inline)
+	}
+	if src.Repository != nil {
+		t.Errorf("src.Repository = %+v, want nil", src.Repository)
+	}
+}
+
+// TestSourceRepositoryLinkDuplicateCALN verifies that duplicate CALN strings
+// with differing MEDI subordinates retain both call numbers in the slice while
+// CallNumberMedia collapses to last-writer-wins.
+func TestSourceRepositoryLinkDuplicateCALN(t *testing.T) {
+	input := `0 HEAD
+1 GEDC
+2 VERS 5.5.1
+0 @S1@ SOUR
+1 TITL Parish Register
+1 REPO @R1@
+2 CALN Box 1
+3 MEDI Manuscript
+2 CALN Box 1
+3 MEDI Photo
+0 TRLR
+`
+	doc, err := Decode(strings.NewReader(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	link := doc.GetSource("@S1@").RepositoryLink
+	if !reflect.DeepEqual(link.CallNumbers, []string{"Box 1", "Box 1"}) {
+		t.Errorf("link.CallNumbers = %v, want [Box 1, Box 1]", link.CallNumbers)
+	}
+	if got := link.CallNumberMedia["Box 1"]; got != "Photo" {
+		t.Errorf("link.CallNumberMedia[Box 1] = %q, want last-writer-wins %q", got, "Photo")
+	}
 }
 
 // TestFamilySearchIDParsing tests parsing of the _FSFTID tag (FamilySearch Family Tree ID).

--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -61,6 +61,100 @@ func TestEncodeRoundtrip(t *testing.T) {
 	}
 }
 
+// TestEncodeSourceRepositoryLink verifies the structured REPO link (CALN, MEDI,
+// NOTE) survives a decode -> encode -> decode cycle without loss (Issue #289).
+func TestEncodeSourceRepositoryLink(t *testing.T) {
+	input := `0 HEAD
+1 GEDC
+2 VERS 5.5.1
+0 @S1@ SOUR
+1 TITL Census Record
+1 REPO @R1@
+2 CALN MS-1234
+3 MEDI Manuscript
+2 NOTE Held in archives
+0 TRLR
+`
+
+	doc, err := decoder.Decode(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := Encode(&buf, doc); err != nil {
+		t.Fatalf("Encode() error = %v", err)
+	}
+	output := buf.String()
+
+	for _, want := range []string{
+		"1 REPO @R1@",
+		"2 CALN MS-1234",
+		"3 MEDI Manuscript",
+		"2 NOTE Held in archives",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("output missing %q\noutput:\n%s", want, output)
+		}
+	}
+
+	doc2, err := decoder.Decode(strings.NewReader(output))
+	if err != nil {
+		t.Fatalf("re-decode error = %v\noutput:\n%s", err, output)
+	}
+	link := doc2.GetSource("@S1@").RepositoryLink
+	if link == nil {
+		t.Fatalf("RepositoryLink nil after roundtrip\noutput:\n%s", output)
+	}
+	if link.XRef != "@R1@" {
+		t.Errorf("link.XRef = %q, want %q", link.XRef, "@R1@")
+	}
+	if len(link.CallNumbers) != 1 || link.CallNumbers[0] != "MS-1234" {
+		t.Errorf("link.CallNumbers = %v, want [MS-1234]", link.CallNumbers)
+	}
+	if link.CallNumberMedia["MS-1234"] != "Manuscript" {
+		t.Errorf("link.CallNumberMedia[MS-1234] = %q, want %q", link.CallNumberMedia["MS-1234"], "Manuscript")
+	}
+	if len(link.Notes) != 1 || link.Notes[0] != "Held in archives" {
+		t.Errorf("link.Notes = %v, want [Held in archives]", link.Notes)
+	}
+}
+
+// TestEncodeSourceRepositoryLinkInline verifies an inline (by-name) REPO link
+// with a call number round-trips (Issue #289).
+func TestEncodeSourceRepositoryLinkInline(t *testing.T) {
+	input := `0 HEAD
+1 GEDC
+2 VERS 5.5.1
+0 @S1@ SOUR
+1 TITL Parish Register
+1 REPO
+2 NAME State Archives
+2 CALN PR-99
+0 TRLR
+`
+
+	doc, err := decoder.Decode(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := Encode(&buf, doc); err != nil {
+		t.Fatalf("Encode() error = %v", err)
+	}
+	output := buf.String()
+
+	for _, want := range []string{"1 REPO", "2 NAME State Archives", "2 CALN PR-99"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("output missing %q\noutput:\n%s", want, output)
+		}
+	}
+	if strings.Contains(output, "1 REPO @") {
+		t.Errorf("inline REPO should not have an XRef value\noutput:\n%s", output)
+	}
+}
+
 func TestEncodeCRLF(t *testing.T) {
 	input := `0 HEAD
 1 GEDC

--- a/encoder/encoder_test.go
+++ b/encoder/encoder_test.go
@@ -155,6 +155,34 @@ func TestEncodeSourceRepositoryLinkInline(t *testing.T) {
 	}
 }
 
+// TestEncodeSourceRepositoryLinkDegenerate verifies that a non-nil but empty
+// RepositoryLink (no XRef, no inline name, no subordinates) emits no REPO tag
+// rather than a meaningless bare `1 REPO` (Issue #289).
+func TestEncodeSourceRepositoryLinkDegenerate(t *testing.T) {
+	doc := &gedcom.Document{
+		Header: &gedcom.Header{Version: "5.5.1"},
+		Records: []*gedcom.Record{
+			{
+				Type: gedcom.RecordTypeSource,
+				XRef: "@S1@",
+				Entity: &gedcom.Source{
+					XRef:           "@S1@",
+					Title:          "Parish Register",
+					RepositoryLink: &gedcom.SourceRepositoryLink{},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := Encode(&buf, doc); err != nil {
+		t.Fatalf("Encode() error = %v", err)
+	}
+	if strings.Contains(buf.String(), "REPO") {
+		t.Errorf("degenerate RepositoryLink should emit no REPO tag\noutput:\n%s", buf.String())
+	}
+}
+
 func TestEncodeCRLF(t *testing.T) {
 	input := `0 HEAD
 1 GEDC

--- a/encoder/entity_writer.go
+++ b/encoder/entity_writer.go
@@ -345,10 +345,14 @@ func sourceToTags(src *gedcom.Source, opts *EncodeOptions) []*gedcom.Tag {
 		tags = append(tags, textToTags(src.Text, 1, "TEXT", opts)...)
 	}
 
-	// Repository reference or inline (level 1) - REPO
-	if src.RepositoryRef != "" {
+	// Repository link (level 1) - REPO. Prefer the structured RepositoryLink;
+	// fall back to the legacy RepositoryRef/Repository fields.
+	switch {
+	case src.RepositoryLink != nil:
+		tags = append(tags, sourceRepositoryLinkToTags(src.RepositoryLink, opts)...)
+	case src.RepositoryRef != "":
 		tags = append(tags, &gedcom.Tag{Level: 1, Tag: "REPO", Value: src.RepositoryRef})
-	} else if src.Repository != nil && src.Repository.Name != "" {
+	case src.Repository != nil && src.Repository.Name != "":
 		tags = append(tags,
 			&gedcom.Tag{Level: 1, Tag: "REPO"},
 			&gedcom.Tag{Level: 2, Tag: "NAME", Value: src.Repository.Name},
@@ -383,6 +387,42 @@ func sourceToTags(src *gedcom.Source, opts *EncodeOptions) []*gedcom.Tag {
 	// UID (level 1)
 	if src.UID != "" {
 		tags = append(tags, &gedcom.Tag{Level: 1, Tag: "UID", Value: src.UID})
+	}
+
+	return tags
+}
+
+// sourceRepositoryLinkToTags converts a SourceRepositoryLink to GEDCOM tags,
+// emitting the REPO pointer (or inline NAME) plus CALN (with optional MEDI) and
+// NOTE subordinates.
+func sourceRepositoryLinkToTags(link *gedcom.SourceRepositoryLink, opts *EncodeOptions) []*gedcom.Tag {
+	var tags []*gedcom.Tag
+
+	if link.XRef != "" {
+		tags = append(tags, &gedcom.Tag{Level: 1, Tag: "REPO", Value: link.XRef})
+	} else {
+		tags = append(tags, &gedcom.Tag{Level: 1, Tag: "REPO"})
+		if link.Inline != nil && link.Inline.Name != "" {
+			tags = append(tags, &gedcom.Tag{Level: 2, Tag: "NAME", Value: link.Inline.Name})
+		}
+	}
+
+	// Call numbers (level 2) - CALN, each with an optional MEDI (level 3).
+	for _, caln := range link.CallNumbers {
+		tags = append(tags, &gedcom.Tag{Level: 2, Tag: "CALN", Value: caln})
+		medi := link.CallNumberMedia[caln]
+		if medi == "" && len(link.CallNumbers) == 1 {
+			// Single CALN: fall back to the flat MediaType field.
+			medi = link.MediaType
+		}
+		if medi != "" {
+			tags = append(tags, &gedcom.Tag{Level: 3, Tag: "MEDI", Value: medi})
+		}
+	}
+
+	// Per-link notes (level 2) - NOTE (with CONT/CONC for multiline/long).
+	for _, note := range link.Notes {
+		tags = append(tags, textToTags(note, 2, "NOTE", opts)...)
 	}
 
 	return tags

--- a/encoder/entity_writer.go
+++ b/encoder/entity_writer.go
@@ -398,6 +398,14 @@ func sourceToTags(src *gedcom.Source, opts *EncodeOptions) []*gedcom.Tag {
 func sourceRepositoryLinkToTags(link *gedcom.SourceRepositoryLink, opts *EncodeOptions) []*gedcom.Tag {
 	var tags []*gedcom.Tag
 
+	// A degenerate link with neither pointer, inline name, nor any
+	// subordinate data would emit a meaningless bare `1 REPO` that round-trips
+	// as an empty inline repository. Skip it entirely.
+	hasInlineName := link.Inline != nil && link.Inline.Name != ""
+	if link.XRef == "" && !hasInlineName && len(link.CallNumbers) == 0 && len(link.Notes) == 0 {
+		return nil
+	}
+
 	if link.XRef != "" {
 		tags = append(tags, &gedcom.Tag{Level: 1, Tag: "REPO", Value: link.XRef})
 	} else {

--- a/gedcom/clone.go
+++ b/gedcom/clone.go
@@ -255,6 +255,8 @@ func (s *Source) Clone() *Source {
 		copied.Repository = &InlineRepository{Name: s.Repository.Name}
 	}
 
+	copied.RepositoryLink = cloneSourceRepositoryLink(s.RepositoryLink)
+
 	if s.Media != nil {
 		copied.Media = make([]*MediaLink, len(s.Media))
 		for k, media := range s.Media {
@@ -282,6 +284,34 @@ func (r *Repository) Clone() *Repository {
 		Notes:   cloneStringSlice(r.Notes),
 		Tags:    CloneTags(r.Tags),
 	}
+}
+
+// cloneSourceRepositoryLink returns a deep copy of a SourceRepositoryLink.
+// Returns nil if link is nil.
+func cloneSourceRepositoryLink(link *SourceRepositoryLink) *SourceRepositoryLink {
+	if link == nil {
+		return nil
+	}
+
+	copied := &SourceRepositoryLink{
+		XRef:        link.XRef,
+		CallNumbers: cloneStringSlice(link.CallNumbers),
+		MediaType:   link.MediaType,
+		Notes:       cloneStringSlice(link.Notes),
+	}
+
+	if link.Inline != nil {
+		copied.Inline = &InlineRepository{Name: link.Inline.Name}
+	}
+
+	if link.CallNumberMedia != nil {
+		copied.CallNumberMedia = make(map[string]string, len(link.CallNumberMedia))
+		for k, v := range link.CallNumberMedia {
+			copied.CallNumberMedia[k] = v
+		}
+	}
+
+	return copied
 }
 
 // Clone returns a deep copy of the note. Returns nil if n is nil.

--- a/gedcom/clone_test.go
+++ b/gedcom/clone_test.go
@@ -566,10 +566,17 @@ func TestSourceClone(t *testing.T) {
 			RefNumber:     "789",
 			UID:           "uid-789",
 			Repository:    &InlineRepository{Name: "Inline Repo"},
-			Media:         []*MediaLink{{MediaXRef: "@M1@"}},
-			ChangeDate:    &ChangeDate{Date: "1 JAN 2024"},
-			CreationDate:  &ChangeDate{Date: "1 JAN 2020"},
-			Tags:          []*Tag{{Tag: "CUSTOM"}},
+			RepositoryLink: &SourceRepositoryLink{
+				XRef:            "@R1@",
+				CallNumbers:     []string{"MS-1234"},
+				MediaType:       "Manuscript",
+				CallNumberMedia: map[string]string{"MS-1234": "Manuscript"},
+				Notes:           []string{"Held in archives"},
+			},
+			Media:        []*MediaLink{{MediaXRef: "@M1@"}},
+			ChangeDate:   &ChangeDate{Date: "1 JAN 2024"},
+			CreationDate: &ChangeDate{Date: "1 JAN 2020"},
+			Tags:         []*Tag{{Tag: "CUSTOM"}},
 		}
 
 		copied := original.Clone()
@@ -584,6 +591,28 @@ func TestSourceClone(t *testing.T) {
 		}
 		if copied.Repository.Name != original.Repository.Name {
 			t.Errorf("Repository.Name = %v, want %v", copied.Repository.Name, original.Repository.Name)
+		}
+		if copied.RepositoryLink == original.RepositoryLink {
+			t.Error("RepositoryLink should have different pointer")
+		}
+		if copied.RepositoryLink.XRef != original.RepositoryLink.XRef {
+			t.Errorf("RepositoryLink.XRef = %v, want %v", copied.RepositoryLink.XRef, original.RepositoryLink.XRef)
+		}
+		// Mutating the copy's maps/slices must not affect the original.
+		copied.RepositoryLink.CallNumberMedia["MS-1234"] = "changed"
+		if original.RepositoryLink.CallNumberMedia["MS-1234"] != "Manuscript" {
+			t.Error("RepositoryLink.CallNumberMedia map shares backing storage with original")
+		}
+		copied.RepositoryLink.CallNumbers[0] = "changed"
+		if original.RepositoryLink.CallNumbers[0] != "MS-1234" {
+			t.Error("RepositoryLink.CallNumbers slice shares backing storage with original")
+		}
+	})
+
+	t.Run("nil RepositoryLink clones to nil", func(t *testing.T) {
+		original := &Source{XRef: "@S2@"}
+		if original.Clone().RepositoryLink != nil {
+			t.Error("nil RepositoryLink should clone to nil")
 		}
 	})
 }

--- a/gedcom/repository.go
+++ b/gedcom/repository.go
@@ -34,7 +34,9 @@ type InlineRepository struct {
 // of a SOUR record, which can carry CALN (call number), MEDI (media type), and
 // NOTE subordinates in addition to the repository pointer itself.
 type SourceRepositoryLink struct {
-	// XRef is the repository pointer, e.g. "@R1@". Empty if Inline is set.
+	// XRef is the repository pointer, e.g. "@R1@". XRef and Inline are
+	// mutually exclusive: when XRef is non-empty, Inline is nil (the decoder
+	// enforces this even for malformed input that carries both).
 	XRef string
 
 	// Inline is set when the source references the repository by name rather
@@ -48,10 +50,20 @@ type SourceRepositoryLink struct {
 	// MediaType is the MEDI subordinate of the first CALN that carries one
 	// (manuscript, photo, etc.). When multiple CALNs have differing MEDI
 	// values, use CallNumberMedia to recover the per-CALN pairing.
+	//
+	// The encoder only round-trips MediaType faithfully for a single-CALN
+	// link (it is emitted as that CALN's MEDI when CallNumberMedia has no
+	// entry for it). For multi-CALN links the encoder relies on
+	// CallNumberMedia; a MediaType set without a matching CallNumberMedia
+	// entry is not written out.
 	MediaType string
 
 	// CallNumberMedia indexes MEDI values by their parent CALN, when CALN and
 	// MEDI need to stay paired. Empty when no MEDI subordinates exist.
+	//
+	// Keyed by the CALN string value. If a record carries two CALN entries
+	// with identical text but different MEDI subordinates, the later MEDI
+	// wins (last-writer-wins); CallNumbers still retains both entries.
 	CallNumberMedia map[string]string
 
 	// Notes carries NOTE subordinates of the REPO link (not the source).

--- a/gedcom/repository.go
+++ b/gedcom/repository.go
@@ -29,6 +29,35 @@ type InlineRepository struct {
 	Name string
 }
 
+// SourceRepositoryLink is a Source's reference to a Repository, with per-link
+// metadata (call numbers, media type, notes). It models the REPO substructure
+// of a SOUR record, which can carry CALN (call number), MEDI (media type), and
+// NOTE subordinates in addition to the repository pointer itself.
+type SourceRepositoryLink struct {
+	// XRef is the repository pointer, e.g. "@R1@". Empty if Inline is set.
+	XRef string
+
+	// Inline is set when the source references the repository by name rather
+	// than by XRef (i.e. the GEDCOM has `1 REPO` with a name value and no
+	// separate repository record).
+	Inline *InlineRepository
+
+	// CallNumbers holds CALN values (multiple allowed per GEDCOM spec).
+	CallNumbers []string
+
+	// MediaType is the MEDI subordinate of the first CALN that carries one
+	// (manuscript, photo, etc.). When multiple CALNs have differing MEDI
+	// values, use CallNumberMedia to recover the per-CALN pairing.
+	MediaType string
+
+	// CallNumberMedia indexes MEDI values by their parent CALN, when CALN and
+	// MEDI need to stay paired. Empty when no MEDI subordinates exist.
+	CallNumberMedia map[string]string
+
+	// Notes carries NOTE subordinates of the REPO link (not the source).
+	Notes []string
+}
+
 // Address represents a physical or digital address.
 type Address struct {
 	// Line1 is the first address line

--- a/gedcom/source.go
+++ b/gedcom/source.go
@@ -17,10 +17,25 @@ type Source struct {
 	// Text is the actual text from the source
 	Text string
 
-	// RepositoryRef is the XRef to the repository where this source is stored
+	// RepositoryLink is the structured form of the source's repository link.
+	// It carries the call number(s), media type, and per-link notes that the
+	// REPO substructure can hold. Prefer this over RepositoryRef/Repository,
+	// which only expose the bare pointer or inline name.
+	RepositoryLink *SourceRepositoryLink
+
+	// RepositoryRef is the XRef to the repository where this source is stored.
+	//
+	// Superseded by RepositoryLink (use RepositoryLink.XRef). Retained for
+	// backward compatibility until the next major release; it is populated
+	// from RepositoryLink.XRef during decode.
 	RepositoryRef string
 
-	// Repository is an inline repository definition (alternative to RepositoryRef)
+	// Repository is an inline repository definition (alternative to
+	// RepositoryRef).
+	//
+	// Superseded by RepositoryLink (use RepositoryLink.Inline). Retained for
+	// backward compatibility until the next major release; it is populated
+	// from RepositoryLink.Inline during decode.
 	Repository *InlineRepository
 
 	// Media are references to media objects with optional crop/title

--- a/gedcom/xrefwalk.go
+++ b/gedcom/xrefwalk.go
@@ -369,9 +369,16 @@ func walkSource(s *Source, cb refCallback) {
 	if s == nil {
 		return
 	}
-	cb(&s.RepositoryRef)
+	// RepositoryRef is the legacy alias of RepositoryLink.XRef (the decoder
+	// populates both from the same REPO pointer). Walk only the canonical
+	// field to avoid visiting/rewriting the same logical pointer twice, then
+	// re-sync the alias so an Apply rewrite propagates to it. When there is no
+	// RepositoryLink (legacy-only Source), fall back to walking RepositoryRef.
 	if s.RepositoryLink != nil {
 		cb(&s.RepositoryLink.XRef)
+		s.RepositoryRef = s.RepositoryLink.XRef
+	} else {
+		cb(&s.RepositoryRef)
 	}
 	for k := range s.Notes {
 		cb(&s.Notes[k])

--- a/gedcom/xrefwalk.go
+++ b/gedcom/xrefwalk.go
@@ -370,6 +370,9 @@ func walkSource(s *Source, cb refCallback) {
 		return
 	}
 	cb(&s.RepositoryRef)
+	if s.RepositoryLink != nil {
+		cb(&s.RepositoryLink.XRef)
+	}
 	for k := range s.Notes {
 		cb(&s.Notes[k])
 	}

--- a/gedcom/xrefwalk_test.go
+++ b/gedcom/xrefwalk_test.go
@@ -127,9 +127,12 @@ func xrefwalkFullDocument() *Document {
 	}
 
 	source := &Source{
-		XRef:           "@S1@",
+		XRef: "@S1@",
+		// The decoder populates RepositoryRef and RepositoryLink.XRef with the
+		// same value; the fixture mirrors that so walkSource is exercised the
+		// way real decoded documents look.
 		RepositoryRef:  "@R-SRC@",
-		RepositoryLink: &SourceRepositoryLink{XRef: "@R-LINK@"},
+		RepositoryLink: &SourceRepositoryLink{XRef: "@R-SRC@"},
 		Notes:          []string{"@N-SRC@"},
 		Media: []*MediaLink{
 			{MediaXRef: "@M-SRC@"},
@@ -236,8 +239,9 @@ func xrefwalkExpectedRefs() []string {
 		"@I-HUSB@", "@I-WIFE@", "@I-CHILD1@", "@I-CHILD2@",
 		"@N-FAM@", "@S-FAM@", "@M-FAM@",
 		"@N-FAM-EVENT@", "@F-FAM-LDS@", "@T-FAM@",
-		// Source record
-		"@R-SRC@", "@R-LINK@", "@N-SRC@", "@M-SRC@", "@T-SRC@",
+		// Source record (RepositoryRef and RepositoryLink.XRef are the same
+		// logical pointer, so it is visited once)
+		"@R-SRC@", "@N-SRC@", "@M-SRC@", "@T-SRC@",
 		// Repository record
 		"@N-REPO@", "@T-REPO@",
 		// Note record
@@ -419,7 +423,7 @@ func TestApply_RewritesEverything(t *testing.T) {
 	if got := src.RepositoryRef; got != "@R-SRC@X" {
 		t.Errorf("Source.RepositoryRef = %q", got)
 	}
-	if got := src.RepositoryLink.XRef; got != "@R-LINK@X" {
+	if got := src.RepositoryLink.XRef; got != "@R-SRC@X" {
 		t.Errorf("Source.RepositoryLink.XRef = %q", got)
 	}
 	if got := src.Tags[0].Value; got != "@T-SRC@X" {

--- a/gedcom/xrefwalk_test.go
+++ b/gedcom/xrefwalk_test.go
@@ -127,9 +127,10 @@ func xrefwalkFullDocument() *Document {
 	}
 
 	source := &Source{
-		XRef:          "@S1@",
-		RepositoryRef: "@R-SRC@",
-		Notes:         []string{"@N-SRC@"},
+		XRef:           "@S1@",
+		RepositoryRef:  "@R-SRC@",
+		RepositoryLink: &SourceRepositoryLink{XRef: "@R-LINK@"},
+		Notes:          []string{"@N-SRC@"},
 		Media: []*MediaLink{
 			{MediaXRef: "@M-SRC@"},
 		},
@@ -236,7 +237,7 @@ func xrefwalkExpectedRefs() []string {
 		"@N-FAM@", "@S-FAM@", "@M-FAM@",
 		"@N-FAM-EVENT@", "@F-FAM-LDS@", "@T-FAM@",
 		// Source record
-		"@R-SRC@", "@N-SRC@", "@M-SRC@", "@T-SRC@",
+		"@R-SRC@", "@R-LINK@", "@N-SRC@", "@M-SRC@", "@T-SRC@",
 		// Repository record
 		"@N-REPO@", "@T-REPO@",
 		// Note record
@@ -417,6 +418,9 @@ func TestApply_RewritesEverything(t *testing.T) {
 	src := doc.Records[2].Entity.(*Source)
 	if got := src.RepositoryRef; got != "@R-SRC@X" {
 		t.Errorf("Source.RepositoryRef = %q", got)
+	}
+	if got := src.RepositoryLink.XRef; got != "@R-LINK@X" {
+		t.Errorf("Source.RepositoryLink.XRef = %q", got)
 	}
 	if got := src.Tags[0].Value; got != "@T-SRC@X" {
 		t.Errorf("Source.Tags[0].Value = %q", got)


### PR DESCRIPTION
Promotes a Source's REPO substructure from a flat `RepositoryRef` string to a structured `RepositoryLink` that carries call numbers (CALN), media type (MEDI), and per-link notes (NOTE). Without this, consumers silently dropped CALN/MEDI/NOTE on import and broke round-trip on export.

## Changes

- Add `gedcom.SourceRepositoryLink` (XRef or inline name, `CallNumbers`, `MediaType`, `CallNumberMedia` for per-CALN MEDI pairing, `Notes`).
- Add `Source.RepositoryLink`; keep `RepositoryRef`/`Repository` populated from it for backward compatibility (removal deferred to next major).
- Decoder parses CALN (with subordinate MEDI) and per-link NOTE under REPO; enforces XRef/inline mutual exclusion for malformed input.
- Encoder prefers `RepositoryLink` when present, falls back to the legacy fields; skips degenerate empty links.
- Deep clone and XRef-walk support for the new structure (walks the canonical `RepositoryLink.XRef` and re-syncs the legacy alias).

## Backward compatibility

Additive only — `make api-check` reports no breaking changes. Legacy `RepositoryRef`/`Repository` continue to work.

## Verification

- `make preflight` passes (lint, race tests, 95.9% total coverage, security scans).
- `make api-check`: no breaking API changes.

Closes #289
