### PR TITLE
Add merge_group CI trigger for merge queue support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  merge_group:
+    branches: [ main ]
 
 # Restrict default GITHUB_TOKEN permissions (principle of least privilege)
 permissions:


### PR DESCRIPTION
## What

Add a `merge_group:` trigger to `.github/workflows/ci.yml`, mirroring the existing `pull_request:` branch filter (`branches: [ main ]`).

## Why

A GitHub merge queue creates a temporary merge commit and waits for the repo's **required** status checks to report on the `merge_group` event. If a required check's workflow doesn't trigger on `merge_group`, the queue hangs forever.

This repo's required status checks are **"CI Success"** and **"Security Scan"**, both produced by `ci.yml`, which previously only triggered on `push` and `pull_request`. This change lets them report on the queue's merge commit.

## Gate behavior under merge_group (verified)

- **Security Scan** (`security` job): no `if:` guard, runs on every event — reports directly under `merge_group`. Safe.
- **CI Success** (`ci-success` gate): `if: always()`, so it always runs and reports. Its pass/fail logic is `contains(needs.*.result, 'failure' | 'cancelled')`. PR-only jobs (`dependency-review`, `api-compatibility`, `pr-title`, `commit-type`) are guarded `if: github.event_name == 'pull_request'` and report `'skipped'` under `merge_group` — neither `'failure'` nor `'cancelled'`, so the gate still passes. Safe.

No required check's own job is pull-request-only-guarded, so nothing will hang the queue.

## Impact

No-op until a merge queue is actually enabled on the repo's ruleset. The external "GitGuardian Security Checks" app check is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
