### PR TITLE
Remove local filesystem paths from tracked files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,6 @@ This library is consumed by `github.com/cacack/my-family`, which depends on tagg
 
 1. **Driven by real usage**: Features should be added when my-family needs them, not speculatively
 2. **Self-contained commits**: Each enhancement should be a complete, testable unit with its own tests
-3. **Verify after release**: Consumer verification happens once a version is released, since my-family pulls the released artifact. After tagging a release, bump my-family and run its tests: from the my-family checkout, `go get github.com/cacack/gedcom-go@latest && go test ./...`
+3. **Verify after release**: Consumer verification happens once a version is released, since my-family pulls the released artifact. After tagging a release, bump my-family and run its tests: from the my-family checkout, `go get github.com/cacack/gedcom-go/v2@latest && go test ./...`
 4. **API stability**: Follow `docs/API_STABILITY.md`; prefer additive changes over breaking ones
 5. **Document in commit**: Note which my-family feature drove the change (e.g., "feat(decoder): add entity parsing for GEDCOM import")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,10 +176,10 @@ This prevents duplicate changelog entries (release-please picks up both PR title
 
 ## Downstream Consumer
 
-This library is used by `github.com/cacack/my-family` (at `/Users/chris/devel/home/my-family`) via a `replace` directive during development. When adding features:
+This library is consumed by `github.com/cacack/my-family`, which depends on tagged releases via the Go module system — it builds against the published artifact, not a local `replace`. When adding features:
 
 1. **Driven by real usage**: Features should be added when my-family needs them, not speculatively
 2. **Self-contained commits**: Each enhancement should be a complete, testable unit with its own tests
-3. **Run consumer tests**: After changes, verify my-family still works: `cd /Users/chris/devel/home/my-family && go test ./...`
+3. **Verify after release**: Consumer verification happens once a version is released, since my-family pulls the released artifact. After tagging a release, bump my-family and run its tests: from the my-family checkout, `go get github.com/cacack/gedcom-go@latest && go test ./...`
 4. **API stability**: Follow `docs/API_STABILITY.md`; prefer additive changes over breaking ones
 5. **Document in commit**: Note which my-family feature drove the change (e.g., "feat(decoder): add entity parsing for GEDCOM import")

--- a/docs/audit-godoc-quality.md
+++ b/docs/audit-godoc-quality.md
@@ -261,21 +261,21 @@ The library has **good inline documentation** for most types and functions, but 
 
 ### Critical (Must Fix for 1.0)
 
-1. **Add doc.go for decoder/** - `/Users/chris/devel/home/gedcom-go/decoder/doc.go`
+1. **Add doc.go for decoder/** - `decoder/doc.go`
    - Package is the primary entry point; needs comprehensive package comment
    - Should include: purpose, basic usage example, common patterns
 
-2. **Add doc.go for encoder/** - `/Users/chris/devel/home/gedcom-go/encoder/doc.go`
+2. **Add doc.go for encoder/** - `encoder/doc.go`
    - Missing package-level documentation
 
-3. **Add Example for decoder.Decode()** - `/Users/chris/devel/home/gedcom-go/decoder/example_test.go`
+3. **Add Example for decoder.Decode()** - `decoder/example_test.go`
    - Most users will start here
    - Should show file opening, decoding, accessing individuals
 
-4. **Add Example for encoder.Encode()** - `/Users/chris/devel/home/gedcom-go/encoder/example_test.go`
+4. **Add Example for encoder.Encode()** - `encoder/example_test.go`
    - Basic encoding to file/buffer
 
-5. **Add doc.go for gedcom/** - `/Users/chris/devel/home/gedcom-go/gedcom/doc.go`
+5. **Add doc.go for gedcom/** - `gedcom/doc.go`
    - Package overview for core types
    - Should explain Document structure, record types, cross-references
 
@@ -294,10 +294,10 @@ The library has **good inline documentation** for most types and functions, but 
 4. **Add Example for StreamEncoder** - `encoder/example_test.go`
    - Streaming large file generation
 
-5. **Document Decoder type** - `/Users/chris/devel/home/gedcom-go/decoder/decoder.go`
+5. **Document Decoder type** - `decoder/decoder.go`
    - Add type-level comment explaining purpose
 
-6. **Document Encoder type** - `/Users/chris/devel/home/gedcom-go/encoder/encoder.go`
+6. **Document Encoder type** - `encoder/encoder.go`
    - Add type-level comment
 
 7. **Add Example for DecodeFile()** - `decoder/example_test.go`

--- a/testdata/edge-cases/gramps-2025-export.ged
+++ b/testdata/edge-cases/gramps-2025-export.ged
@@ -5,7 +5,7 @@
 1 DATE 27 JAN 2026
 2 TIME 20:36:18
 1 SUBM @SUBM@
-1 FILE /Users/chris/Untitled_1.ged
+1 FILE Untitled_1.ged
 1 COPR Copyright (c) 2026 .
 1 GEDC
 2 VERS 5.5.1


### PR DESCRIPTION
## Summary

Strip personal absolute paths (`/Users/<user>/...`) that had leaked into tracked files, exposing a local username and OS.

- **CLAUDE.md** — drop the local my-family checkout path; the consumer builds against the released artifact, so the absolute path was irrelevant anyway.
- **docs/audit-godoc-quality.md** — make the 7 absolute file paths repo-relative, matching the rest of the document.
- **testdata/edge-cases/gramps-2025-export.ged** — neutralize the `HEAD.FILE` value to a bare filename. No Go test asserts on the value, and the roundtrip fixture is preserved.

## Notes

Working-tree cleanup only — prior commit history still contains the strings (intentionally not rewriting public history). Left in place: the `Chris Clonch` copyright (intentional attribution) and the upstream gedcom4j `frizbog` sample path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance for validating releases against a downstream consumer using tagged module versions.
  * Refreshed audit notes to use repo-relative references and clarified recommended documentation and example coverage improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->