### PR TITLE
Split inline notes from shared-note XRefs in record types

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,6 +56,12 @@ linters:
         path: _test\.go
       - path: _test\.go
         text: SA5011
+      # The record-level Notes field is deprecated in favor of NoteXRefs and
+      # InlineNotes (issue #290), but must stay populated and readable during
+      # the deprecation window, so internal uses of it are expected.
+      - linters:
+          - staticcheck
+        text: 'SA1019:.*is deprecated: use NoteXRefs and InlineNotes'
       - linters:
           - lll
           - gocritic

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -441,6 +441,13 @@ mutated.
 
 - Cross-reference ID (`@N1@`)
 - Text content with continuation
+- Split note fields on note-bearing records (Individual, Family, Source,
+  Repository, Submitter, MediaObject): `NoteXRefs` holds XRef pointers to
+  shared NOTE/SNOTE records, `InlineNotes` holds note text written directly
+  on the record. The legacy `Notes []string` field is deprecated (kept for
+  backward compatibility, populated in original GEDCOM order).
+- `AllNotes(doc)` helper returns inline note text plus the resolved text of
+  any shared notes referenced by XRef
 
 ### Multimedia (OBJE)
 

--- a/decoder/entity.go
+++ b/decoder/entity.go
@@ -137,7 +137,7 @@ func parseIndividual(record *gedcom.Record, collector *diagnosticCollector) *ged
 			indi.SourceCitations = append(indi.SourceCitations, cite)
 
 		case "NOTE":
-			indi.Notes = append(indi.Notes, tag.Value)
+			indi.NoteXRefs, indi.InlineNotes, indi.Notes = appendRecordNote(record.Tags, i, indi.NoteXRefs, indi.InlineNotes, indi.Notes)
 
 		case "OBJE":
 			link := parseMediaLink(record.Tags, i, tag.Level, collector)
@@ -779,7 +779,7 @@ func parseFamily(record *gedcom.Record, collector *diagnosticCollector) *gedcom.
 			fam.SourceCitations = append(fam.SourceCitations, cite)
 
 		case "NOTE":
-			fam.Notes = append(fam.Notes, tag.Value)
+			fam.NoteXRefs, fam.InlineNotes, fam.Notes = appendRecordNote(record.Tags, i, fam.NoteXRefs, fam.InlineNotes, fam.Notes)
 
 		case "OBJE":
 			link := parseMediaLink(record.Tags, i, tag.Level, collector)
@@ -841,7 +841,7 @@ func parseSource(record *gedcom.Record, collector *diagnosticCollector) *gedcom.
 			src.RepositoryRef = src.RepositoryLink.XRef
 			src.Repository = src.RepositoryLink.Inline
 		case "NOTE":
-			src.Notes = append(src.Notes, tag.Value)
+			src.NoteXRefs, src.InlineNotes, src.Notes = appendRecordNote(record.Tags, i, src.NoteXRefs, src.InlineNotes, src.Notes)
 		case "OBJE":
 			link := parseMediaLink(record.Tags, i, tag.Level, collector)
 			src.Media = append(src.Media, link)
@@ -1018,7 +1018,7 @@ func parseSubmitter(record *gedcom.Record, collector *diagnosticCollector) *gedc
 			subm.Language = append(subm.Language, tag.Value)
 
 		case "NOTE":
-			subm.Notes = append(subm.Notes, tag.Value)
+			subm.NoteXRefs, subm.InlineNotes, subm.Notes = appendRecordNote(record.Tags, i, subm.NoteXRefs, subm.InlineNotes, subm.Notes)
 
 		case "EXID":
 			subm.ExternalIDs = append(subm.ExternalIDs, parseExternalID(record.Tags, i))
@@ -1075,7 +1075,7 @@ func parseRepository(record *gedcom.Record, collector *diagnosticCollector) *ged
 			repo.Address.Website = tag.Value
 
 		case "NOTE":
-			repo.Notes = append(repo.Notes, tag.Value)
+			repo.NoteXRefs, repo.InlineNotes, repo.Notes = appendRecordNote(record.Tags, i, repo.NoteXRefs, repo.InlineNotes, repo.Notes)
 
 		case "EXID":
 			repo.ExternalIDs = append(repo.ExternalIDs, parseExternalID(record.Tags, i))
@@ -1091,6 +1091,40 @@ func parseRepository(record *gedcom.Record, collector *diagnosticCollector) *ged
 	}
 
 	return repo
+}
+
+// appendRecordNote classifies a record-level NOTE tag at noteIdx and appends it
+// to the appropriate slice. A pointer-shaped value (e.g. "@N1@") is an XRef to a
+// shared NOTE/SNOTE record and is appended to *xrefs. Any other value is inline
+// note text and is appended to *inline, with subordinate CONT/CONC lines folded
+// in (CONT joins with a newline, CONC concatenates). The legacy combined Notes
+// slice is appended to in the same order for backward compatibility.
+//
+// It returns the updated xrefs, inline, and legacy slices.
+func appendRecordNote(tags []*gedcom.Tag, noteIdx int, xrefs, inline, legacy []string) (newXRefs, newInline, newLegacy []string) {
+	tag := tags[noteIdx]
+	if gedcom.IsPointerXRef(tag.Value) {
+		return append(xrefs, tag.Value), inline, append(legacy, tag.Value)
+	}
+
+	text := tag.Value
+	baseLevel := tag.Level
+	for i := noteIdx + 1; i < len(tags); i++ {
+		sub := tags[i]
+		if sub.Level <= baseLevel {
+			break
+		}
+		if sub.Level != baseLevel+1 {
+			continue
+		}
+		switch sub.Tag {
+		case "CONT":
+			text += "\n" + sub.Value
+		case "CONC":
+			text += sub.Value
+		}
+	}
+	return xrefs, append(inline, text), append(legacy, text)
 }
 
 // parseNote converts record tags to a Note entity.
@@ -1237,7 +1271,7 @@ func parseMediaObject(record *gedcom.Record, collector *diagnosticCollector) *ge
 			file := parseMediaFile(record.Tags, i, tag.Level, collector)
 			media.Files = append(media.Files, file)
 		case "NOTE":
-			media.Notes = append(media.Notes, tag.Value)
+			media.NoteXRefs, media.InlineNotes, media.Notes = appendRecordNote(record.Tags, i, media.NoteXRefs, media.InlineNotes, media.Notes)
 		case "SOUR":
 			cite := parseSourceCitation(record.Tags, i, tag.Level, collector)
 			media.SourceCitations = append(media.SourceCitations, cite)

--- a/decoder/entity.go
+++ b/decoder/entity.go
@@ -1104,6 +1104,8 @@ func parseRepository(record *gedcom.Record, collector *diagnosticCollector) *ged
 func appendRecordNote(tags []*gedcom.Tag, noteIdx int, xrefs, inline, legacy []string) (newXRefs, newInline, newLegacy []string) {
 	tag := tags[noteIdx]
 	if gedcom.IsPointerXRef(tag.Value) {
+		// XRef pointer to a shared note: the GEDCOM specs do not permit
+		// subordinate CONT/CONC lines here, so there is nothing to fold in.
 		return append(xrefs, tag.Value), inline, append(legacy, tag.Value)
 	}
 

--- a/decoder/entity.go
+++ b/decoder/entity.go
@@ -136,7 +136,7 @@ func parseIndividual(record *gedcom.Record, collector *diagnosticCollector) *ged
 			cite := parseSourceCitation(record.Tags, i, tag.Level, collector)
 			indi.SourceCitations = append(indi.SourceCitations, cite)
 
-		case "NOTE":
+		case "NOTE", "SNOTE":
 			indi.NoteXRefs, indi.InlineNotes, indi.Notes = appendRecordNote(record.Tags, i, indi.NoteXRefs, indi.InlineNotes, indi.Notes)
 
 		case "OBJE":
@@ -778,7 +778,7 @@ func parseFamily(record *gedcom.Record, collector *diagnosticCollector) *gedcom.
 			cite := parseSourceCitation(record.Tags, i, tag.Level, collector)
 			fam.SourceCitations = append(fam.SourceCitations, cite)
 
-		case "NOTE":
+		case "NOTE", "SNOTE":
 			fam.NoteXRefs, fam.InlineNotes, fam.Notes = appendRecordNote(record.Tags, i, fam.NoteXRefs, fam.InlineNotes, fam.Notes)
 
 		case "OBJE":
@@ -800,7 +800,7 @@ func parseFamily(record *gedcom.Record, collector *diagnosticCollector) *gedcom.
 		case "EXID":
 			fam.ExternalIDs = append(fam.ExternalIDs, parseExternalID(record.Tags, i))
 
-		case "RESN", "SUBM", "ASSO", "SNOTE":
+		case "RESN", "SUBM", "ASSO":
 			// Known tags not yet parsed into typed fields
 
 		default:
@@ -840,7 +840,7 @@ func parseSource(record *gedcom.Record, collector *diagnosticCollector) *gedcom.
 			// Populate deprecated fields for backward compatibility.
 			src.RepositoryRef = src.RepositoryLink.XRef
 			src.Repository = src.RepositoryLink.Inline
-		case "NOTE":
+		case "NOTE", "SNOTE":
 			src.NoteXRefs, src.InlineNotes, src.Notes = appendRecordNote(record.Tags, i, src.NoteXRefs, src.InlineNotes, src.Notes)
 		case "OBJE":
 			link := parseMediaLink(record.Tags, i, tag.Level, collector)
@@ -855,7 +855,7 @@ func parseSource(record *gedcom.Record, collector *diagnosticCollector) *gedcom.
 			src.UID = tag.Value
 		case "EXID":
 			src.ExternalIDs = append(src.ExternalIDs, parseExternalID(record.Tags, i))
-		case "DATA", "ABBR", "SNOTE":
+		case "DATA", "ABBR":
 			// Known tags not yet parsed into typed fields
 		default:
 			if !strings.HasPrefix(tag.Tag, "_") {
@@ -1017,13 +1017,13 @@ func parseSubmitter(record *gedcom.Record, collector *diagnosticCollector) *gedc
 		case "LANG":
 			subm.Language = append(subm.Language, tag.Value)
 
-		case "NOTE":
+		case "NOTE", "SNOTE":
 			subm.NoteXRefs, subm.InlineNotes, subm.Notes = appendRecordNote(record.Tags, i, subm.NoteXRefs, subm.InlineNotes, subm.Notes)
 
 		case "EXID":
 			subm.ExternalIDs = append(subm.ExternalIDs, parseExternalID(record.Tags, i))
 
-		case "CHAN", "FAX", "WWW", "OBJE", "RIN", "UID", "SNOTE":
+		case "CHAN", "FAX", "WWW", "OBJE", "RIN", "UID":
 			// Known tags not yet parsed into typed fields
 
 		default:
@@ -1074,13 +1074,13 @@ func parseRepository(record *gedcom.Record, collector *diagnosticCollector) *ged
 			}
 			repo.Address.Website = tag.Value
 
-		case "NOTE":
+		case "NOTE", "SNOTE":
 			repo.NoteXRefs, repo.InlineNotes, repo.Notes = appendRecordNote(record.Tags, i, repo.NoteXRefs, repo.InlineNotes, repo.Notes)
 
 		case "EXID":
 			repo.ExternalIDs = append(repo.ExternalIDs, parseExternalID(record.Tags, i))
 
-		case "CHAN", "REFN", "UID", "SNOTE", "FAX":
+		case "CHAN", "REFN", "UID", "FAX":
 			// Known tags not yet parsed into typed fields
 
 		default:
@@ -1274,6 +1274,13 @@ func parseMediaObject(record *gedcom.Record, collector *diagnosticCollector) *ge
 			media.Files = append(media.Files, file)
 		case "NOTE":
 			media.NoteXRefs, media.InlineNotes, media.Notes = appendRecordNote(record.Tags, i, media.NoteXRefs, media.InlineNotes, media.Notes)
+		case "SNOTE":
+			// Route shared-note pointers through the split-note path so they
+			// reach the typed NoteXRefs API, the legacy Notes slice, and survive
+			// re-encode. Also track them in SharedNoteXRefs, which records the
+			// GEDCOM 7.0 SNOTE form used for version detection.
+			media.NoteXRefs, media.InlineNotes, media.Notes = appendRecordNote(record.Tags, i, media.NoteXRefs, media.InlineNotes, media.Notes)
+			media.SharedNoteXRefs = append(media.SharedNoteXRefs, tag.Value)
 		case "SOUR":
 			cite := parseSourceCitation(record.Tags, i, tag.Level, collector)
 			media.SourceCitations = append(media.SourceCitations, cite)
@@ -1289,8 +1296,6 @@ func parseMediaObject(record *gedcom.Record, collector *diagnosticCollector) *ge
 			media.Restriction = tag.Value
 		case "EXID":
 			media.ExternalIDs = append(media.ExternalIDs, parseExternalID(record.Tags, i))
-		case "SNOTE":
-			media.SharedNoteXRefs = append(media.SharedNoteXRefs, tag.Value)
 		default:
 			if !strings.HasPrefix(tag.Tag, "_") {
 				collector.addUnknownTag(tag.LineNumber, tag.Tag, tag.Value)

--- a/decoder/entity_test.go
+++ b/decoder/entity_test.go
@@ -2974,8 +2974,13 @@ func TestParseMediaObject_FullMetadata(t *testing.T) {
 		t.Errorf("media.SharedNoteXRefs[0] = %s, want @N1@", media.SharedNoteXRefs[0])
 	}
 
-	if len(media.Notes) != 1 {
-		t.Errorf("len(media.Notes) = %d, want 1", len(media.Notes))
+	// Notes holds the inline NOTE text plus the SNOTE pointer (routed through
+	// the split-note path), interleaved in original order.
+	if len(media.Notes) != 2 {
+		t.Errorf("len(media.Notes) = %d, want 2", len(media.Notes))
+	}
+	if len(media.NoteXRefs) != 1 || media.NoteXRefs[0] != "@N1@" {
+		t.Errorf("media.NoteXRefs = %#v, want [@N1@]", media.NoteXRefs)
 	}
 
 	if len(media.SourceCitations) != 1 {

--- a/decoder/note_split_test.go
+++ b/decoder/note_split_test.go
@@ -1,0 +1,150 @@
+package decoder
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// recordNotes is the common shape of the split note fields populated by
+// appendRecordNote, used to assert decode results across record types.
+type recordNotes struct {
+	xrefs  []string
+	inline []string
+	legacy []string
+}
+
+// TestDecodeRecordNoteSplit verifies that record-level NOTE tags are split into
+// NoteXRefs (pointer-shaped values) and InlineNotes (text values, with CONT/CONC
+// folded), while the deprecated combined Notes slice preserves the original
+// order for backward compatibility. It covers every note-bearing record type.
+func TestDecodeRecordNoteSplit(t *testing.T) {
+	const input = `0 HEAD
+1 GEDC
+2 VERS 7.0
+1 CHAR UTF-8
+0 @N1@ NOTE A shared note record
+0 @I1@ INDI
+1 NOTE Inline individual note
+1 NOTE @N1@
+1 NOTE Multi line note
+2 CONT second line
+2 CONC continued
+0 @F1@ FAM
+1 NOTE @N1@
+1 NOTE Inline family note
+0 @S1@ SOUR
+1 TITL A Source
+1 NOTE Inline source note
+1 NOTE @N1@
+0 @R1@ REPO
+1 NAME A Repository
+1 NOTE @N1@
+0 @SUB1@ SUBM
+1 NAME A Submitter
+1 NOTE Inline submitter note
+0 @O1@ OBJE
+1 FILE photo.jpg
+2 FORM image/jpeg
+1 NOTE Inline media note
+1 NOTE @N1@
+0 TRLR`
+
+	doc, err := Decode(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("Decode failed: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		got  recordNotes
+		want recordNotes
+	}{
+		{
+			name: "Individual splits inline, xref, and CONT/CONC",
+			got: func() recordNotes {
+				i := doc.GetIndividual("@I1@")
+				return recordNotes{i.NoteXRefs, i.InlineNotes, i.Notes}
+			}(),
+			want: recordNotes{
+				xrefs:  []string{"@N1@"},
+				inline: []string{"Inline individual note", "Multi line note\nsecond linecontinued"},
+				legacy: []string{"Inline individual note", "@N1@", "Multi line note\nsecond linecontinued"},
+			},
+		},
+		{
+			name: "Family xref before inline preserves order",
+			got: func() recordNotes {
+				f := doc.GetFamily("@F1@")
+				return recordNotes{f.NoteXRefs, f.InlineNotes, f.Notes}
+			}(),
+			want: recordNotes{
+				xrefs:  []string{"@N1@"},
+				inline: []string{"Inline family note"},
+				legacy: []string{"@N1@", "Inline family note"},
+			},
+		},
+		{
+			name: "Source inline before xref",
+			got: func() recordNotes {
+				s := doc.GetSource("@S1@")
+				return recordNotes{s.NoteXRefs, s.InlineNotes, s.Notes}
+			}(),
+			want: recordNotes{
+				xrefs:  []string{"@N1@"},
+				inline: []string{"Inline source note"},
+				legacy: []string{"Inline source note", "@N1@"},
+			},
+		},
+		{
+			name: "Repository xref only",
+			got: func() recordNotes {
+				r := doc.GetRepository("@R1@")
+				return recordNotes{r.NoteXRefs, r.InlineNotes, r.Notes}
+			}(),
+			want: recordNotes{
+				xrefs:  []string{"@N1@"},
+				inline: nil,
+				legacy: []string{"@N1@"},
+			},
+		},
+		{
+			name: "Submitter inline only",
+			got: func() recordNotes {
+				s := doc.GetSubmitter("@SUB1@")
+				return recordNotes{s.NoteXRefs, s.InlineNotes, s.Notes}
+			}(),
+			want: recordNotes{
+				xrefs:  nil,
+				inline: []string{"Inline submitter note"},
+				legacy: []string{"Inline submitter note"},
+			},
+		},
+		{
+			name: "MediaObject inline before xref",
+			got: func() recordNotes {
+				m := doc.GetMediaObject("@O1@")
+				return recordNotes{m.NoteXRefs, m.InlineNotes, m.Notes}
+			}(),
+			want: recordNotes{
+				xrefs:  []string{"@N1@"},
+				inline: []string{"Inline media note"},
+				legacy: []string{"Inline media note", "@N1@"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !reflect.DeepEqual(tt.got.xrefs, tt.want.xrefs) {
+				t.Errorf("NoteXRefs = %#v, want %#v", tt.got.xrefs, tt.want.xrefs)
+			}
+			if !reflect.DeepEqual(tt.got.inline, tt.want.inline) {
+				t.Errorf("InlineNotes = %#v, want %#v", tt.got.inline, tt.want.inline)
+			}
+			if !reflect.DeepEqual(tt.got.legacy, tt.want.legacy) {
+				t.Errorf("Notes = %#v, want %#v", tt.got.legacy, tt.want.legacy)
+			}
+		})
+	}
+}

--- a/decoder/note_split_test.go
+++ b/decoder/note_split_test.go
@@ -40,6 +40,7 @@ func TestDecodeRecordNoteSplit(t *testing.T) {
 0 @R1@ REPO
 1 NAME A Repository
 1 NOTE @N1@
+1 SNOTE @N1@
 0 @SUB1@ SUBM
 1 NAME A Submitter
 1 NOTE Inline submitter note
@@ -48,6 +49,7 @@ func TestDecodeRecordNoteSplit(t *testing.T) {
 2 FORM image/jpeg
 1 NOTE Inline media note
 1 NOTE @N1@
+1 SNOTE @N1@
 0 TRLR`
 
 	doc, err := Decode(strings.NewReader(input))
@@ -97,15 +99,15 @@ func TestDecodeRecordNoteSplit(t *testing.T) {
 			},
 		},
 		{
-			name: "Repository xref only",
+			name: "Repository routes NOTE and SNOTE xrefs through split path",
 			got: func() recordNotes {
 				r := doc.GetRepository("@R1@")
 				return recordNotes{r.NoteXRefs, r.InlineNotes, r.Notes}
 			}(),
 			want: recordNotes{
-				xrefs:  []string{"@N1@"},
+				xrefs:  []string{"@N1@", "@N1@"},
 				inline: nil,
-				legacy: []string{"@N1@"},
+				legacy: []string{"@N1@", "@N1@"},
 			},
 		},
 		{
@@ -121,15 +123,15 @@ func TestDecodeRecordNoteSplit(t *testing.T) {
 			},
 		},
 		{
-			name: "MediaObject inline before xref",
+			name: "MediaObject routes NOTE and SNOTE through split path",
 			got: func() recordNotes {
 				m := doc.GetMediaObject("@O1@")
 				return recordNotes{m.NoteXRefs, m.InlineNotes, m.Notes}
 			}(),
 			want: recordNotes{
-				xrefs:  []string{"@N1@"},
+				xrefs:  []string{"@N1@", "@N1@"},
 				inline: []string{"Inline media note"},
-				legacy: []string{"Inline media note", "@N1@"},
+				legacy: []string{"Inline media note", "@N1@", "@N1@"},
 			},
 		},
 	}
@@ -146,5 +148,11 @@ func TestDecodeRecordNoteSplit(t *testing.T) {
 				t.Errorf("Notes = %#v, want %#v", tt.got.legacy, tt.want.legacy)
 			}
 		})
+	}
+
+	// A media SNOTE is also tracked in SharedNoteXRefs (the GEDCOM 7.0 form used
+	// for version detection) in addition to the split-note path.
+	if got, want := doc.GetMediaObject("@O1@").SharedNoteXRefs, []string{"@N1@"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("MediaObject SharedNoteXRefs = %#v, want %#v", got, want)
 	}
 }

--- a/encoder/entity_writer.go
+++ b/encoder/entity_writer.go
@@ -55,14 +55,17 @@ func textToTags(value string, level int, tagName string, opts *EncodeOptions) []
 	return tags
 }
 
-// recordNotesToEncode returns the record-level NOTE values to emit, preferring
-// the split NoteXRefs/InlineNotes fields when either is populated and falling
-// back to the deprecated combined Notes slice otherwise. XRef pointers are
-// emitted first (as "NOTE @Nn@"), followed by inline note text. For documents
-// produced by the decoder the split fields and Notes carry the same values, so
-// this yields identical output; for hand-built documents that set only the
-// split fields it ensures their notes are still written.
+// recordNotesToEncode returns the record-level NOTE values to emit. The
+// deprecated combined Notes slice preserves the original GEDCOM order of
+// interleaved XRef pointers and inline notes, so it is preferred whenever it is
+// populated to keep round-trips lossless. Only when Notes is empty (a hand-built
+// document that set just the split fields) does this fall back to combining the
+// split NoteXRefs/InlineNotes fields, emitting XRef pointers first (as
+// "NOTE @Nn@") followed by inline note text.
 func recordNotesToEncode(noteXRefs, inlineNotes, notes []string) []string {
+	if len(notes) > 0 {
+		return notes
+	}
 	if len(noteXRefs) == 0 && len(inlineNotes) == 0 {
 		return notes
 	}
@@ -483,7 +486,7 @@ func submitterToTags(subm *gedcom.Submitter, opts *EncodeOptions) []*gedcom.Tag 
 	}
 
 	// Notes (level 1) - NOTE (with CONT/CONC for multiline/long)
-	for _, note := range subm.Notes {
+	for _, note := range recordNotesToEncode(subm.NoteXRefs, subm.InlineNotes, subm.Notes) {
 		tags = append(tags, textToTags(note, 1, "NOTE", opts)...)
 	}
 
@@ -505,7 +508,7 @@ func repositoryToTags(repo *gedcom.Repository, opts *EncodeOptions) []*gedcom.Ta
 	}
 
 	// Notes (level 1) - NOTE (with CONT/CONC for multiline/long)
-	for _, note := range repo.Notes {
+	for _, note := range recordNotesToEncode(repo.NoteXRefs, repo.InlineNotes, repo.Notes) {
 		tags = append(tags, textToTags(note, 1, "NOTE", opts)...)
 	}
 
@@ -534,7 +537,7 @@ func mediaObjectToTags(media *gedcom.MediaObject, opts *EncodeOptions) []*gedcom
 	}
 
 	// Notes (level 1) - NOTE (with CONT/CONC for multiline/long)
-	for _, note := range media.Notes {
+	for _, note := range recordNotesToEncode(media.NoteXRefs, media.InlineNotes, media.Notes) {
 		tags = append(tags, textToTags(note, 1, "NOTE", opts)...)
 	}
 

--- a/encoder/entity_writer.go
+++ b/encoder/entity_writer.go
@@ -55,6 +55,23 @@ func textToTags(value string, level int, tagName string, opts *EncodeOptions) []
 	return tags
 }
 
+// recordNotesToEncode returns the record-level NOTE values to emit, preferring
+// the split NoteXRefs/InlineNotes fields when either is populated and falling
+// back to the deprecated combined Notes slice otherwise. XRef pointers are
+// emitted first (as "NOTE @Nn@"), followed by inline note text. For documents
+// produced by the decoder the split fields and Notes carry the same values, so
+// this yields identical output; for hand-built documents that set only the
+// split fields it ensures their notes are still written.
+func recordNotesToEncode(noteXRefs, inlineNotes, notes []string) []string {
+	if len(noteXRefs) == 0 && len(inlineNotes) == 0 {
+		return notes
+	}
+	combined := make([]string, 0, len(noteXRefs)+len(inlineNotes))
+	combined = append(combined, noteXRefs...)
+	combined = append(combined, inlineNotes...)
+	return combined
+}
+
 // splitLineForLength splits a single line into segments that fit within MaxLineLength.
 // Returns a slice with at least one element (the original line if no splitting needed).
 // Attempts to split at word boundaries (spaces) when possible.
@@ -210,7 +227,7 @@ func individualToTags(indi *gedcom.Individual, opts *EncodeOptions) []*gedcom.Ta
 	}
 
 	// Notes (level 1) - NOTE (with CONT/CONC for multiline/long)
-	for _, note := range indi.Notes {
+	for _, note := range recordNotesToEncode(indi.NoteXRefs, indi.InlineNotes, indi.Notes) {
 		tags = append(tags, textToTags(note, 1, "NOTE", opts)...)
 	}
 
@@ -289,7 +306,7 @@ func familyToTags(fam *gedcom.Family, opts *EncodeOptions) []*gedcom.Tag {
 	}
 
 	// Notes (level 1) - NOTE (with CONT/CONC for multiline/long)
-	for _, note := range fam.Notes {
+	for _, note := range recordNotesToEncode(fam.NoteXRefs, fam.InlineNotes, fam.Notes) {
 		tags = append(tags, textToTags(note, 1, "NOTE", opts)...)
 	}
 
@@ -365,7 +382,7 @@ func sourceToTags(src *gedcom.Source, opts *EncodeOptions) []*gedcom.Tag {
 	}
 
 	// Notes (level 1) - NOTE (with CONT/CONC for multiline/long)
-	for _, note := range src.Notes {
+	for _, note := range recordNotesToEncode(src.NoteXRefs, src.InlineNotes, src.Notes) {
 		tags = append(tags, textToTags(note, 1, "NOTE", opts)...)
 	}
 

--- a/encoder/entity_writer.go
+++ b/encoder/entity_writer.go
@@ -57,13 +57,17 @@ func textToTags(value string, level int, tagName string, opts *EncodeOptions) []
 
 // recordNotesToEncode returns the record-level NOTE values to emit. The
 // deprecated combined Notes slice preserves the original GEDCOM order of
-// interleaved XRef pointers and inline notes, so it is preferred whenever it is
-// populated to keep round-trips lossless. Only when Notes is empty (a hand-built
-// document that set just the split fields) does this fall back to combining the
-// split NoteXRefs/InlineNotes fields, emitting XRef pointers first (as
-// "NOTE @Nn@") followed by inline note text.
+// interleaved XRef pointers and inline notes, so it is authoritative only while
+// the split NoteXRefs/InlineNotes fields still match what that Notes slice
+// decoded into. This keeps decoded round-trips lossless without letting the
+// deprecated slice shadow edits made through the typed split fields.
+//
+// When the split fields diverge from Notes (a hand-built document, or a caller
+// that edited NoteXRefs/InlineNotes after decode), this encodes from the split
+// fields instead, emitting XRef pointers first (as "NOTE @Nn@") followed by
+// inline note text.
 func recordNotesToEncode(noteXRefs, inlineNotes, notes []string) []string {
-	if len(notes) > 0 {
+	if len(notes) > 0 && splitMatchesNotes(noteXRefs, inlineNotes, notes) {
 		return notes
 	}
 	if len(noteXRefs) == 0 && len(inlineNotes) == 0 {
@@ -73,6 +77,33 @@ func recordNotesToEncode(noteXRefs, inlineNotes, notes []string) []string {
 	combined = append(combined, noteXRefs...)
 	combined = append(combined, inlineNotes...)
 	return combined
+}
+
+// splitMatchesNotes reports whether the split NoteXRefs/InlineNotes fields are
+// exactly the partition that decoding the legacy Notes slice would produce:
+// pointer-shaped entries become XRefs and the rest become inline text, each in
+// original order. When true, Notes still reflects the split fields and can be
+// emitted as-is to preserve interleaved order; when false, the split fields have
+// diverged and must be encoded instead.
+func splitMatchesNotes(noteXRefs, inlineNotes, notes []string) bool {
+	if len(noteXRefs)+len(inlineNotes) != len(notes) {
+		return false
+	}
+	var xi, ii int
+	for _, note := range notes {
+		if gedcom.IsPointerXRef(note) {
+			if xi >= len(noteXRefs) || noteXRefs[xi] != note {
+				return false
+			}
+			xi++
+		} else {
+			if ii >= len(inlineNotes) || inlineNotes[ii] != note {
+				return false
+			}
+			ii++
+		}
+	}
+	return xi == len(noteXRefs) && ii == len(inlineNotes)
 }
 
 // splitLineForLength splits a single line into segments that fit within MaxLineLength.

--- a/encoder/note_split_test.go
+++ b/encoder/note_split_test.go
@@ -32,6 +32,20 @@ func TestRecordNotesToEncode(t *testing.T) {
 			want:      []string{"@N1@", "first inline", "@N2@", "second inline"},
 		},
 		{
+			name:      "edited split fields override stale legacy Notes",
+			noteXRefs: []string{"@N1@"},
+			inline:    []string{"edited inline"},
+			notes:     []string{"@N1@", "original inline"},
+			want:      []string{"@N1@", "edited inline"},
+		},
+		{
+			name:      "added xref not in legacy Notes encodes from split fields",
+			noteXRefs: []string{"@N1@", "@N2@"},
+			inline:    []string{"first inline"},
+			notes:     []string{"@N1@", "first inline"},
+			want:      []string{"@N1@", "@N2@", "first inline"},
+		},
+		{
 			name:      "combines split fields when legacy Notes empty",
 			noteXRefs: []string{"@N1@", "@N2@"},
 			inline:    []string{"first inline", "second inline"},
@@ -97,11 +111,26 @@ func noteTagValues(tags []*gedcom.Tag) []string {
 	return out
 }
 
-// TestSubmitterRepositoryMediaNoteSplit confirms Submitter, Repository, and
-// MediaObject records built with only the split note fields still emit NOTE
-// tags for both the XRef pointer and inline text.
-func TestSubmitterRepositoryMediaNoteSplit(t *testing.T) {
+// TestRecordTypesNoteSplit confirms every note-bearing record type built with
+// only the split note fields still emits NOTE tags for both the XRef pointer and
+// inline text. It covers all six record types whose NOTE emission was changed.
+func TestRecordTypesNoteSplit(t *testing.T) {
 	want := []string{"@N1@", "An inline note"}
+
+	indi := &gedcom.Individual{NoteXRefs: []string{"@N1@"}, InlineNotes: []string{"An inline note"}}
+	if got := noteTagValues(individualToTags(indi, nil)); !reflect.DeepEqual(got, want) {
+		t.Errorf("individualToTags() NOTE values = %#v, want %#v", got, want)
+	}
+
+	fam := &gedcom.Family{NoteXRefs: []string{"@N1@"}, InlineNotes: []string{"An inline note"}}
+	if got := noteTagValues(familyToTags(fam, nil)); !reflect.DeepEqual(got, want) {
+		t.Errorf("familyToTags() NOTE values = %#v, want %#v", got, want)
+	}
+
+	src := &gedcom.Source{NoteXRefs: []string{"@N1@"}, InlineNotes: []string{"An inline note"}}
+	if got := noteTagValues(sourceToTags(src, nil)); !reflect.DeepEqual(got, want) {
+		t.Errorf("sourceToTags() NOTE values = %#v, want %#v", got, want)
+	}
 
 	subm := &gedcom.Submitter{NoteXRefs: []string{"@N1@"}, InlineNotes: []string{"An inline note"}}
 	if got := noteTagValues(submitterToTags(subm, nil)); !reflect.DeepEqual(got, want) {

--- a/encoder/note_split_test.go
+++ b/encoder/note_split_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/cacack/gedcom-go/v2/gedcom"
 )
 
-// TestRecordNotesToEncode verifies the encoder prefers the split
-// NoteXRefs/InlineNotes fields (emitting XRefs first, then inline text) and
-// falls back to the deprecated combined Notes slice only when both split fields
-// are empty.
+// TestRecordNotesToEncode verifies the encoder prefers the order-preserving
+// legacy Notes slice whenever it is populated (keeping round-trips lossless),
+// and only combines the split NoteXRefs/InlineNotes fields (XRefs first, then
+// inline text) when Notes is empty.
 func TestRecordNotesToEncode(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -20,27 +20,31 @@ func TestRecordNotesToEncode(t *testing.T) {
 		want      []string
 	}{
 		{
-			name:  "falls back to legacy Notes when split fields empty",
+			name:  "uses legacy Notes when split fields empty",
 			notes: []string{"@N1@", "inline text"},
 			want:  []string{"@N1@", "inline text"},
 		},
 		{
-			name:      "split fields preferred, xrefs before inline",
+			name:      "legacy Notes preserves original interleaved order",
 			noteXRefs: []string{"@N1@", "@N2@"},
 			inline:    []string{"first inline", "second inline"},
-			notes:     []string{"ignored legacy value"},
+			notes:     []string{"@N1@", "first inline", "@N2@", "second inline"},
+			want:      []string{"@N1@", "first inline", "@N2@", "second inline"},
+		},
+		{
+			name:      "combines split fields when legacy Notes empty",
+			noteXRefs: []string{"@N1@", "@N2@"},
+			inline:    []string{"first inline", "second inline"},
 			want:      []string{"@N1@", "@N2@", "first inline", "second inline"},
 		},
 		{
-			name:      "only xrefs populated",
+			name:      "only xrefs populated, no legacy",
 			noteXRefs: []string{"@N1@"},
-			notes:     []string{"ignored"},
 			want:      []string{"@N1@"},
 		},
 		{
-			name:   "only inline populated",
+			name:   "only inline populated, no legacy",
 			inline: []string{"just inline"},
-			notes:  []string{"ignored"},
 			want:   []string{"just inline"},
 		},
 		{
@@ -79,5 +83,56 @@ func TestIndividualToTagsNoteSplit(t *testing.T) {
 	want := []string{"@N1@", "An inline note"}
 	if !reflect.DeepEqual(noteValues, want) {
 		t.Errorf("individualToTags() NOTE values = %#v, want %#v", noteValues, want)
+	}
+}
+
+// noteTagValues returns the Value of each top-level NOTE tag in order.
+func noteTagValues(tags []*gedcom.Tag) []string {
+	var out []string
+	for _, tag := range tags {
+		if tag.Tag == "NOTE" {
+			out = append(out, tag.Value)
+		}
+	}
+	return out
+}
+
+// TestSubmitterRepositoryMediaNoteSplit confirms Submitter, Repository, and
+// MediaObject records built with only the split note fields still emit NOTE
+// tags for both the XRef pointer and inline text.
+func TestSubmitterRepositoryMediaNoteSplit(t *testing.T) {
+	want := []string{"@N1@", "An inline note"}
+
+	subm := &gedcom.Submitter{NoteXRefs: []string{"@N1@"}, InlineNotes: []string{"An inline note"}}
+	if got := noteTagValues(submitterToTags(subm, nil)); !reflect.DeepEqual(got, want) {
+		t.Errorf("submitterToTags() NOTE values = %#v, want %#v", got, want)
+	}
+
+	repo := &gedcom.Repository{NoteXRefs: []string{"@N1@"}, InlineNotes: []string{"An inline note"}}
+	if got := noteTagValues(repositoryToTags(repo, nil)); !reflect.DeepEqual(got, want) {
+		t.Errorf("repositoryToTags() NOTE values = %#v, want %#v", got, want)
+	}
+
+	media := &gedcom.MediaObject{NoteXRefs: []string{"@N1@"}, InlineNotes: []string{"An inline note"}}
+	if got := noteTagValues(mediaObjectToTags(media, nil)); !reflect.DeepEqual(got, want) {
+		t.Errorf("mediaObjectToTags() NOTE values = %#v, want %#v", got, want)
+	}
+}
+
+// TestNoteOrderPreservedFromLegacy confirms that when the legacy Notes slice is
+// populated (as it always is for decoded documents), the encoder emits notes in
+// that original interleaved order rather than reordering xrefs ahead of inline
+// text. This guards the lossless round-trip of interleaved record notes.
+func TestNoteOrderPreservedFromLegacy(t *testing.T) {
+	indi := &gedcom.Individual{
+		NoteXRefs:   []string{"@N1@", "@N2@"},
+		InlineNotes: []string{"inline text"},
+		Notes:       []string{"@N1@", "inline text", "@N2@"},
+	}
+
+	got := noteTagValues(individualToTags(indi, nil))
+	want := []string{"@N1@", "inline text", "@N2@"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("individualToTags() NOTE order = %#v, want %#v", got, want)
 	}
 }

--- a/encoder/note_split_test.go
+++ b/encoder/note_split_test.go
@@ -1,0 +1,83 @@
+package encoder
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/cacack/gedcom-go/v2/gedcom"
+)
+
+// TestRecordNotesToEncode verifies the encoder prefers the split
+// NoteXRefs/InlineNotes fields (emitting XRefs first, then inline text) and
+// falls back to the deprecated combined Notes slice only when both split fields
+// are empty.
+func TestRecordNotesToEncode(t *testing.T) {
+	tests := []struct {
+		name      string
+		noteXRefs []string
+		inline    []string
+		notes     []string
+		want      []string
+	}{
+		{
+			name:  "falls back to legacy Notes when split fields empty",
+			notes: []string{"@N1@", "inline text"},
+			want:  []string{"@N1@", "inline text"},
+		},
+		{
+			name:      "split fields preferred, xrefs before inline",
+			noteXRefs: []string{"@N1@", "@N2@"},
+			inline:    []string{"first inline", "second inline"},
+			notes:     []string{"ignored legacy value"},
+			want:      []string{"@N1@", "@N2@", "first inline", "second inline"},
+		},
+		{
+			name:      "only xrefs populated",
+			noteXRefs: []string{"@N1@"},
+			notes:     []string{"ignored"},
+			want:      []string{"@N1@"},
+		},
+		{
+			name:   "only inline populated",
+			inline: []string{"just inline"},
+			notes:  []string{"ignored"},
+			want:   []string{"just inline"},
+		},
+		{
+			name: "all empty returns nil legacy",
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := recordNotesToEncode(tt.noteXRefs, tt.inline, tt.notes)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("recordNotesToEncode() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIndividualToTagsNoteSplit confirms an individual built with only the split
+// note fields still emits NOTE tags for both the XRef pointer and inline text.
+func TestIndividualToTagsNoteSplit(t *testing.T) {
+	indi := &gedcom.Individual{
+		NoteXRefs:   []string{"@N1@"},
+		InlineNotes: []string{"An inline note"},
+	}
+
+	tags := individualToTags(indi, nil)
+
+	var noteValues []string
+	for _, tag := range tags {
+		if tag.Tag == "NOTE" {
+			noteValues = append(noteValues, tag.Value)
+		}
+	}
+
+	want := []string{"@N1@", "An inline note"}
+	if !reflect.DeepEqual(noteValues, want) {
+		t.Errorf("individualToTags() NOTE values = %#v, want %#v", noteValues, want)
+	}
+}

--- a/gedcom/family.go
+++ b/gedcom/family.go
@@ -23,7 +23,18 @@ type Family struct {
 	// SourceCitations are source citations with page/quality details
 	SourceCitations []*SourceCitation
 
-	// Notes are references to note records
+	// NoteXRefs are XRef pointers to shared NOTE/SNOTE records (e.g. "@N1@").
+	NoteXRefs []string
+
+	// InlineNotes are note text values written directly on this record
+	// (1 NOTE <text> form, including CONT/CONC continuations).
+	InlineNotes []string
+
+	// Notes is deprecated: use NoteXRefs and InlineNotes instead. It is kept
+	// for backward compatibility and populated during decode as the
+	// concatenation NoteXRefs + InlineNotes.
+	//
+	// Deprecated: use NoteXRefs and InlineNotes.
 	Notes []string
 
 	// Media are references to media objects with optional crop/title
@@ -50,6 +61,13 @@ type Family struct {
 
 	// Tags contains all raw tags for this family (for unknown/custom tags)
 	Tags []*Tag
+}
+
+// AllNotes returns this family's inline notes followed by the text of any
+// shared notes referenced by NoteXRefs, resolved against doc. Shared notes that
+// do not resolve are skipped. Returns nil when there are no notes.
+func (f *Family) AllNotes(doc *Document) []string {
+	return allNotes(doc, f.InlineNotes, f.NoteXRefs)
 }
 
 // HusbandIndividual returns the Individual record for the husband.

--- a/gedcom/family.go
+++ b/gedcom/family.go
@@ -31,8 +31,9 @@ type Family struct {
 	InlineNotes []string
 
 	// Notes is deprecated: use NoteXRefs and InlineNotes instead. It is kept
-	// for backward compatibility and populated during decode as the
-	// concatenation NoteXRefs + InlineNotes.
+	// for backward compatibility and populated during decode with the inline
+	// note text and shared-note XRefs interleaved in their original GEDCOM
+	// order (not the NoteXRefs-then-InlineNotes order of the split fields).
 	//
 	// Deprecated: use NoteXRefs and InlineNotes.
 	Notes []string

--- a/gedcom/individual.go
+++ b/gedcom/individual.go
@@ -37,11 +37,12 @@ type Individual struct {
 	InlineNotes []string
 
 	// Notes is deprecated: use NoteXRefs and InlineNotes instead. It is kept
-	// for backward compatibility and populated during decode as the
-	// concatenation NoteXRefs + InlineNotes.
+	// for backward compatibility and populated during decode with the inline
+	// note text and shared-note XRefs interleaved in their original GEDCOM
+	// order (not the NoteXRefs-then-InlineNotes order of the split fields).
 	//
 	// Deprecated: use NoteXRefs and InlineNotes.
-	Notes []string // XRef to Note records
+	Notes []string
 
 	// Media are references to media objects with optional crop/title
 	Media []*MediaLink

--- a/gedcom/individual.go
+++ b/gedcom/individual.go
@@ -29,7 +29,18 @@ type Individual struct {
 	// SourceCitations are source citations with page/quality details
 	SourceCitations []*SourceCitation
 
-	// Notes are references to note records
+	// NoteXRefs are XRef pointers to shared NOTE/SNOTE records (e.g. "@N1@").
+	NoteXRefs []string
+
+	// InlineNotes are note text values written directly on this record
+	// (1 NOTE <text> form, including CONT/CONC continuations).
+	InlineNotes []string
+
+	// Notes is deprecated: use NoteXRefs and InlineNotes instead. It is kept
+	// for backward compatibility and populated during decode as the
+	// concatenation NoteXRefs + InlineNotes.
+	//
+	// Deprecated: use NoteXRefs and InlineNotes.
 	Notes []string // XRef to Note records
 
 	// Media are references to media objects with optional crop/title
@@ -61,6 +72,13 @@ type Individual struct {
 
 	// Tags contains all raw tags for this individual (for unknown/custom tags)
 	Tags []*Tag
+}
+
+// AllNotes returns this individual's inline notes followed by the text of any
+// shared notes referenced by NoteXRefs, resolved against doc. Shared notes that
+// do not resolve are skipped. Returns nil when there are no notes.
+func (i *Individual) AllNotes(doc *Document) []string {
+	return allNotes(doc, i.InlineNotes, i.NoteXRefs)
 }
 
 // PersonalName represents a person's name with optional components.

--- a/gedcom/media.go
+++ b/gedcom/media.go
@@ -104,10 +104,29 @@ type MediaObject struct {
 }
 
 // AllNotes returns this media object's inline notes followed by the text of any
-// shared notes referenced by NoteXRefs, resolved against doc. Shared notes that
-// do not resolve are skipped. Returns nil when there are no notes.
+// shared notes referenced by NoteXRefs, resolved against doc. SharedNoteXRefs
+// entries (GEDCOM 7.0 SNOTE pointers) that are not already present in NoteXRefs
+// are included as well, so shared notes are never dropped. Shared notes that do
+// not resolve are skipped. Returns nil when there are no notes.
 func (m *MediaObject) AllNotes(doc *Document) []string {
-	return allNotes(doc, m.InlineNotes, m.NoteXRefs)
+	xrefs := make([]string, len(m.NoteXRefs), len(m.NoteXRefs)+len(m.SharedNoteXRefs))
+	copy(xrefs, m.NoteXRefs)
+	for _, sx := range m.SharedNoteXRefs {
+		if !containsString(xrefs, sx) {
+			xrefs = append(xrefs, sx)
+		}
+	}
+	return allNotes(doc, m.InlineNotes, xrefs)
+}
+
+// containsString reports whether s is present in xs.
+func containsString(xs []string, s string) bool {
+	for _, x := range xs {
+		if x == s {
+			return true
+		}
+	}
+	return false
 }
 
 // MediaTranslation represents an alternate version of a file (GEDCOM 7.0 FILE-TRAN).

--- a/gedcom/media.go
+++ b/gedcom/media.go
@@ -60,7 +60,20 @@ type MediaObject struct {
 	// Files contains 1:M file references (required, at least one)
 	Files []*MediaFile
 
-	// Notes are references to note records
+	// NoteXRefs are XRef pointers to shared NOTE/SNOTE records (e.g. "@N1@")
+	// carried by NOTE tags. SNOTE pointers are tracked separately in
+	// SharedNoteXRefs.
+	NoteXRefs []string
+
+	// InlineNotes are note text values written directly on this record
+	// (1 NOTE <text> form, including CONT/CONC continuations).
+	InlineNotes []string
+
+	// Notes is deprecated: use NoteXRefs and InlineNotes instead. It is kept
+	// for backward compatibility and populated during decode as the
+	// concatenation NoteXRefs + InlineNotes.
+	//
+	// Deprecated: use NoteXRefs and InlineNotes.
 	Notes []string
 
 	// RefNumbers are user reference numbers (REFN tag, can have multiple)
@@ -87,6 +100,13 @@ type MediaObject struct {
 
 	// XRef is the cross-reference identifier for this media object
 	XRef string
+}
+
+// AllNotes returns this media object's inline notes followed by the text of any
+// shared notes referenced by NoteXRefs, resolved against doc. Shared notes that
+// do not resolve are skipped. Returns nil when there are no notes.
+func (m *MediaObject) AllNotes(doc *Document) []string {
+	return allNotes(doc, m.InlineNotes, m.NoteXRefs)
 }
 
 // MediaTranslation represents an alternate version of a file (GEDCOM 7.0 FILE-TRAN).

--- a/gedcom/media.go
+++ b/gedcom/media.go
@@ -70,8 +70,9 @@ type MediaObject struct {
 	InlineNotes []string
 
 	// Notes is deprecated: use NoteXRefs and InlineNotes instead. It is kept
-	// for backward compatibility and populated during decode as the
-	// concatenation NoteXRefs + InlineNotes.
+	// for backward compatibility and populated during decode with the inline
+	// note text and shared-note XRefs interleaved in their original GEDCOM
+	// order (not the NoteXRefs-then-InlineNotes order of the split fields).
 	//
 	// Deprecated: use NoteXRefs and InlineNotes.
 	Notes []string

--- a/gedcom/notes.go
+++ b/gedcom/notes.go
@@ -33,5 +33,8 @@ func allNotes(doc *Document, inline, xrefs []string) []string {
 			result = append(result, text)
 		}
 	}
+	if len(result) == 0 {
+		return nil
+	}
 	return result
 }

--- a/gedcom/notes.go
+++ b/gedcom/notes.go
@@ -1,0 +1,37 @@
+package gedcom
+
+// resolveSharedNoteText returns the text of the NOTE or SNOTE record that xref
+// points to. NOTE records contribute their full text (including CONT/CONC
+// continuations); SNOTE records contribute their text. The bool reports whether
+// the XRef resolved to a known note record.
+func resolveSharedNoteText(doc *Document, xref string) (string, bool) {
+	if doc == nil {
+		return "", false
+	}
+	if note := doc.GetNote(xref); note != nil {
+		return note.FullText(), true
+	}
+	if snote := doc.GetSharedNote(xref); snote != nil {
+		return snote.Text, true
+	}
+	return "", false
+}
+
+// allNotes combines a record's inline note text with the resolved text of any
+// shared notes referenced by XRef. Shared notes that do not resolve against doc
+// are skipped. Inline notes are returned first, in order, followed by resolved
+// XRef notes in order. This backs the AllNotes method on each note-bearing
+// record type.
+func allNotes(doc *Document, inline, xrefs []string) []string {
+	if len(inline) == 0 && len(xrefs) == 0 {
+		return nil
+	}
+	result := make([]string, 0, len(inline)+len(xrefs))
+	result = append(result, inline...)
+	for _, xref := range xrefs {
+		if text, ok := resolveSharedNoteText(doc, xref); ok {
+			result = append(result, text)
+		}
+	}
+	return result
+}

--- a/gedcom/notes_test.go
+++ b/gedcom/notes_test.go
@@ -122,6 +122,11 @@ func TestAllNotes(t *testing.T) {
 			xrefs:  []string{"@MISSING@", "@N1@"},
 			want:   []string{"keep", "Shared note line 1\nline 2"},
 		},
+		{
+			name:  "all xrefs unresolved with no inline returns nil",
+			xrefs: []string{"@MISSING@", "@ALSO_MISSING@"},
+			want:  nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/gedcom/notes_test.go
+++ b/gedcom/notes_test.go
@@ -1,0 +1,198 @@
+package gedcom
+
+import (
+	"reflect"
+	"testing"
+)
+
+// noteDoc builds a Document with one NOTE record (@N1@, multi-line) and one
+// SNOTE record (@S1@) for resolution tests.
+func noteDoc() *Document {
+	noteRec := &Record{
+		XRef: "@N1@",
+		Type: RecordTypeNote,
+		Entity: &Note{
+			XRef:         "@N1@",
+			Text:         "Shared note line 1",
+			Continuation: []string{"line 2"},
+		},
+	}
+	snoteRec := &Record{
+		XRef: "@S1@",
+		Type: RecordTypeSharedNote,
+		Entity: &SharedNote{
+			XRef: "@S1@",
+			Text: "A shared SNOTE",
+		},
+	}
+	return &Document{
+		Records: []*Record{noteRec, snoteRec},
+		XRefMap: map[string]*Record{
+			"@N1@": noteRec,
+			"@S1@": snoteRec,
+		},
+	}
+}
+
+func TestResolveSharedNoteText(t *testing.T) {
+	doc := noteDoc()
+
+	tests := []struct {
+		name     string
+		doc      *Document
+		xref     string
+		wantText string
+		wantOK   bool
+	}{
+		{
+			name:     "resolves NOTE record with continuation",
+			doc:      doc,
+			xref:     "@N1@",
+			wantText: "Shared note line 1\nline 2",
+			wantOK:   true,
+		},
+		{
+			name:     "resolves SNOTE record",
+			doc:      doc,
+			xref:     "@S1@",
+			wantText: "A shared SNOTE",
+			wantOK:   true,
+		},
+		{
+			name:     "unknown xref does not resolve",
+			doc:      doc,
+			xref:     "@N99@",
+			wantText: "",
+			wantOK:   false,
+		},
+		{
+			name:     "nil document does not resolve",
+			doc:      nil,
+			xref:     "@N1@",
+			wantText: "",
+			wantOK:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			text, ok := resolveSharedNoteText(tt.doc, tt.xref)
+			if ok != tt.wantOK {
+				t.Fatalf("resolveSharedNoteText() ok = %v, want %v", ok, tt.wantOK)
+			}
+			if text != tt.wantText {
+				t.Errorf("resolveSharedNoteText() text = %q, want %q", text, tt.wantText)
+			}
+		})
+	}
+}
+
+func TestAllNotes(t *testing.T) {
+	doc := noteDoc()
+
+	tests := []struct {
+		name   string
+		inline []string
+		xrefs  []string
+		want   []string
+	}{
+		{
+			name: "no notes returns nil",
+			want: nil,
+		},
+		{
+			name:   "inline only, in order",
+			inline: []string{"first", "second"},
+			want:   []string{"first", "second"},
+		},
+		{
+			name:  "xrefs only, resolved in order",
+			xrefs: []string{"@N1@", "@S1@"},
+			want:  []string{"Shared note line 1\nline 2", "A shared SNOTE"},
+		},
+		{
+			name:   "inline first then resolved xrefs",
+			inline: []string{"inline note"},
+			xrefs:  []string{"@S1@"},
+			want:   []string{"inline note", "A shared SNOTE"},
+		},
+		{
+			name:   "unresolved xref is skipped",
+			inline: []string{"keep"},
+			xrefs:  []string{"@MISSING@", "@N1@"},
+			want:   []string{"keep", "Shared note line 1\nline 2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := allNotes(doc, tt.inline, tt.xrefs)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("allNotes() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRecordAllNotes exercises the AllNotes method on each note-bearing record
+// type, confirming they all delegate to allNotes with the same semantics.
+func TestRecordAllNotes(t *testing.T) {
+	doc := noteDoc()
+	want := []string{"inline", "A shared SNOTE"}
+
+	tests := []struct {
+		name string
+		got  []string
+	}{
+		{
+			name: "Individual",
+			got: (&Individual{
+				InlineNotes: []string{"inline"},
+				NoteXRefs:   []string{"@S1@"},
+			}).AllNotes(doc),
+		},
+		{
+			name: "Family",
+			got: (&Family{
+				InlineNotes: []string{"inline"},
+				NoteXRefs:   []string{"@S1@"},
+			}).AllNotes(doc),
+		},
+		{
+			name: "Source",
+			got: (&Source{
+				InlineNotes: []string{"inline"},
+				NoteXRefs:   []string{"@S1@"},
+			}).AllNotes(doc),
+		},
+		{
+			name: "Repository",
+			got: (&Repository{
+				InlineNotes: []string{"inline"},
+				NoteXRefs:   []string{"@S1@"},
+			}).AllNotes(doc),
+		},
+		{
+			name: "Submitter",
+			got: (&Submitter{
+				InlineNotes: []string{"inline"},
+				NoteXRefs:   []string{"@S1@"},
+			}).AllNotes(doc),
+		},
+		{
+			name: "MediaObject",
+			got: (&MediaObject{
+				InlineNotes: []string{"inline"},
+				NoteXRefs:   []string{"@S1@"},
+			}).AllNotes(doc),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !reflect.DeepEqual(tt.got, want) {
+				t.Errorf("%s.AllNotes() = %#v, want %#v", tt.name, tt.got, want)
+			}
+		})
+	}
+}

--- a/gedcom/repository.go
+++ b/gedcom/repository.go
@@ -19,8 +19,9 @@ type Repository struct {
 	InlineNotes []string
 
 	// Notes is deprecated: use NoteXRefs and InlineNotes instead. It is kept
-	// for backward compatibility and populated during decode as the
-	// concatenation NoteXRefs + InlineNotes.
+	// for backward compatibility and populated during decode with the inline
+	// note text and shared-note XRefs interleaved in their original GEDCOM
+	// order (not the NoteXRefs-then-InlineNotes order of the split fields).
 	//
 	// Deprecated: use NoteXRefs and InlineNotes.
 	Notes []string

--- a/gedcom/repository.go
+++ b/gedcom/repository.go
@@ -11,7 +11,18 @@ type Repository struct {
 	// Address is the physical address
 	Address *Address
 
-	// Notes are references to note records
+	// NoteXRefs are XRef pointers to shared NOTE/SNOTE records (e.g. "@N1@").
+	NoteXRefs []string
+
+	// InlineNotes are note text values written directly on this record
+	// (1 NOTE <text> form, including CONT/CONC continuations).
+	InlineNotes []string
+
+	// Notes is deprecated: use NoteXRefs and InlineNotes instead. It is kept
+	// for backward compatibility and populated during decode as the
+	// concatenation NoteXRefs + InlineNotes.
+	//
+	// Deprecated: use NoteXRefs and InlineNotes.
 	Notes []string
 
 	// ExternalIDs are external identifiers (EXID tags, GEDCOM 7.0).
@@ -20,6 +31,13 @@ type Repository struct {
 
 	// Tags contains all raw tags for this repository (for unknown/custom tags)
 	Tags []*Tag
+}
+
+// AllNotes returns this repository's inline notes followed by the text of any
+// shared notes referenced by NoteXRefs, resolved against doc. Shared notes that
+// do not resolve are skipped. Returns nil when there are no notes.
+func (r *Repository) AllNotes(doc *Document) []string {
+	return allNotes(doc, r.InlineNotes, r.NoteXRefs)
 }
 
 // InlineRepository represents an inline repository definition within a Source.

--- a/gedcom/source.go
+++ b/gedcom/source.go
@@ -41,7 +41,18 @@ type Source struct {
 	// Media are references to media objects with optional crop/title
 	Media []*MediaLink
 
-	// Notes are references to note records
+	// NoteXRefs are XRef pointers to shared NOTE/SNOTE records (e.g. "@N1@").
+	NoteXRefs []string
+
+	// InlineNotes are note text values written directly on this record
+	// (1 NOTE <text> form, including CONT/CONC continuations).
+	InlineNotes []string
+
+	// Notes is deprecated: use NoteXRefs and InlineNotes instead. It is kept
+	// for backward compatibility and populated during decode as the
+	// concatenation NoteXRefs + InlineNotes.
+	//
+	// Deprecated: use NoteXRefs and InlineNotes.
 	Notes []string
 
 	// ChangeDate is when the record was last modified (CHAN tag)
@@ -62,6 +73,13 @@ type Source struct {
 
 	// Tags contains all raw tags for this source (for unknown/custom tags)
 	Tags []*Tag
+}
+
+// AllNotes returns this source's inline notes followed by the text of any
+// shared notes referenced by NoteXRefs, resolved against doc. Shared notes that
+// do not resolve are skipped. Returns nil when there are no notes.
+func (s *Source) AllNotes(doc *Document) []string {
+	return allNotes(doc, s.InlineNotes, s.NoteXRefs)
 }
 
 // SourceCitationData represents extracted text and date from a source citation.

--- a/gedcom/source.go
+++ b/gedcom/source.go
@@ -49,8 +49,9 @@ type Source struct {
 	InlineNotes []string
 
 	// Notes is deprecated: use NoteXRefs and InlineNotes instead. It is kept
-	// for backward compatibility and populated during decode as the
-	// concatenation NoteXRefs + InlineNotes.
+	// for backward compatibility and populated during decode with the inline
+	// note text and shared-note XRefs interleaved in their original GEDCOM
+	// order (not the NoteXRefs-then-InlineNotes order of the split fields).
 	//
 	// Deprecated: use NoteXRefs and InlineNotes.
 	Notes []string

--- a/gedcom/submitter.go
+++ b/gedcom/submitter.go
@@ -22,7 +22,18 @@ type Submitter struct {
 	// Language contains preferred languages (can have multiple)
 	Language []string
 
-	// Notes are references to note records
+	// NoteXRefs are XRef pointers to shared NOTE/SNOTE records (e.g. "@N1@").
+	NoteXRefs []string
+
+	// InlineNotes are note text values written directly on this record
+	// (1 NOTE <text> form, including CONT/CONC continuations).
+	InlineNotes []string
+
+	// Notes is deprecated: use NoteXRefs and InlineNotes instead. It is kept
+	// for backward compatibility and populated during decode as the
+	// concatenation NoteXRefs + InlineNotes.
+	//
+	// Deprecated: use NoteXRefs and InlineNotes.
 	Notes []string
 
 	// ExternalIDs are external identifiers (EXID tags, GEDCOM 7.0).
@@ -31,4 +42,11 @@ type Submitter struct {
 
 	// Tags contains all raw tags for this submitter (for unknown/custom tags)
 	Tags []*Tag
+}
+
+// AllNotes returns this submitter's inline notes followed by the text of any
+// shared notes referenced by NoteXRefs, resolved against doc. Shared notes that
+// do not resolve are skipped. Returns nil when there are no notes.
+func (s *Submitter) AllNotes(doc *Document) []string {
+	return allNotes(doc, s.InlineNotes, s.NoteXRefs)
 }

--- a/gedcom/submitter.go
+++ b/gedcom/submitter.go
@@ -30,8 +30,9 @@ type Submitter struct {
 	InlineNotes []string
 
 	// Notes is deprecated: use NoteXRefs and InlineNotes instead. It is kept
-	// for backward compatibility and populated during decode as the
-	// concatenation NoteXRefs + InlineNotes.
+	// for backward compatibility and populated during decode with the inline
+	// note text and shared-note XRefs interleaved in their original GEDCOM
+	// order (not the NoteXRefs-then-InlineNotes order of the split fields).
 	//
 	// Deprecated: use NoteXRefs and InlineNotes.
 	Notes []string


### PR DESCRIPTION
Splits inline note text from shared-note XRef references on note-bearing record types (Individual, Family, Source, Repository, Submitter, MediaObject).

## Changes

- Add `NoteXRefs []string` (XRef pointers to shared NOTE/SNOTE records) and `InlineNotes []string` (note text written directly on the record) to each note-bearing record type.
- Deprecate the legacy `Notes []string` field, kept for backward compatibility and populated during decode in original GEDCOM order.
- Add `AllNotes(doc *Document) []string` helper that returns inline note text plus the resolved text of any shared notes referenced by XRef (unresolved XRefs skipped).
- Decoder splits `NOTE` lines into XRef vs inline values; encoder emits both forms preserving note order across all record types.
- Document the new API in FEATURES.md.

## Verification

- `make preflight` passes (lint, tests with race detector, 96.1% coverage, security scans).
- Downstream consumer `my-family` tests pass against this branch.

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for separate inline notes and shared note references across records.
  * Introduced a new “all notes” view that combines inline text with resolved shared notes.
  * Updated note output to preserve original GEDCOM ordering when possible.

* **Bug Fixes**
  * Improved handling of NOTE entries with continuations, including folded multi-line text.
  * Ensured legacy note output remains backward compatible during the transition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->